### PR TITLE
- Prevent spamming of outbound connections by checking for duplicates…

### DIFF
--- a/fix-gateway-core/src/test/java/uk/co/real_logic/fix_gateway/engine/framer/FramerTest.java
+++ b/fix-gateway-core/src/test/java/uk/co/real_logic/fix_gateway/engine/framer/FramerTest.java
@@ -777,11 +777,16 @@ public class FramerTest
 
         assertEquals(CONTINUE, onInitiateConnection());
 
+        int NO_WORK_LEEWAY = 20;
+        int zeroWorkDoneCount = 0;
+
         do
         {
-            framer.doWork();
+            if(framer.doWork() == 0){
+                zeroWorkDoneCount++;
+            }
         }
-        while (server.accept() == null);
+        while (zeroWorkDoneCount < NO_WORK_LEEWAY);
 
         assertNotNull("Connection not completed yet", connectionId.getValue());
     }


### PR DESCRIPTION
… first.

- Fix initiate session test since we no longer create a connection until we know the session isn't a duplicate we can't use the connection as a sentinel.