### PR TITLE
Do liveness check before polling sessions because the session poll ca…

### DIFF
--- a/fix-gateway-core/src/main/java/uk/co/real_logic/fix_gateway/library/LibraryPoller.java
+++ b/fix-gateway-core/src/main/java/uk/co/real_logic/fix_gateway/library/LibraryPoller.java
@@ -303,8 +303,8 @@ final class LibraryPoller implements LibraryEndPointHandler, ProtocolHandler, Au
     {
         int operations = 0;
         operations += inboundSubscription.controlledPoll(outboundSubscription, fragmentLimit);
-        operations += pollSessions(timeInMs);
         operations += livenessDetector.poll(timeInMs);
+        operations += pollSessions(timeInMs);
         operations += checkReplies(timeInMs);
         return operations;
     }


### PR DESCRIPTION
…n throw an exception - and we still want to check liveness.