### PR TITLE
Move buildscript dependencies to build.gradle, not general gradle con…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,13 @@
  */
 import org.gradle.plugins.ide.eclipse.model.Classpath
 
+buildscript {
+    dependencies {
+        classpath "com.github.jengelman.gradle.plugins:shadow:1.2.4"
+        classpath 'net.researchgate:gradle-release:2.6.0'
+    }
+}
+
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'net.researchgate.release'

--- a/init.gradle
+++ b/init.gradle
@@ -8,9 +8,5 @@ allprojects {
                 url 'https://plugins.gradle.org/m2/'
             }
         }
-        dependencies {
-            classpath "com.github.jengelman.gradle.plugins:shadow:1.2.4"
-            classpath 'net.researchgate:gradle-release:2.6.0'
-        }
     }
 }


### PR DESCRIPTION
…figuration file. Remove this when plugin management is out of beta.

The repo configuration can be done at the global gradle level, but these dependencies should be specific to the project that is using them in the buildscript.