### PR TITLE
Does the offset need to skip forward when the next file is read?

### DIFF
--- a/fix-gateway-core/src/main/java/uk/co/real_logic/fix_gateway/engine/logger/ArchiveReader.java
+++ b/fix-gateway-core/src/main/java/uk/co/real_logic/fix_gateway/engine/logger/ArchiveReader.java
@@ -66,6 +66,8 @@ public class ArchiveReader implements AutoCloseable
      */
     public static final long CORRUPT_LOG = -4;
 
+    public static final long START_OF_TERM = 0;
+
     private final Int2ObjectHashMap<SessionReader> aeronSessionIdToReader;
     private final ExistingBufferFactory archiveBufferFactory;
     private final ArchiveMetaData metaData;
@@ -425,8 +427,19 @@ public class ArchiveReader implements AutoCloseable
                 return UNKNOWN_TERM;
             }
 
-            final int termOffset = computeTermOffsetFromPosition(position);
-            final int headerOffset = termOffset - HEADER_LENGTH;
+            int termOffset = computeTermOffsetFromPosition(position);
+            int headerOffset;
+
+            if (termOffset == START_OF_TERM)
+            {
+                headerOffset = 0;
+                termOffset = HEADER_LENGTH;
+            }
+            else
+            {
+                headerOffset = termOffset - HEADER_LENGTH;
+            }
+
             buffer.wrap(termBuffer);
             header.buffer(buffer);
             header.offset(headerOffset);


### PR DESCRIPTION
This is not really a serious PR, but for discussion.  Reading in the archive, the termOffset goes to 0 - I'm presuming this is when we are moving to the next file? Previously, the headerOffset would have been set to -32 which obviously can't be read from the file.