### PR TITLE
Codec generated tool. Additional setters is added

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
@@ -59,17 +59,18 @@ public final class CodecGenerationTool
         final PackageOutputManager parent = new PackageOutputManager(outputPath, PARENT_PACKAGE);
         final PackageOutputManager decoder = new PackageOutputManager(outputPath, DECODER_PACKAGE);
 
-        final EnumGenerator enumGenerator = new EnumGenerator(dictionary, parent);
+        final EnumGenerator enumGenerator = new EnumGenerator(dictionary, PARENT_PACKAGE, parent);
         final ConstantGenerator constantGenerator = new ConstantGenerator(dictionary, DECODER_PACKAGE, decoder);
 
         final EncoderGenerator encoderGenerator = new EncoderGenerator(
             dictionary,
             1,
             ENCODER_PACKAGE,
+            PARENT_PACKAGE,
             new PackageOutputManager(outputPath, ENCODER_PACKAGE), Validation.class);
 
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
-            dictionary, 1, DECODER_PACKAGE, decoder, Validation.class);
+            dictionary, 1, DECODER_PACKAGE, PARENT_PACKAGE, decoder, Validation.class);
         final PrinterGenerator printerGenerator = new PrinterGenerator(dictionary, DECODER_PACKAGE, decoder);
         final AcceptorGenerator acceptorGenerator = new AcceptorGenerator(dictionary, DECODER_PACKAGE, decoder);
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/DictionaryParser.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/DictionaryParser.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import static javax.xml.xpath.XPathConstants.NODESET;
@@ -163,6 +164,7 @@ public final class DictionaryParser
         forwardReferences.forEach((entry, name) ->
         {
             final Component component = components.get(name);
+            Verify.notNull(component, "element:" + name);
             entry.element(component);
         });
     }
@@ -335,7 +337,9 @@ public final class DictionaryParser
 
     private String getValue(final NamedNodeMap attributes, final String attributeName)
     {
-        return attributes.getNamedItem(attributeName).getNodeValue();
+        Objects.requireNonNull(attributes, "Null attributes for " + attributeName);
+        return Objects.requireNonNull(attributes.getNamedItem(attributeName), "Empty item for:" +
+            attributeName).getNodeValue();
     }
 
     private void extractNodes(

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
@@ -71,7 +71,7 @@ public class AcceptorGenerator
     private void generateAcceptorCallback(final Writer acceptorOutput, final Message message) throws IOException
     {
         acceptorOutput.append(String.format(
-            "    void on%1$s(final %2$s decoder);\n\n",
+            "    default void on%1$s(final %2$s decoder) {};\n\n",
             message.name(),
             decoderClassName(message)
         ));
@@ -79,7 +79,7 @@ public class AcceptorGenerator
 
     private void generateAcceptorSuffix(final Writer acceptorOutput) throws IOException
     {
-        acceptorOutput.append("\n}\n");
+        acceptorOutput.append("    default void onUnknownMessage(int messageType) {};\n}\n");
     }
 
     private void generateAcceptorClass(final Writer acceptorOutput) throws IOException
@@ -117,6 +117,7 @@ public class AcceptorGenerator
     private void generateDecoderSuffix(final Writer decoderOutput) throws IOException
     {
         decoderOutput.append(
+            "        default:\n            acceptor.onUnknownMessage(messageType);\n" +
             "        }\n" +
             "    }\n\n");
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
@@ -99,10 +99,10 @@ public class AcceptorGenerator
     private void generateDefaultAcceptorCallback(final Writer acceptorOutput, final Message message) throws IOException
     {
         acceptorOutput.append(String.format(
-                "    @Override\n" +
-                "    public void on%1$s(final %2$s decoder) {};\n\n",
-                message.name(),
-                decoderClassName(message)
+            "    @Override\n" +
+            "    public void on%1$s(final %2$s decoder) {};\n\n",
+            message.name(),
+            decoderClassName(message)
         ));
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
@@ -57,12 +57,16 @@ public final class CodecUtil
      */
     public static byte[] toBytes(final char[] value, final byte[] oldBuffer, final int length)
     {
+        return toBytes(value, oldBuffer, 0, length);
+    }
+
+    public static byte[] toBytes(final char[] value, final byte[] oldBuffer, final int offset, final int length)
+    {
         final byte[] buffer = (oldBuffer.length < length) ? new byte[length] : oldBuffer;
         for (int i = 0; i < length; i++)
         {
-            buffer[i] = (byte)value[i];
+            buffer[i] = (byte)value[i + offset];
         }
-
         return buffer;
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -649,15 +649,15 @@ public class DecoderGenerator extends Generator
 
         final String enumValueDecoder = String.format(
             type.isStringBased() ?
-                "%1$s.decode(%2$s, %2$sLength)" :
-                "%1$s.decode(%2$s)",
+            "%1$s.decode(%2$s, %2$sLength)" :
+            "%1$s.decode(%2$s)",
             name,
             fieldName);
 
         final String asEnumBody = String.format(
             entry.required() ?
-                "%1$s" :
-                "has%2$s ? %1$s : null",
+            "%1$s" :
+            "has%2$s ? %1$s : null",
             enumValueDecoder,
             name
         );
@@ -677,17 +677,15 @@ public class DecoderGenerator extends Generator
             optionalCheck,
             asStringBody) : "";
 
-        final String enumDecoder = field.isEnum() ?
-            String.format(
-                "    public %s %sAsEnum()\n" +
-                "    {\n" +
-                "        return %s;\n" +
-                "    }\n\n",
-                name,
-                fieldName,
-                asEnumBody
-            ) :
-            "";
+        final String enumDecoder = field.isEnum() ? String.format(
+            "    public %s %sAsEnum()\n" +
+            "    {\n" +
+            "        return %s;\n" +
+            "    }\n\n",
+            name,
+            fieldName,
+            asEnumBody
+        ) : "";
 
         return String.format(
             "    private %s %s%s;\n\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -664,15 +664,15 @@ public class DecoderGenerator extends Generator
 
         final String stringDecoder = type.isStringBased() ? String.format(
             "    private int %1$sLength;\n\n" +
-                    "    public int %1$sLength()\n" +
-                    "    {\n" +
-                    "%2$s" +
-                    "        return %1$sLength;\n" +
-                    "    }\n\n" +
-                    "    public String %1$sAsString()\n" +
-                    "    {\n" +
-                    "        return %3$s;\n" +
-                    "    }\n\n",
+            "    public int %1$sLength()\n" +
+            "    {\n" +
+            "%2$s" +
+            "        return %1$sLength;\n" +
+            "    }\n\n" +
+            "    public String %1$sAsString()\n" +
+            "    {\n" +
+            "        return %3$s;\n" +
+            "    }\n\n",
             fieldName,
             optionalCheck,
             asStringBody) : "";

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -90,10 +90,11 @@ public class DecoderGenerator extends Generator
         final Dictionary dictionary,
         final int initialBufferSize,
         final String builderPackage,
+        final String builderCommonPackage,
         final OutputManager outputManager,
         final Class<?> validationClass)
     {
-        super(dictionary, builderPackage, outputManager, validationClass);
+        super(dictionary, builderPackage, builderCommonPackage, outputManager, validationClass);
         this.initialBufferSize = initialBufferSize;
     }
 
@@ -647,7 +648,22 @@ public class DecoderGenerator extends Generator
             fieldName,
             name);
 
-        final String suffix = type.isStringBased() ?
+        final String enumValueDecoder = String.format(
+            type.isStringBased() ?
+                "%1$s.decode(%2$s, %2$sLength)" :
+                "%1$s.decode(%2$s)",
+            name,
+            fieldName);
+
+        final String asEnumBody = String.format(
+            entry.required() ?
+                "%1$s" :
+                "has%2$s ? %1$s : null",
+            enumValueDecoder,
+            name
+        );
+
+        final String stringDecoder = type.isStringBased() ?
             String.format(
                 "    private int %1$sLength;\n\n" +
                 "    public int %1$sLength()\n" +
@@ -664,6 +680,18 @@ public class DecoderGenerator extends Generator
                 asStringBody) :
             "";
 
+        final String enumDecoder = field.isEnum() ?
+            String.format(
+                "    public %s %sAsEnum()\n" +
+                "    {\n" +
+                "        return %s;\n" +
+                "    }\n\n",
+                name,
+                fieldName,
+                asEnumBody
+            ) :
+            "";
+
         return String.format(
             "    private %s %s%s;\n\n" +
             "%s" +
@@ -673,6 +701,7 @@ public class DecoderGenerator extends Generator
             "        return %2$s;\n" +
             "    }\n\n" +
             "%s\n" +
+            "%s\n" +
             "%s",
             javaTypeOf(type),
             fieldName,
@@ -680,7 +709,8 @@ public class DecoderGenerator extends Generator
             hasField(entry),
             optionalCheck,
             optionalGetter(entry),
-            suffix);
+            stringDecoder,
+            enumDecoder);
     }
 
     private String fieldInitialisation(final Type type)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -428,9 +428,9 @@ public class EncoderGenerator extends Generator
     }
 
     private String enumSetter(
-            final String className,
-            final String fieldName,
-            final String enumType)
+        final String className,
+        final String fieldName,
+        final String enumType)
     {
         return String.format(
             "    public %s %2$s(%3$s value)\n" +
@@ -440,7 +440,6 @@ public class EncoderGenerator extends Generator
             className, fieldName, enumType
         );
     }
-
 
     private String encodeMethod(final List<Entry> entries, final AggregateType aggregateType)
     {

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
@@ -35,11 +35,13 @@ import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.*;
 public final class EnumGenerator
 {
     private final Dictionary dictionary;
+    private final String builderPackage;
     private final OutputManager outputManager;
 
-    public EnumGenerator(final Dictionary dictionary, final OutputManager outputManager)
+    public EnumGenerator(final Dictionary dictionary, final String builderPackage, final OutputManager outputManager)
     {
         this.dictionary = dictionary;
+        this.builderPackage = builderPackage;
         this.outputManager = outputManager;
     }
 
@@ -64,7 +66,7 @@ public final class EnumGenerator
         {
             try
             {
-                out.append(fileHeader(PARENT_PACKAGE));
+                out.append(fileHeader(builderPackage));
                 out.append(importFor(CharArrayMap.class));
                 out.append(importFor(Map.class));
                 out.append(importFor(HashMap.class));
@@ -142,7 +144,7 @@ public final class EnumGenerator
                 "    }\n",
             optionalCharArrayDecode,
             name,
-            representation.declaration(),
+            representation.methodArgsDeclaration(),
             cases);
     }
 
@@ -200,6 +202,7 @@ public final class EnumGenerator
     private Var representation(final Type type)
     {
         final String typeValue;
+        final String argTypeValue;
         switch (type)
         {
             case STRING:
@@ -210,14 +213,17 @@ public final class EnumGenerator
             case UTCTIMEONLY:
             case UTCDATEONLY:
             case MONTHYEAR:
-                typeValue = "String";
+                argTypeValue = typeValue = "String";
                 break;
-
+            case CHAR:
+                typeValue = "char";
+                argTypeValue = "int";
+                break;
             default:
-                typeValue = "int";
+                argTypeValue = typeValue = "int";
         }
 
-        return new Var(typeValue, "representation");
+        return new Var(typeValue, argTypeValue, "representation");
     }
 
     private String literal(final Value value, final Type type)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -58,11 +58,13 @@ public final class GenerationUtil
     public static class Var
     {
         private final String type;
+        private final String methodArgsType;
         private final String name;
 
-        public Var(final String type, final String name)
+        public Var(final String type, final String methodArgsType, final String name)
         {
             this.type = type;
+            this.methodArgsType = methodArgsType;
             this.name = name;
         }
 
@@ -79,6 +81,11 @@ public final class GenerationUtil
         public String declaration()
         {
             return String.format("final %s %s", type, name);
+        }
+
+        public String methodArgsDeclaration()
+        {
+            return String.format("final %s %s", methodArgsType, name);
         }
     }
 
@@ -103,6 +110,12 @@ public final class GenerationUtil
     {
         return String.format("import %s;\n", cls.getCanonicalName());
     }
+
+    public static String importFor(final String className)
+    {
+        return String.format("import %s;\n", className);
+    }
+
 
     public static String importStaticFor(final Class<?> cls)
     {

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -80,17 +80,20 @@ public abstract class Generator
 
     protected final Dictionary dictionary;
     protected final String builderPackage;
+    private String builderCommonPackage;
     protected final OutputManager outputManager;
     protected final Class<?> validationClass;
 
     protected Generator(
         final Dictionary dictionary,
         final String builderPackage,
+        final String builderCommonPackage,
         final OutputManager outputManager,
         final Class<?> validationClass)
     {
         this.dictionary = dictionary;
         this.builderPackage = builderPackage;
+        this.builderCommonPackage = builderCommonPackage;
         this.outputManager = outputManager;
         this.validationClass = validationClass;
     }
@@ -139,6 +142,10 @@ public abstract class Generator
             .append(importFor(EncodingException.class))
             .append(importStaticFor(StandardCharsets.class, "US_ASCII"))
             .append(importStaticFor(validationClass, CODEC_VALIDATION_ENABLED));
+        if (!builderPackage.equals(builderCommonPackage) && !builderCommonPackage.isEmpty())
+        {
+            out.append(importFor(builderCommonPackage + ".*"));
+        }
     }
 
     protected String classDeclaration(

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Field.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Field.java
@@ -92,7 +92,7 @@ public final class Field implements Element
             "number=" + number +
             ", name='" + name + '\'' +
             ", type=" + type +
-            "values=" + values +
+            ", values=" + values +
             '}';
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -45,6 +45,8 @@ public final class ExampleDictionary
     public static final String OTHER_ENUM = PARENT_PACKAGE + "." + "OtherEnum";
     public static final String STRING_ENUM = PARENT_PACKAGE + "." + "stringEnum";
 
+    public static final String TEST_PARENT_PACKAGE = PARENT_PACKAGE;
+
     public static final String TEST_PACKAGE = ENCODER_PACKAGE + ".test";
 
     public static final String HEARTBEAT_ENCODER = TEST_PACKAGE + ".HeartbeatEncoder";
@@ -63,15 +65,19 @@ public final class ExampleDictionary
     public static final String ABC = "abc";
     public static final byte[] VALUE_IN_BYTES = {97, 98, 99};
     public static final String TEST_REQ_ID = "testReqID";
+    public static final String ON_BEHALF_OF_COMP_ID = "onBehalfOfCompID";
     public static final String INT_FIELD = "intField";
+    public static final String CHAR_FIELD = "charField";
     public static final String FLOAT_FIELD = "floatField";
     public static final String BOOLEAN_FIELD = "booleanField";
     public static final String DATA_FIELD = "dataField";
     public static final String TEST_REQ_ID_LENGTH = "testReqIDLength";
+    public static final String ON_BEHALF_OF_COMP_ID_LENGTH = "onBehalfOfCompIDLength";
     public static final String SOME_TIME_FIELD = "someTimeField";
     public static final String COMPONENT_FIELD = "componentField";
 
     public static final String HAS_TEST_REQ_ID = "hasTestReqID";
+    public static final String HAS_ON_BEHALF_OF_COMP_ID = "hasonBehalfOfCompID";
     public static final String HAS_BOOLEAN_FIELD = "hasBooleanField";
     public static final String HAS_DATA_FIELD = "hasDataField";
     public static final String HAS_COMPONENT_FIELD = "hasComponentField";
@@ -284,7 +290,10 @@ public final class ExampleDictionary
         final Field booleanField = registerField(messageEgFields, 118, "BooleanField", Type.BOOLEAN);
         final Field dataField = registerField(messageEgFields, 119, "DataField", Type.DATA);
         final Field someTime = registerField(messageEgFields, 127,  "SomeTimeField", Type.UTCTIMESTAMP);
-        final Field charField = registerField(messageEgFields, 128,  "CharField", Type.CHAR);
+        final Field charField = registerField(messageEgFields, 128,  "CharField", Type.CHAR)
+            .addValue("a", "One")
+            .addValue("b", "Two");
+
         final Field dayOfMonthField = registerField(messageEgFields, 129,  "DayOfMonthField", Type.DAYOFMONTH);
 
         final Group nestedGroup = Group.of(registerField(messageEgFields, 122, "NoNestedGroup", INT));

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
@@ -36,8 +36,10 @@ public class AcceptorGeneratorTest
     private static StringWriterOutputManager outputManager = new StringWriterOutputManager();
     private static ConstantGenerator constantGenerator =
         new ConstantGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+    private static EnumGenerator enumGenerator =
+            new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static DecoderGenerator decoderGenerator =
-        new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, outputManager, ValidationOn.class);
+        new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class);
     private static AcceptorGenerator acceptorGenerator =
         new AcceptorGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> acceptor;
@@ -49,6 +51,7 @@ public class AcceptorGeneratorTest
     public static void generate() throws Exception
     {
         constantGenerator.generate();
+        enumGenerator.generate();
         decoderGenerator.generate();
         acceptorGenerator.generate();
         final Map<String, CharSequence> sources = outputManager.getSources();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
@@ -37,7 +37,7 @@ public class AcceptorGeneratorTest
     private static ConstantGenerator constantGenerator =
         new ConstantGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static EnumGenerator enumGenerator =
-            new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+        new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class);
     private static AcceptorGenerator acceptorGenerator =

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
@@ -87,10 +87,12 @@ public class DecoderGeneratorTest
         final StringWriterOutputManager outputManager = new StringWriterOutputManager();
         final ConstantGenerator constantGenerator = new ConstantGenerator(
             MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+        final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
-            MESSAGE_EXAMPLE, 1, TEST_PACKAGE, outputManager, validationClass);
+            MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass);
 
         constantGenerator.generate();
+        enumGenerator.generate();
         decoderGenerator.generate();
         return outputManager.getSources();
     }
@@ -149,6 +151,16 @@ public class DecoderGeneratorTest
 
         assertValid(decoder);
     }
+
+    @Test
+    public void decodesPrimitiveValuesAsEnum() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(DERIVED_FIELDS_MESSAGE);
+        assertEquals(2, getRepresentation(get(decoder, INT_FIELD + "AsEnum")));
+        assertNull(get(decoder, CHAR_FIELD + "AsEnum"));
+        assertValid(decoder);
+    }
+
 
     @Test
     public void shouldIgnoreMissingOptionalValues() throws Exception
@@ -473,6 +485,16 @@ public class DecoderGeneratorTest
         assertEquals("abc", get(decoder, "onBehalfOfCompIDAsString"));
         assertNull(get(decoder, "testReqIDAsString"));
     }
+
+    @Test
+    public void shouldBeAbleToExtractEnumFromStringFields() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(NO_OPTIONAL_MESSAGE);
+
+        final Object onBehalfEnum = get(decoder, "onBehalfOfCompIDAsEnum");
+        assertEquals("abc", getRepresentation(onBehalfEnum));
+    }
+
 
     @Test
     public void shouldProduceCorrectMessageTypeForTwoCharTypes() throws Exception

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -132,9 +132,9 @@ public class EncoderGeneratorTest
         final Object encoder = heartbeat.newInstance();
 
         setEnumByRepresentation(encoder,
-                ON_BEHALF_OF_COMP_ID,
-                PARENT_PACKAGE + ".OnBehalfOfCompID",
-                "abc");
+            ON_BEHALF_OF_COMP_ID,
+            PARENT_PACKAGE + ".OnBehalfOfCompID",
+            "abc");
         assertOnBehalfOfCompIDValue(encoder, "abc");
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -34,6 +34,7 @@ import static org.agrona.generation.CompilerUtil.compileInMemory;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static uk.co.real_logic.artio.dictionary.ExampleDictionary.*;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.PARENT_PACKAGE;
 import static uk.co.real_logic.artio.util.Reflection.*;
 
 public class EncoderGeneratorTest
@@ -64,8 +65,10 @@ public class EncoderGeneratorTest
     {
         final Class<?> validationClass = validation ? ValidationOn.class : ValidationOff.class;
         final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+        final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final EncoderGenerator encoderGenerator =
-            new EncoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, outputManager, validationClass);
+            new EncoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass);
+        enumGenerator.generate();
         encoderGenerator.generate();
         return outputManager.getSources();
     }
@@ -83,9 +86,11 @@ public class EncoderGeneratorTest
     }
 
     @Test
-    public void generatesSetters() throws NoSuchMethodException
+    public void generatesSetters() throws Exception
     {
-        heartbeat.getMethod("onBehalfOfCompID", CharSequence.class);
+        heartbeat.getMethod(ON_BEHALF_OF_COMP_ID, CharSequence.class);
+        final Class<?> stringEnumClass = heartbeat.getClassLoader().loadClass(PARENT_PACKAGE + ".OnBehalfOfCompID");
+        heartbeat.getMethod(ON_BEHALF_OF_COMP_ID, stringEnumClass);
     }
 
     @Test
@@ -122,6 +127,19 @@ public class EncoderGeneratorTest
     }
 
     @Test
+    public void stringSettersByEnumToFields() throws Exception
+    {
+        final Object encoder = heartbeat.newInstance();
+
+        setEnumByRepresentation(encoder,
+                ON_BEHALF_OF_COMP_ID,
+                PARENT_PACKAGE + ".OnBehalfOfCompID",
+                "abc");
+        assertOnBehalfOfCompIDValue(encoder, "abc");
+    }
+
+
+    @Test
     public void intSettersWriteToFields() throws Exception
     {
         final Object encoder = heartbeat.newInstance();
@@ -130,6 +148,16 @@ public class EncoderGeneratorTest
 
         assertEquals(1, getField(encoder, INT_FIELD));
     }
+
+    @Test
+    public void intSettersByEnumWriteToFields() throws Exception
+    {
+        final Object encoder = heartbeat.newInstance();
+        setEnumByRepresentation(encoder, INT_FIELD, PARENT_PACKAGE + ".IntField", 1);
+
+        assertEquals(1, getField(encoder, INT_FIELD));
+    }
+
 
     @Test
     public void floatSettersWriteToFields() throws Exception
@@ -226,7 +254,7 @@ public class EncoderGeneratorTest
 
         encoder.encode(buffer, 1);
 
-        setCharSequence(encoder, "onBehalfOfCompID", "ab");
+        setCharSequence(encoder, ON_BEHALF_OF_COMP_ID, "ab");
 
         assertEncodesTo(encoder, SHORTER_STRING_MESSAGE);
     }
@@ -238,7 +266,7 @@ public class EncoderGeneratorTest
 
         setRequiredFields(encoder);
 
-        setCharSequence(encoder, "onBehalfOfCompID", "ab");
+        setCharSequence(encoder, ON_BEHALF_OF_COMP_ID, "ab");
 
         assertThat(encoder.toString(), containsString("ab"));
         assertThat(encoder.toString(), not(containsString("abc")));
@@ -665,7 +693,7 @@ public class EncoderGeneratorTest
 
     private void setOnBehalfOfCompID(final Encoder encoder) throws Exception
     {
-        setCharSequence(encoder, "onBehalfOfCompID", "abc");
+        setCharSequence(encoder, ON_BEHALF_OF_COMP_ID, "abc");
     }
 
     private void setFloatField(final Encoder encoder) throws Exception
@@ -714,6 +742,13 @@ public class EncoderGeneratorTest
         assertArrayEquals(VALUE_IN_BYTES, (byte[])getField(encoder, TEST_REQ_ID));
         assertEquals(3, getField(encoder, TEST_REQ_ID_LENGTH));
     }
+
+    private void assertOnBehalfOfCompIDValue(final Object encoder, final String value) throws Exception
+    {
+        assertArrayEquals(value.getBytes(), (byte[])getField(encoder, ON_BEHALF_OF_COMP_ID));
+        assertEquals(value.length(), getField(encoder, ON_BEHALF_OF_COMP_ID_LENGTH));
+    }
+
 
     private boolean hasTestReqId(final Object encoder) throws Exception
     {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EnumGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EnumGeneratorTest.java
@@ -150,11 +150,10 @@ public class EnumGeneratorTest
 
     private void assertRepresentation(final char expected, final Enum<?> enumElement) throws Exception
     {
-        final char representation =
-                (char)enumElement
-                        .getDeclaringClass()
-                        .getMethod("representation")
-                        .invoke(enumElement);
+        final char representation = (char)enumElement
+            .getDeclaringClass()
+            .getMethod("representation")
+            .invoke(enumElement);
 
         assertEquals(expected, representation);
     }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EnumGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EnumGeneratorTest.java
@@ -25,11 +25,12 @@ import java.lang.reflect.Method;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static uk.co.real_logic.artio.dictionary.ExampleDictionary.*;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.PARENT_PACKAGE;
 
 public class EnumGeneratorTest
 {
     private StringWriterOutputManager outputManager = new StringWriterOutputManager();
-    private EnumGenerator enumGenerator = new EnumGenerator(FIELD_EXAMPLE, outputManager);
+    private EnumGenerator enumGenerator = new EnumGenerator(FIELD_EXAMPLE, PARENT_PACKAGE, outputManager);
 
     @Before
     public void generate()
@@ -147,4 +148,16 @@ public class EnumGeneratorTest
 
         assertEquals(expected, representation);
     }
+
+    private void assertRepresentation(final char expected, final Enum<?> enumElement) throws Exception
+    {
+        final char representation =
+                (char)enumElement
+                        .getDeclaringClass()
+                        .getMethod("representation")
+                        .invoke(enumElement);
+
+        assertEquals(expected, representation);
+    }
+
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
@@ -34,7 +34,7 @@ public class PrinterGeneratorTest
     private static ConstantGenerator constantGenerator =
         new ConstantGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static EnumGenerator enumGenerator =
-            new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+        new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
 
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
@@ -33,8 +33,11 @@ public class PrinterGeneratorTest
     private static StringWriterOutputManager outputManager = new StringWriterOutputManager();
     private static ConstantGenerator constantGenerator =
         new ConstantGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+    private static EnumGenerator enumGenerator =
+            new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+
     private static DecoderGenerator decoderGenerator =
-        new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, outputManager, ValidationOn.class);
+        new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class);
     private static PrinterGenerator printerGenerator =
         new PrinterGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> printer;
@@ -45,6 +48,7 @@ public class PrinterGeneratorTest
     public static void generate() throws Exception
     {
         constantGenerator.generate();
+        enumGenerator.generate();
         decoderGenerator.generate();
         printerGenerator.generate();
         final Map<String, CharSequence> sources = outputManager.getSources();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
@@ -20,7 +20,10 @@ import uk.co.real_logic.artio.builder.Encoder;
 import uk.co.real_logic.artio.fields.DecimalFloat;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public final class Reflection
 {
@@ -32,6 +35,22 @@ public final class Reflection
         throws Exception
     {
         set(object, setter, int.class, value);
+    }
+
+    public static void setEnum(final Object object, final String setter, final Object value)
+        throws Exception
+    {
+        set(object, setter, value.getClass(), value);
+    }
+
+    public static void setEnumByRepresentation(final Object object,
+                                               final String setter,
+                                               final String enumClass,
+                                               final Object representation)
+        throws Exception
+    {
+        final Object enumValue = getEnumByRepresentation(object, enumClass, representation);
+        set(object, setter, enumValue.getClass(), enumValue);
     }
 
     public static void setFloat(final Object object, final String setter, final DecimalFloat value)
@@ -153,6 +172,23 @@ public final class Reflection
     public static Object getEgComponent(final Object object) throws Exception
     {
         return get(object, "egComponent");
+    }
+
+    public static Object getRepresentation(final Object object) throws Exception
+    {
+        return get(object, "representation");
+    }
+
+    public static Object getEnumByRepresentation(final Object containingObject,
+                                                 final String className,
+                                                 final Object representation)
+            throws Exception
+    {
+        final Class<?> enumClass = containingObject.getClass().getClassLoader().loadClass(className);
+        final Optional<Method> decodeMethod = Stream.of(enumClass.getMethods())
+                .filter(x -> x.getName().equals("decode"))
+                .findFirst();
+        return decodeMethod.get().invoke(null, representation);
     }
 
     public static byte[] getBytes(final Decoder decoder, final String field) throws Exception

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
@@ -43,10 +43,11 @@ public final class Reflection
         set(object, setter, value.getClass(), value);
     }
 
-    public static void setEnumByRepresentation(final Object object,
-                                               final String setter,
-                                               final String enumClass,
-                                               final Object representation)
+    public static void setEnumByRepresentation(
+        final Object object,
+        final String setter,
+        final String enumClass,
+        final Object representation)
         throws Exception
     {
         final Object enumValue = getEnumByRepresentation(object, enumClass, representation);
@@ -179,15 +180,16 @@ public final class Reflection
         return get(object, "representation");
     }
 
-    public static Object getEnumByRepresentation(final Object containingObject,
-                                                 final String className,
-                                                 final Object representation)
-            throws Exception
+    public static Object getEnumByRepresentation(
+        final Object containingObject,
+        final String className,
+        final Object representation)
+        throws Exception
     {
         final Class<?> enumClass = containingObject.getClass().getClassLoader().loadClass(className);
         final Optional<Method> decodeMethod = Stream.of(enumClass.getMethods())
-                .filter(x -> x.getName().equals("decode"))
-                .findFirst();
+            .filter(x -> x.getName().equals("decode"))
+            .findFirst();
         return decodeMethod.get().invoke(null, representation);
     }
 


### PR DESCRIPTION
1. The generation of getters/setters by Enum is added to Decoder/Encoder generation tool.
For ex.
Encoder:
```java
    public NewOrderSingleEncoder ordType(OrdType value)
    {
        return ordType(value.representation());
    }
```
Decoder:
```java
    public OrdType ordTypeAsEnum()
    {
        return OrdType.decode(ordType);
    }
```
2. Type of representation of char type in generated Enum is changed from 'int' to 'char'
3. DictionaryAcceptor: 
- added default empty implementation to method
- added onUnknownMessage(int messageType) with empty default implementation
  