### PR TITLE
#157 Change sentinel values for missing INT and LONG to min values

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
@@ -27,9 +27,9 @@ public final class CodecUtil
     public static final int BODY_LENGTH_SIZE = BODY_LENGTH_GAP + 1;
     public static final byte[] BODY_LENGTH = "9=0000\001".getBytes(US_ASCII);
 
-    public static final int MISSING_INT = -1;
+    public static final int MISSING_INT = Integer.MIN_VALUE;
     public static final char MISSING_CHAR = '\001';
-    public static final long MISSING_LONG = -1L;
+    public static final long MISSING_LONG = Long.MIN_VALUE;
 
     /**
      * NB: only valid for ASCII bytes.

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -644,7 +644,7 @@ public class DecoderGenerator extends Generator
         final String asEnumBody = String.format(
             entry.required() ?
             "%1$s" :
-            "has%2$s ? %1$s : null",
+            "has%2$s ? %1$s : %2$s.NULL_VAL",
             enumValueDecoder,
             name
         );

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
@@ -15,38 +15,47 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.agrona.LangUtil;
 import org.agrona.collections.IntHashSet;
 import org.agrona.generation.OutputManager;
-
-
 import uk.co.real_logic.artio.dictionary.CharArrayMap;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.Field;
 import uk.co.real_logic.artio.dictionary.ir.Field.Type;
 import uk.co.real_logic.artio.dictionary.ir.Field.Value;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
-import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.INDENT;
-import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.Var;
-import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.constructor;
-import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
-import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
-import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.optionalStaticInit;
+import static uk.co.real_logic.artio.dictionary.generation.CodecUtil.MISSING_CHAR;
+import static uk.co.real_logic.artio.dictionary.generation.CodecUtil.MISSING_INT;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.*;
 
 public final class EnumGenerator
 {
+    private static final String NULL_VALUE_NAME = "NULL_VAL";
+    private static final String NULL_VALUE_CHAR = Character.toString(MISSING_CHAR);
+    private static final String NULL_VALUE_INT = Integer.toString(MISSING_INT);
+    private static final String NULL_VALUE_STRING = "";
+
+    private static final String UNKNOWN_VALUE_NAME = "UNKNOWN_REPRESENTATION";
+    private static final String UNKNOWN_VALUE_CHAR = "\u0002";
+    private static final String UNKNOWN_VALUE_INT = Integer.toString(Integer.MAX_VALUE);
+    private static final String UNKNOWN_VALUE_STRING = "\u0002";
+
     private final Dictionary dictionary;
     private final String builderPackage;
     private final OutputManager outputManager;
 
-    public EnumGenerator(final Dictionary dictionary, final String builderPackage, final OutputManager outputManager)
+    public EnumGenerator(
+        final Dictionary dictionary,
+        final String builderPackage,
+        final OutputManager outputManager)
     {
         this.dictionary = dictionary;
         this.builderPackage = builderPackage;
@@ -73,6 +82,31 @@ public final class EnumGenerator
         final String enumName = field.name();
         final Type type = field.type();
         final List<Value> values = field.values();
+        final List<Value> valuesWithSentinels = new ArrayList<>(values.size() + 2);
+        final String nullValue;
+        final String unknownValue;
+        if (type == Type.CHAR || type == Type.MULTIPLECHARVALUE)
+        {
+            nullValue = NULL_VALUE_CHAR;
+            unknownValue = UNKNOWN_VALUE_CHAR;
+        }
+        else if (type.isIntBased())
+        {
+            nullValue = NULL_VALUE_INT;
+            unknownValue = UNKNOWN_VALUE_INT;
+        }
+        else if (type.isStringBased())
+        {
+            nullValue = NULL_VALUE_STRING;
+            unknownValue = UNKNOWN_VALUE_STRING;
+        }
+        else
+        {
+            throw new IllegalArgumentException("Field type is invalid for Enum generation " + field);
+        }
+        valuesWithSentinels.addAll(values);
+        valuesWithSentinels.add(new Value(nullValue, NULL_VALUE_NAME));
+        valuesWithSentinels.add(new Value(unknownValue, UNKNOWN_VALUE_NAME));
 
         outputManager.withOutput(enumName, (out) ->
         {
@@ -85,7 +119,7 @@ public final class EnumGenerator
                 out.append(importFor(HashMap.class));
                 out.append(generateEnumDeclaration(enumName));
 
-                out.append(generateEnumValues(values, type));
+                out.append(generateEnumValues(valuesWithSentinels, type));
 
                 out.append(generateEnumBody(enumName, type));
                 out.append(generateEnumLookupMethod(enumName, values, type));
@@ -154,7 +188,8 @@ public final class EnumGenerator
             "        switch(representation)\n" +
             "        {\n" +
             "%s" +
-            "        default: throw new IllegalArgumentException(\"Unknown: \" + representation);\n" +
+            "        default:\n" +
+            "            return " + UNKNOWN_VALUE_NAME + ";\n" +
             "        }\n" +
             "    }\n",
             optionalCharArrayDecode,
@@ -257,7 +292,12 @@ public final class EnumGenerator
                     "\n" +
                     "    public static %1$s decode(final char[] representation, final int length)\n" +
                     "    {\n" +
-                    "        return charMap.get(representation, length);\n" +
+                            "        final %1$s value = charMap.get(representation, length);\n" +
+                            "        if (value == null)\n" +
+                            "        {\n" +
+                            "            return " + UNKNOWN_VALUE_NAME + ";\n" +
+                            "        }\n" +
+                            "        return value;\n" +
                     "    }\n",
                     typeName,
                     entries);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -30,6 +30,7 @@ import static java.util.Collections.emptyMap;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.ENCODER_PACKAGE;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.PARENT_PACKAGE;
 import static uk.co.real_logic.artio.dictionary.ir.Category.ADMIN;
+import static uk.co.real_logic.artio.dictionary.ir.Category.APP;
 import static uk.co.real_logic.artio.dictionary.ir.Field.Type.*;
 import static uk.co.real_logic.artio.dictionary.ir.Field.registerField;
 
@@ -55,6 +56,7 @@ public final class ExampleDictionary
     public static final String HEADER_ENCODER = TEST_PACKAGE + ".HeaderEncoder";
 
     public static final String HEARTBEAT_DECODER = TEST_PACKAGE + ".HeartbeatDecoder";
+    public static final String ALL_REQ_FIELD_TYPES_MESSAGE_DECODER = TEST_PACKAGE + ".AllReqFieldTypesMessageDecoder";
     public static final String FIELDS_MESSAGE_DECODER = TEST_PACKAGE + "." + FIELDS_MESSAGE + "Decoder";
     public static final String HEADER_DECODER = TEST_PACKAGE + ".HeaderDecoder";
     public static final String COMPONENT_DECODER = TEST_PACKAGE + "." + EG_COMPONENT + "Decoder";
@@ -76,6 +78,16 @@ public final class ExampleDictionary
     public static final String ON_BEHALF_OF_COMP_ID_LENGTH = "onBehalfOfCompIDLength";
     public static final String SOME_TIME_FIELD = "someTimeField";
     public static final String COMPONENT_FIELD = "componentField";
+
+    public static final String ALL_REQ_FIELD_TYPES_MESSAGE_NAME = "AllReqFieldTypesMessage";
+    public static final String ALL_REQ_FIELD_TYPES_MESSAGE_TYPE = "RF";
+    public static final String STRING_RF = "StringRF";
+    public static final String INT_RF = "IntRF";
+    public static final String CHAR_RF = "CharRF";
+    public static final String DECIMAL_RF = "DecimalRF";
+    public static final String STRING_ENUM_RF = "StringEnumRF";
+    public static final String INT_ENUM_RF = "IntEnumRF";
+    public static final String CHAR_ENUM_RF = "CharEnumRF";
 
     public static final String HAS_TEST_REQ_ID = "hasTestReqID";
     public static final String HAS_ON_BEHALF_OF_COMP_ID = "hasonBehalfOfCompID";
@@ -283,6 +295,13 @@ public final class ExampleDictionary
     public static final String EG_HIGH_NUMBER_FIELD_MESSAGE =
         "8=FIX.4.4\0019=0049\00135=Z\0019001=1\0011001=USD\0011002=N\0011003=US\00110=209\001";
 
+    public static final String RF_ALL_FIELDS =
+        "8=FIX.4.4\0019=0049\00135=Z\001700=one\001701=10\001702=b\001703=123.456\001" +
+        "704=one\001705=10\001706=b\00110=209\001";
+
+    public static final String RF_NO_FIELDS =
+        "8=FIX.4.4\0019=0049\00135=Z\00110=209\001";
+
     public static final int TEST_REQ_ID_TAG = 112;
 
     public static final String OTHER_MESSAGE_TYPE = "AB";
@@ -397,7 +416,21 @@ public final class ExampleDictionary
         fieldsMessage.optionalEntry(registerField(messageEgFields, 1006, "OptionalCountryField", COUNTRY));
         fieldsMessage.optionalEntry(registerField(messageEgFields, 9001, "HighNumberField", INT));
 
-        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage);
+        final Message allReqFieldTypesMessage = new Message(ALL_REQ_FIELD_TYPES_MESSAGE_NAME,
+            ALL_REQ_FIELD_TYPES_MESSAGE_TYPE, APP);
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 700, STRING_RF, STRING));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 701, INT_RF, INT));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 702, CHAR_RF, CHAR));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 703, DECIMAL_RF, FLOAT));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 704, STRING_ENUM_RF, STRING)
+            .addValue("one", "ONE").addValue("two", "TWO"));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 705, INT_ENUM_RF, INT)
+            .addValue("-1", "NEG_ONE").addValue("10", "TEN"));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 706, CHAR_ENUM_RF, CHAR)
+            .addValue("a", "APPLE").addValue("b", "BANANA"));
+
+
+        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage, allReqFieldTypesMessage);
 
         final Map<String, Component> components = new HashMap<>();
         components.put(EG_COMPONENT, egComponent);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -15,13 +15,18 @@
  */
 package uk.co.real_logic.artio.dictionary;
 
-import uk.co.real_logic.artio.dictionary.generation.GenerationUtil;
-import uk.co.real_logic.artio.dictionary.ir.*;
-import uk.co.real_logic.artio.dictionary.ir.Field.Type;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+
+import uk.co.real_logic.artio.dictionary.generation.GenerationUtil;
+import uk.co.real_logic.artio.dictionary.ir.Component;
+import uk.co.real_logic.artio.dictionary.ir.Dictionary;
+import uk.co.real_logic.artio.dictionary.ir.Field;
+import uk.co.real_logic.artio.dictionary.ir.Field.Type;
+import uk.co.real_logic.artio.dictionary.ir.Group;
+import uk.co.real_logic.artio.dictionary.ir.Message;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Arrays.asList;
@@ -31,6 +36,12 @@ import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.ENCODE
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.PARENT_PACKAGE;
 import static uk.co.real_logic.artio.dictionary.ir.Category.ADMIN;
 import static uk.co.real_logic.artio.dictionary.ir.Category.APP;
+import static uk.co.real_logic.artio.dictionary.ir.Field.Type.CHAR;
+import static uk.co.real_logic.artio.dictionary.ir.Field.Type.COUNTRY;
+import static uk.co.real_logic.artio.dictionary.ir.Field.Type.CURRENCY;
+import static uk.co.real_logic.artio.dictionary.ir.Field.Type.EXCHANGE;
+import static uk.co.real_logic.artio.dictionary.ir.Field.Type.INT;
+import static uk.co.real_logic.artio.dictionary.ir.Field.Type.STRING;
 import static uk.co.real_logic.artio.dictionary.ir.Field.Type.*;
 import static uk.co.real_logic.artio.dictionary.ir.Field.registerField;
 
@@ -62,6 +73,7 @@ public final class ExampleDictionary
     public static final String COMPONENT_DECODER = TEST_PACKAGE + "." + EG_COMPONENT + "Decoder";
     public static final String OTHER_MESSAGE_DECODER = TEST_PACKAGE + ".OtherMessageDecoder";
     public static final String OTHER_MESSAGE_ENCODER = TEST_PACKAGE + ".OtherMessageEncoder";
+    public static final String ENUM_TEST_MESSAGE_DECODER = TEST_PACKAGE + ".EnumTestMessageDecoder";
 
     public static final String PRINTER = TEST_PACKAGE + ".PrinterImpl";
 
@@ -295,6 +307,18 @@ public final class ExampleDictionary
     public static final String EG_HIGH_NUMBER_FIELD_MESSAGE =
         "8=FIX.4.4\0019=0049\00135=Z\0019001=1\0011001=USD\0011002=N\0011003=US\00110=209\001";
 
+    public static final String ET_ALL_FIELDS =
+        "8=FIX.4.4\0019=0049\00135=ET\001501=a\001502=10\001503=alpha\001511=c\001512=30\001513=gamma\00110=209\001";
+
+    public static final String ET_ONLY_REQ_FIELDS =
+        "8=FIX.4.4\0019=0049\00135=ET\001511=d\001512=40\001513=delta\00110=209\001";
+
+    public static final String ET_ONLY_REQ_FIELDS_WITH_BAD_VALUES =
+        "8=FIX.4.4\0019=0049\00135=ET\001511=X\001512=-1\001513=X\00110=209\001";
+
+    public static final String ET_MISSING_REQ_FIELD =
+        "8=FIX.4.4\0019=0049\00135=ET\001511=d\001512=40\00110=209\001";
+
     public static final String RF_ALL_FIELDS =
         "8=FIX.4.4\0019=0049\00135=Z\001700=one\001701=10\001702=b\001703=123.456\001" +
         "704=one\001705=10\001706=b\00110=209\001";
@@ -307,6 +331,8 @@ public final class ExampleDictionary
     public static final String OTHER_MESSAGE_TYPE = "AB";
     public static final byte[] OTHER_MESSAGE_TYPE_BYTES = OTHER_MESSAGE_TYPE.getBytes(US_ASCII);
     public static final int OTHER_MESSAGE_TYPE_PACKED = GenerationUtil.packMessageType(OTHER_MESSAGE_TYPE);
+    private static final String ENUM_TEST_MESSAGE = "EnumTestMessage";
+    private static final String ENUM_TEST_MESSAGE_TYPE = "ET";
 
     static
     {
@@ -416,6 +442,26 @@ public final class ExampleDictionary
         fieldsMessage.optionalEntry(registerField(messageEgFields, 1006, "OptionalCountryField", COUNTRY));
         fieldsMessage.optionalEntry(registerField(messageEgFields, 9001, "HighNumberField", INT));
 
+        final Message enumTestMessage = new Message(ENUM_TEST_MESSAGE, ENUM_TEST_MESSAGE_TYPE, APP);
+        enumTestMessage.optionalEntry(registerField(messageEgFields, 501, "CharEnumOpt", CHAR)
+            .addValue("a", "A")
+            .addValue("b", "B"));
+        enumTestMessage.optionalEntry(registerField(messageEgFields, 502, "IntEnumOpt", INT)
+            .addValue("10", "TEN")
+            .addValue("20", "TWENTY"));
+        enumTestMessage.optionalEntry(registerField(messageEgFields, 503, "StringEnumOpt", STRING)
+            .addValue("alpha", "ALPHA")
+            .addValue("beta", "BETA"));
+        enumTestMessage.requiredEntry(registerField(messageEgFields, 511, "CharEnumReq", CHAR)
+            .addValue("c", "C")
+            .addValue("d", "D"));
+        enumTestMessage.requiredEntry(registerField(messageEgFields, 512, "IntEnumReq", INT)
+            .addValue("30", "THIRTY")
+            .addValue("40", "FORTY"));
+        enumTestMessage.requiredEntry(registerField(messageEgFields, 513, "StringEnumReq", STRING)
+            .addValue("gamma", "GAMMA")
+            .addValue("delta", "DELTA"));
+
         final Message allReqFieldTypesMessage = new Message(ALL_REQ_FIELD_TYPES_MESSAGE_NAME,
             ALL_REQ_FIELD_TYPES_MESSAGE_TYPE, APP);
         allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 700, STRING_RF, STRING));
@@ -430,7 +476,8 @@ public final class ExampleDictionary
             .addValue("a", "APPLE").addValue("b", "BANANA"));
 
 
-        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage, allReqFieldTypesMessage);
+        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage, allReqFieldTypesMessage,
+            enumTestMessage);
 
         final Map<String, Component> components = new HashMap<>();
         components.put(EG_COMPONENT, egComponent);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
@@ -15,10 +15,22 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
 import org.agrona.collections.IntHashSet;
 import org.agrona.generation.StringWriterOutputManager;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.agrona.generation.CompilerUtil.compileInMemory;
+import static org.hamcrest.Matchers.*;
+
+
 import uk.co.real_logic.artio.builder.Decoder;
 import uk.co.real_logic.artio.dictionary.ExampleDictionary;
 import uk.co.real_logic.artio.fields.DecimalFloat;
@@ -27,22 +39,23 @@ import uk.co.real_logic.artio.util.AsciiSequenceView;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 import uk.co.real_logic.artio.util.Reflection;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-
 import static java.lang.reflect.Modifier.isAbstract;
 import static java.lang.reflect.Modifier.isPublic;
-import static org.agrona.generation.CompilerUtil.compileInMemory;
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static uk.co.real_logic.artio.builder.Decoder.NO_ERROR;
 import static uk.co.real_logic.artio.dictionary.ExampleDictionary.*;
+import static uk.co.real_logic.artio.dictionary.generation.CodecUtil.MISSING_CHAR;
 import static uk.co.real_logic.artio.dictionary.generation.CodecUtil.MISSING_INT;
-import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.*;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.ALL_FIELDS;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.CODEC_LOGGING;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.INVALID_TAG_NUMBER;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.REQUIRED_FIELDS;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.REQUIRED_TAG_MISSING;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.TAG_APPEARS_MORE_THAN_ONCE;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.TAG_NOT_DEFINED_FOR_THIS_MESSAGE_TYPE;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.TAG_SPECIFIED_OUT_OF_REQUIRED_ORDER;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.TAG_SPECIFIED_WITHOUT_A_VALUE;
+import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.VALUE_IS_INCORRECT;
 import static uk.co.real_logic.artio.fields.DecimalFloat.MISSING_FLOAT;
 import static uk.co.real_logic.artio.util.Reflection.*;
 
@@ -54,6 +67,12 @@ public class DecoderGeneratorTest
     private static final char[] MULTI_CHAR_VALUE = "a b".toCharArray();
     private static final char[] MULTI_CHAR_VALUE_NO_ENUM = "a b z f".toCharArray();
     private static final char[] MULTI_VALUE_STRING = "ab cd".toCharArray();
+    private static final String CHAR_ENUM_OPT = "charEnumOpt";
+    private static final String INT_ENUM_OPT = "intEnumOpt";
+    private static final String STRING_ENUM_OPT = "stringEnumOpt";
+    private static final String CHAR_ENUM_REQ = "charEnumReq";
+    private static final String INT_ENUM_REQ = "intEnumReq";
+    private static final String STRING_ENUM_REQ = "stringEnumReq";
 
     private static Class<?> heartbeatWithoutValidation;
     private static Class<?> heartbeat;
@@ -61,6 +80,7 @@ public class DecoderGeneratorTest
     private static Class<?> otherMessage;
     private static Class<?> fieldsMessage;
     private static Class<?> allReqFieldTypesMessage;
+    private static Class<?> enumTestMessage;
 
     private MutableAsciiBuffer buffer = new MutableAsciiBuffer(new byte[8 * 1024]);
 
@@ -78,6 +98,7 @@ public class DecoderGeneratorTest
         fieldsMessage = heartbeat.getClassLoader().loadClass(FIELDS_MESSAGE_DECODER);
         compileInMemory(HEADER_DECODER, sourcesWithValidation);
         otherMessage = compileInMemory(OTHER_MESSAGE_DECODER, sourcesWithValidation);
+        enumTestMessage = compileInMemory(ENUM_TEST_MESSAGE_DECODER, sourcesWithValidation);
 
         heartbeatWithoutValidation = compileInMemory(HEARTBEAT_DECODER, sourcesWithoutValidation);
         allReqFieldTypesMessage = compileInMemory(ALL_REQ_FIELD_TYPES_MESSAGE_DECODER, sourcesWithoutValidation);
@@ -149,7 +170,7 @@ public class DecoderGeneratorTest
     @Test
     public void shouldNotRetainStringFromPreviousMessagesForRequiredFieldsWhenReset() throws Throwable
     {
-        final Decoder decoder = (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+        final Decoder decoder = createRequiredFieldMessageDecoder();
         decode(RF_ALL_FIELDS, decoder);
         assertEquals("one", getMethod(decoder, STRING_RF + "AsString"));
 
@@ -161,7 +182,7 @@ public class DecoderGeneratorTest
     @Test
     public void shouldNotRetainIntegerFromPreviousMessagesForRequiredFieldsWhenReset() throws Throwable
     {
-        final Decoder decoder = (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+        final Decoder decoder = createRequiredFieldMessageDecoder();
         decode(RF_ALL_FIELDS, decoder);
         assertEquals(10, getMethod(decoder, INT_RF));
 
@@ -173,7 +194,7 @@ public class DecoderGeneratorTest
     @Test
     public void shouldNotRetainCharFromPreviousMessagesForRequiredFieldsWhenReset() throws Throwable
     {
-        final Decoder decoder = (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+        final Decoder decoder = createRequiredFieldMessageDecoder();
         decode(RF_ALL_FIELDS, decoder);
         assertEquals('b', getMethod(decoder, CHAR_RF));
 
@@ -185,7 +206,7 @@ public class DecoderGeneratorTest
     @Test
     public void shouldNotRetainDecimalFromPreviousMessagesForRequiredFieldsWhenReset() throws Throwable
     {
-        final Decoder decoder = (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+        final Decoder decoder = createRequiredFieldMessageDecoder();
         decode(RF_ALL_FIELDS, decoder);
         assertEquals(new DecimalFloat(123456, 3), getMethod(decoder, DECIMAL_RF));
 
@@ -200,7 +221,7 @@ public class DecoderGeneratorTest
     @Test
     public void shouldNotRetainStringEnumFromPreviousMessagesForRequiredFieldsWhenReset() throws Throwable
     {
-        final Decoder decoder = (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+        final Decoder decoder = createRequiredFieldMessageDecoder();
         decode(RF_ALL_FIELDS, decoder);
         assertEquals("one", getMethod(decoder, STRING_ENUM_RF + "AsString"));
         assertEquals("ONE", getMethod(decoder, STRING_ENUM_RF + "AsEnum").toString());
@@ -208,32 +229,35 @@ public class DecoderGeneratorTest
         decoder.reset();
         decode(RF_NO_FIELDS, decoder);
         assertEquals("", getMethod(decoder, STRING_ENUM_RF + "AsString"));
+        assertEquals("UNKNOWN_REPRESENTATION", getMethod(decoder, STRING_ENUM_RF + "AsEnum").toString());
     }
 
     @Test
     public void shouldNotRetainIntEnumFromPreviousMessagesForRequiredFieldsWhenReset() throws Throwable
     {
-        final Decoder decoder = (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+        final Decoder decoder = createRequiredFieldMessageDecoder();
         decode(RF_ALL_FIELDS, decoder);
         assertEquals(10, getMethod(decoder, INT_ENUM_RF));
         assertEquals("TEN", getMethod(decoder, INT_ENUM_RF + "AsEnum").toString());
 
         decoder.reset();
         decode(RF_NO_FIELDS, decoder);
-        assertEquals(Integer.MIN_VALUE, getMethod(decoder, INT_ENUM_RF));
+        assertEquals(MISSING_INT, getMethod(decoder, INT_ENUM_RF));
+        assertEquals("UNKNOWN_REPRESENTATION", getMethod(decoder, INT_ENUM_RF + "AsEnum").toString());
     }
 
     @Test
     public void shouldNotRetainCharEnumFromPreviousMessagesForRequiredFieldsWhenReset() throws Throwable
     {
-        final Decoder decoder = (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+        final Decoder decoder = createRequiredFieldMessageDecoder();
         decode(RF_ALL_FIELDS, decoder);
         assertEquals('b', getMethod(decoder, CHAR_ENUM_RF));
         assertEquals("BANANA", getMethod(decoder, CHAR_ENUM_RF + "AsEnum").toString());
 
         decoder.reset();
         decode(RF_NO_FIELDS, decoder);
-        assertEquals('\u0001', getMethod(decoder, CHAR_ENUM_RF));
+        assertEquals(MISSING_CHAR, getMethod(decoder, CHAR_ENUM_RF));
+        assertEquals("UNKNOWN_REPRESENTATION", getMethod(decoder, CHAR_ENUM_RF + "AsEnum").toString());
     }
 
     @Test
@@ -249,14 +273,50 @@ public class DecoderGeneratorTest
     }
 
     @Test
-    public void decodesPrimitiveValuesAsEnum() throws Exception
+    public void decodesEnumValuesUsingAsEnumMethods() throws Exception
     {
-        final Decoder decoder = decodeHeartbeat(DERIVED_FIELDS_MESSAGE);
-        assertEquals(2, getRepresentation(get(decoder, INT_FIELD + "AsEnum")));
-        assertNull(get(decoder, CHAR_FIELD + "AsEnum"));
+        final Decoder decoder = (Decoder)enumTestMessage.getConstructor().newInstance();
+        decode(ET_ALL_FIELDS, decoder);
+        assertEquals('a', getRepresentation(get(decoder, CHAR_ENUM_OPT + "AsEnum")));
+        assertEquals(10, getRepresentation(get(decoder, INT_ENUM_OPT + "AsEnum")));
+        assertEquals("alpha", getRepresentation(get(decoder, STRING_ENUM_OPT + "AsEnum")));
+        assertEquals('c', getRepresentation(get(decoder, CHAR_ENUM_REQ + "AsEnum")));
+        assertEquals(30, getRepresentation(get(decoder, INT_ENUM_REQ + "AsEnum")));
+        assertEquals("gamma", getRepresentation(get(decoder, STRING_ENUM_REQ + "AsEnum")));
         assertValid(decoder);
     }
 
+    @Test
+    public void decodesMissingOptionalEnumValuesAsSentinelsUsingAsEnumMethods() throws Exception
+    {
+        final Decoder decoder = (Decoder)enumTestMessage.getConstructor().newInstance();
+        decode(ET_ONLY_REQ_FIELDS, decoder);
+        assertEquals('\u0001', getRepresentation(get(decoder, CHAR_ENUM_OPT + "AsEnum")));
+        assertEquals(Integer.MIN_VALUE, getRepresentation(get(decoder, INT_ENUM_OPT + "AsEnum")));
+        assertEquals("", getRepresentation(get(decoder, STRING_ENUM_OPT + "AsEnum")));
+        assertValid(decoder);
+    }
+
+    @Test
+    public void decodesBadEnumValuesAsSentinelsUsingAsEnumMethods() throws Exception
+    {
+        final Decoder decoder = (Decoder)enumTestMessage.getConstructor().newInstance();
+        decode(ET_ONLY_REQ_FIELDS_WITH_BAD_VALUES, decoder);
+        assertEquals('\u0002', getRepresentation(get(decoder, CHAR_ENUM_REQ + "AsEnum")));
+        assertEquals(Integer.MAX_VALUE, getRepresentation(get(decoder, INT_ENUM_REQ + "AsEnum")));
+        assertEquals("\u0002", getRepresentation(get(decoder, STRING_ENUM_REQ + "AsEnum")));
+        assertInvalid(decoder);
+    }
+
+    @Test
+    public void decodesMissingRequiredEnumFieldUsingAsEnumMethod() throws Exception
+    {
+        final Decoder decoder = (Decoder)enumTestMessage.getConstructor().newInstance();
+        decode(ET_MISSING_REQ_FIELD, decoder);
+        assertEquals("UNKNOWN_REPRESENTATION", get(decoder, STRING_ENUM_REQ + "AsEnum").toString());
+        assertEquals("\u0002", getRepresentation(get(decoder, STRING_ENUM_REQ + "AsEnum")));
+        assertInvalid(decoder);
+    }
 
     @Test
     public void shouldIgnoreMissingOptionalValues() throws Exception
@@ -1383,6 +1443,10 @@ public class DecoderGeneratorTest
         return get(decoder, new String(chars));
     }
 
+    private Decoder createRequiredFieldMessageDecoder() throws Exception
+    {
+        return (Decoder)allReqFieldTypesMessage.getConstructor().newInstance();
+    }
 
     private interface ExceptionThrowingCommand
     {


### PR DESCRIPTION
The argument is that sentinels of -1 are more likely to be used as actual values

This is in preparation for returning sentinel values for enumerations