### PR TITLE
#157 Change sentinel values for missing INT and LONG to min values

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
@@ -27,9 +27,9 @@ public final class CodecUtil
     public static final int BODY_LENGTH_SIZE = BODY_LENGTH_GAP + 1;
     public static final byte[] BODY_LENGTH = "9=0000\001".getBytes(US_ASCII);
 
-    public static final int MISSING_INT = -1;
+    public static final int MISSING_INT = Integer.MIN_VALUE;
     public static final char MISSING_CHAR = '\001';
-    public static final long MISSING_LONG = -1L;
+    public static final long MISSING_LONG = Long.MIN_VALUE;
 
     /**
      * NB: only valid for ASCII bytes.

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -30,6 +30,7 @@ import static java.util.Collections.emptyMap;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.ENCODER_PACKAGE;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.PARENT_PACKAGE;
 import static uk.co.real_logic.artio.dictionary.ir.Category.ADMIN;
+import static uk.co.real_logic.artio.dictionary.ir.Category.APP;
 import static uk.co.real_logic.artio.dictionary.ir.Field.Type.*;
 import static uk.co.real_logic.artio.dictionary.ir.Field.registerField;
 
@@ -55,6 +56,7 @@ public final class ExampleDictionary
     public static final String HEADER_ENCODER = TEST_PACKAGE + ".HeaderEncoder";
 
     public static final String HEARTBEAT_DECODER = TEST_PACKAGE + ".HeartbeatDecoder";
+    public static final String ALL_REQ_FIELD_TYPES_MESSAGE_DECODER = TEST_PACKAGE + ".AllReqFieldTypesMessageDecoder";
     public static final String FIELDS_MESSAGE_DECODER = TEST_PACKAGE + "." + FIELDS_MESSAGE + "Decoder";
     public static final String HEADER_DECODER = TEST_PACKAGE + ".HeaderDecoder";
     public static final String COMPONENT_DECODER = TEST_PACKAGE + "." + EG_COMPONENT + "Decoder";
@@ -76,6 +78,16 @@ public final class ExampleDictionary
     public static final String ON_BEHALF_OF_COMP_ID_LENGTH = "onBehalfOfCompIDLength";
     public static final String SOME_TIME_FIELD = "someTimeField";
     public static final String COMPONENT_FIELD = "componentField";
+
+    public static final String ALL_REQ_FIELD_TYPES_MESSAGE_NAME = "AllReqFieldTypesMessage";
+    public static final String ALL_REQ_FIELD_TYPES_MESSAGE_TYPE = "RF";
+    public static final String STRING_RF = "StringRF";
+    public static final String INT_RF = "IntRF";
+    public static final String CHAR_RF = "CharRF";
+    public static final String DECIMAL_RF = "DecimalRF";
+    public static final String STRING_ENUM_RF = "StringEnumRF";
+    public static final String INT_ENUM_RF = "IntEnumRF";
+    public static final String CHAR_ENUM_RF = "CharEnumRF";
 
     public static final String HAS_TEST_REQ_ID = "hasTestReqID";
     public static final String HAS_ON_BEHALF_OF_COMP_ID = "hasonBehalfOfCompID";
@@ -283,6 +295,13 @@ public final class ExampleDictionary
     public static final String EG_HIGH_NUMBER_FIELD_MESSAGE =
         "8=FIX.4.4\0019=0049\00135=Z\0019001=1\0011001=USD\0011002=N\0011003=US\00110=209\001";
 
+    public static final String RF_ALL_FIELDS =
+        "8=FIX.4.4\0019=0049\00135=Z\001700=one\001701=10\001702=b\001703=123.456\001" +
+        "704=one\001705=10\001706=b\00110=209\001";
+
+    public static final String RF_NO_FIELDS =
+        "8=FIX.4.4\0019=0049\00135=Z\00110=209\001";
+
     public static final int TEST_REQ_ID_TAG = 112;
 
     public static final String OTHER_MESSAGE_TYPE = "AB";
@@ -397,7 +416,21 @@ public final class ExampleDictionary
         fieldsMessage.optionalEntry(registerField(messageEgFields, 1006, "OptionalCountryField", COUNTRY));
         fieldsMessage.optionalEntry(registerField(messageEgFields, 9001, "HighNumberField", INT));
 
-        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage);
+        final Message allReqFieldTypesMessage = new Message(ALL_REQ_FIELD_TYPES_MESSAGE_NAME,
+            ALL_REQ_FIELD_TYPES_MESSAGE_TYPE, APP);
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 700, STRING_RF, STRING));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 701, INT_RF, INT));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 702, CHAR_RF, CHAR));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 703, DECIMAL_RF, FLOAT));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 704, STRING_ENUM_RF, STRING)
+            .addValue("one", "ONE").addValue("two", "TWO"));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 705, INT_ENUM_RF, INT)
+            .addValue("-1", "NEG_ONE").addValue("10", "TEN"));
+        allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 706, CHAR_ENUM_RF, CHAR)
+            .addValue("a", "APPLE").addValue("b", "BANANA"));
+
+
+        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage, allReqFieldTypesMessage);
 
         final Map<String, Component> components = new HashMap<>();
         components.put(EG_COMPONENT, egComponent);


### PR DESCRIPTION
The argument is that sentinels of -1 are more likely to be used as actual values

This is in preparation for returning sentinel values for enumerations