### PR TITLE
[Tom] #150 update the generator to fail on duplicate fields

### DIFF
--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/DictionaryParserTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/DictionaryParserTest.java
@@ -16,7 +16,6 @@
 package uk.co.real_logic.artio.dictionary;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -34,6 +33,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 import uk.co.real_logic.artio.dictionary.ir.Component;
@@ -46,7 +46,6 @@ import uk.co.real_logic.artio.dictionary.ir.Group;
 import uk.co.real_logic.artio.dictionary.ir.Message;
 
 import static uk.co.real_logic.artio.dictionary.ir.Category.ADMIN;
-import static uk.co.real_logic.artio.dictionary.ir.Category.APP;
 import static uk.co.real_logic.artio.dictionary.ir.Field.Type.INT;
 import static uk.co.real_logic.artio.dictionary.ir.Field.Type.STRING;
 import static uk.co.real_logic.artio.util.CustomMatchers.hasFluentProperty;
@@ -184,7 +183,7 @@ public class DictionaryParserTest
     @Test
     public void shouldParseAllMessages()
     {
-        assertEquals(5, dictionary.messages().size());
+        assertEquals(4, dictionary.messages().size());
     }
 
     @Test
@@ -254,15 +253,22 @@ public class DictionaryParserTest
     @Test
     public void shouldDedupeFieldsIncludedTwice()
     {
-        final Message testMessage = dictionary.messages().get(3);
+        shouldThrow(() -> parseDictionary("example_invalid_dictionary_2.xml"),
+            IllegalStateException.class,
+            "Cannot have the same field defined more than once on a message; this is against the FIX spec. " +
+            "Details to follow:\n" +
+            "Message: DedupeFieldsTest Field : MemberSubID (104)\n");
+    }
 
-        assertEquals("DedupeFieldsTest", testMessage.name());
-        assertEquals(12629, testMessage.packedType());
-        assertEquals(APP, testMessage.category());
-
-        final List<Entry> childEntries = testMessage.allChildEntries().collect(Collectors.toList());
-        assertThat(childEntries.size(), is(1));
-        assertThat(childEntries.get(0), isField("MemberSubID"));
+    @Test
+    public void shouldFailIfTwoFieldsAppearInSameMessage()
+    {
+        shouldThrow(() -> parseDictionary("example_invalid_dictionary.xml"),
+            IllegalStateException.class,
+            "Cannot have the same field defined more than once on a message; this is against the FIX spec. " +
+            "Details to follow:\n" +
+            "Message: PoorlyDefinedMessage Field : MemberSubID (104)\n" +
+            "Message: PoorlyDefinedMessage Field : MemberSubID (104)\n");
     }
 
     private Component component(final String name)
@@ -292,7 +298,13 @@ public class DictionaryParserTest
 
     private Dictionary parseExample() throws Exception
     {
-        return new DictionaryParser().parse(DictionaryParserTest.class.getResourceAsStream(EXAMPLE_FILE), null);
+        return parseDictionary(EXAMPLE_FILE);
+    }
+
+    private Dictionary parseDictionary(final String name) throws Exception
+    {
+        return new DictionaryParser()
+            .parse(DictionaryParserTest.class.getResourceAsStream(name), null);
     }
 
     private <T> Matcher<T> withElement(final Matcher<?> valueMatcher)
@@ -338,5 +350,27 @@ public class DictionaryParserTest
     private <T> Matcher<T> isGroup(final String name, final Matcher<T> valueMatcher)
     {
         return allOf(instanceOf(Group.class), withName(equalTo(name)), valueMatcher);
+    }
+
+    private static <T extends Exception> void shouldThrow(
+        final ThrowingRunnable runnable,
+        final Class<T> expectedException,
+        final String message)
+    {
+        try
+        {
+            runnable.run();
+            fail("Expected exception " + expectedException + " with message '" + message + "' but nothing was thrown");
+        }
+        catch (final Exception e)
+        {
+//            assertTrue(e.getClass() instanceof T);
+            assertThat(e.getMessage(), is(message));
+        }
+    }
+
+    private interface ThrowingRunnable
+    {
+        void run() throws Exception;
     }
 }

--- a/artio-codecs/src/test/resources/uk/co/real_logic/artio/dictionary/example_dictionary.xml
+++ b/artio-codecs/src/test/resources/uk/co/real_logic/artio/dictionary/example_dictionary.xml
@@ -47,10 +47,6 @@
             <field name="AvgPx" required="Y"/>
             <field name="OpenCloseSettlFlag" required="N"/>
         </message>
-        <message name="DedupeFieldsTest" msgtype="U1" msgcat="app">
-            <component name="NextComponent" required="N"/>
-            <field name="MemberSubID" required="N"/>
-        </message>
         <message name="News" msgtype="B" msgcat="app">
             <group name="LinesOfText" required="Y">
                 <field name="Text" required="Y"/>
@@ -67,7 +63,7 @@
                     <field name="MemberSubID" required="N"/>
                 </group>
             </group>
-            <component name="NextComponent" required="N"/>
+            <field name="Text" required="N"/>
         </component>
         <component name="NextComponent">
             <field name="MemberSubID" required="N"/>

--- a/artio-codecs/src/test/resources/uk/co/real_logic/artio/dictionary/example_invalid_dictionary.xml
+++ b/artio-codecs/src/test/resources/uk/co/real_logic/artio/dictionary/example_invalid_dictionary.xml
@@ -1,0 +1,45 @@
+<!-- Simple Data Dictionary for testing purposes -->
+<fix type="FIXR" major="7" minor="2">
+    <header>
+        <field name="BeginString" required="Y"/>
+        <field name="BodyLength" required="Y"/>
+        <field name="MsgType" required="Y"/>
+    </header>
+    <trailer>
+        <field name="CheckSum" required="Y"/>
+    </trailer>
+    <messages>
+        <message name="PoorlyDefinedMessage" msgtype="U2" msgcat="app">
+            <component name="Members" required="N"/>
+            <component name="NextComponent" required="N"/>
+        </message>
+    </messages>
+    <components>
+        <component name="Members">
+            <group name="NoMemberIDs" required="N">
+                <field name="MemberID" required="N"/>
+                <group name="NoMemberSubIDs" required="N">
+                    <field name="MemberSubID" required="N"/>
+                </group>
+            </group>
+            <component name="NextComponent" required="N"/>
+        </component>
+        <component name="NextComponent">
+            <field name="MemberSubID" required="N"/>
+        </component>
+    </components>
+    <fields>
+        <field number="8" name="BeginString" type="STRING"/>
+        <field number="9" name="BodyLength" type="INT"/>
+        <field number="35" name="MsgType" type="STRING">
+            <value enum="0" description="HEARTBEAT"/>
+            <value enum="8" description="EXECUTION_REPORT"/>
+            <value enum="D" description="ORDER_SINGLE"/>
+        </field>
+        <field number="10" name="CheckSum" type="STRING"/>
+        <field number="100" name="MemberID" type="STRING"/>
+        <field number="101" name="NoMemberIDs" type="NUMINGROUP"/>
+        <field number="102" name="NoMemberSubIDs" type="NUMINGROUP"/>
+        <field number="104" name="MemberSubID" type="INT"/>
+    </fields>
+</fix>

--- a/artio-codecs/src/test/resources/uk/co/real_logic/artio/dictionary/example_invalid_dictionary_2.xml
+++ b/artio-codecs/src/test/resources/uk/co/real_logic/artio/dictionary/example_invalid_dictionary_2.xml
@@ -1,0 +1,33 @@
+<!-- Simple Data Dictionary for testing purposes -->
+<fix type="FIXR" major="7" minor="2">
+    <header>
+        <field name="BeginString" required="Y"/>
+        <field name="BodyLength" required="Y"/>
+        <field name="MsgType" required="Y"/>
+    </header>
+    <trailer>
+        <field name="CheckSum" required="Y"/>
+    </trailer>
+    <messages>
+        <message name="DedupeFieldsTest" msgtype="U1" msgcat="app">
+            <component name="NextComponent" required="N"/>
+            <field name="MemberSubID" required="N"/>
+        </message>
+    </messages>
+    <components>
+        <component name="NextComponent">
+            <field name="MemberSubID" required="N"/>
+        </component>
+    </components>
+    <fields>
+        <field number="8" name="BeginString" type="STRING"/>
+        <field number="9" name="BodyLength" type="INT"/>
+        <field number="35" name="MsgType" type="STRING">
+            <value enum="0" description="HEARTBEAT"/>
+            <value enum="8" description="EXECUTION_REPORT"/>
+            <value enum="D" description="ORDER_SINGLE"/>
+        </field>
+        <field number="10" name="CheckSum" type="STRING"/>
+        <field number="104" name="MemberSubID" type="INT"/>
+    </fields>
+</fix>


### PR DESCRIPTION
The FIX specification states:

"A tag number (field) should only appear in a message once. If it
appears more than once in the message it should be considered an error
with the specification document. The error should be pointed out to
the FIX Global Technical Committee."

Failing the code generation informs the user the FIX spec they are
using is "invalid"; attempting to use the generated codecs may
result in unexpected behaviour