### PR TITLE
[Tom] improve toString() for message with repeating group

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -1176,12 +1176,13 @@ public class DecoderGenerator extends Generator
     protected String groupEntryToString(final Group element, final String name)
     {
         return String.format(
-            "                (%2$s != null ? String.format(\"  \\\"%1$s\\\": [\\n" +
+            "                (has%3$s ? String.format(\"  \\\"%1$s\\\": [\\n" +
             "  %%s" +
             "\\n  ]" +
             "\\n\", %2$s.toString().replace(\"\\n\", \"\\n  \")" + ") : \"\")",
             name,
-            formatPropertyName(name));
+            formatPropertyName(name),
+            element.numberField().name());
     }
 
     protected String optionalReset(final Field field, final String name)


### PR DESCRIPTION
Currently, the toString() for a decoder checks to see if a repeating
group is null or not to determine what to output. This can be misleading
in the following scenario:

1) Parse a message that does not contain the repeating group
2) Parse a message that has a repeating group with multiple elements
3) Parse a message that does not contain the repeating group

In the case of the messages 1) and 3) being the same, they will produce
different output on toString() as the repeating group is no longer null
due to the parsing of message 2).