### PR TITLE
Clean up generation of GROUP_FIELDS for decoders.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -252,7 +252,11 @@ public class DecoderGenerator extends Generator
 
         if (aggregate.containsGroup())
         {
-            final List<Field> groupFields = aggregate.allDescendantFields().collect(toList());
+            final List<Field> groupFields = aggregate
+                .allChildEntries()
+                .map(Entry::element)
+                .map(element -> (Field)element)
+                .collect(toList());
             final String groupFieldString = generateFieldDictionary(groupFields, GROUP_FIELDS);
             out.append(groupFieldString);
         }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Aggregate.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Aggregate.java
@@ -63,17 +63,6 @@ public abstract class Aggregate
                 ));
     }
 
-    public Stream<Field> allDescendantFields()
-    {
-        return entries.stream()
-            .flatMap(
-                (entry) -> entry.match(
-                    (ele, field) -> Stream.of(field),
-                    (ele, group) -> group.allDescendantFields(),
-                    (ele, component) -> component.allDescendantFields()
-                ));
-    }
-
     public Aggregate optionalEntry(final Entry.Element element)
     {
         entries().add(Entry.optional(element));


### PR DESCRIPTION
Given a the following message definition:
```
<message name="NewOrderSingle" msgtype="D" msgcat="app">
  <field name="ClOrdID" required="Y"/>
  <component name="Members" required="N"/>
</message>
<component name="Members">
<group name="NoMemberIDs" required="N">
  <field name="MemberID" required="Y"/>
  <field name="Text" required="N"/>
</group>
</component>
```
The NewOrderSingleDecoder has ClOrdID, MemberID, and Text inside it's GROUP_FIELDS IntHashSet.
The MembersGroupDecoder has  MemberID, and Text inside it's GROUP_FIELDS IntHashSet.

NewOrderSingleDecoder only needs to know about ClOrdID as MembersGroupDecoder deals
with the other fields (and whether they are known).