### PR TITLE
Improve validate method generated by message decoders.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -265,7 +265,6 @@ public class DecoderGenerator extends Generator
 
         final String groupValidation = aggregate
             .entriesWith(element -> element instanceof Group)
-            .filter(Entry::isGroup)
             .map((entry) -> validateGroup(entry, out))
             .collect(joining("\n"));
 
@@ -409,8 +408,7 @@ public class DecoderGenerator extends Generator
             "            }\n" +
             "        }\n",
             decoderClassName(group),
-            iteratorFieldName(group),
-            group.name());
+            iteratorFieldName(group));
 
         if (entry.required())
         {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -38,6 +38,7 @@ public final class ExampleDictionary
 {
 
     public static final String NO_EG_GROUP = "NoEgGroup";
+    public static final String NO_SECOND_EG_GROUP = "NoSecondEgGroup";
     public static final String NO_COMPONENT_GROUP = "NoComponentGroup";
     public static final String EG_COMPONENT = "EgComponent";
     public static final String FIELDS_MESSAGE = "FieldsMessage";
@@ -185,6 +186,18 @@ public final class ExampleDictionary
     public static final String MISSING_REQUIRED_FIELDS_MESSAGE =
         "8=FIX.4.4\0019=0027\00135=0\001115=abc\001117=1.1\001127=19700101-00:00:00.001" +
         "\00110=161\001";
+
+    public static final String MISSING_REQUIRED_FIELDS_IN_REPEATING_GROUP_MESSAGE =
+        "8=FIX.4.4\0019=53\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\001136=1\001137=TOM\00110=043\001";
+
+    public static final String NO_MISSING_REQUIRED_FIELDS_IN_REPEATING_GROUP_MESSAGE =
+        "8=FIX.4.4\0019=53\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\001136=1\001138=180\001137=TOM\00110=043\001";
+
+    public static final String NO_REPEATING_GROUP_IN_REPEATING_GROUP_MESSAGE =
+        "8=FIX.4.4\0019=53\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\00110=043\001";
 
     public static final String INVALID_TAG_NUMBER_MESSAGE =
         "8=FIX.4.4\0019=0027\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
@@ -367,6 +380,10 @@ public final class ExampleDictionary
         egGroup.optionalEntry(registerField(messageEgFields, 121, "GroupField", INT));
         egGroup.optionalEntry(nestedGroup);
 
+        final Group groupWithRequiredField = Group.of(registerField(messageEgFields, 136, NO_SECOND_EG_GROUP, INT));
+        groupWithRequiredField.optionalEntry(registerField(messageEgFields, 137, "SecondGroupField", STRING));
+        groupWithRequiredField.requiredEntry(registerField(messageEgFields, 138, "ThirdGroupField", INT));
+
         final Group componentGroup = Group.of(registerField(messageEgFields, 130, NO_COMPONENT_GROUP, INT));
         componentGroup.optionalEntry(registerField(messageEgFields, 131, "ComponentGroupField", INT));
 
@@ -394,6 +411,7 @@ public final class ExampleDictionary
         heartbeat.optionalEntry(egGroup);
         heartbeat.requiredEntry(egComponent);
         heartbeat.optionalEntry(dataFieldLength);
+        heartbeat.optionalEntry(groupWithRequiredField);
 
         final Component header = new Component("Header");
         header

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
@@ -492,6 +492,32 @@ public class DecoderGeneratorTest
     }
 
     @Test
+    public void shouldValidateMissingRequiredFieldsInRepeatingGroup() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(MISSING_REQUIRED_FIELDS_IN_REPEATING_GROUP_MESSAGE);
+
+        assertFalse("Passed validation with missing fields", decoder.validate());
+        assertEquals("Wrong tag id", 138, decoder.invalidTagId());
+        assertEquals("Wrong reject reason", REQUIRED_TAG_MISSING, decoder.rejectReason());
+    }
+
+    @Test
+    public void shouldValidateIfNoRequiredFieldsMissingInRepeatingGroup() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(NO_MISSING_REQUIRED_FIELDS_IN_REPEATING_GROUP_MESSAGE);
+
+        assertTrue("Failed validation when it should have passed", decoder.validate());
+    }
+
+    @Test
+    public void shouldValidateIfNoRepeatingGroup() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(NO_REPEATING_GROUP_IN_REPEATING_GROUP_MESSAGE);
+
+        assertTrue("Failed validation when it should have passed", decoder.validate());
+    }
+
+    @Test
     public void shouldValidateTagNumbers() throws Exception
     {
         final Decoder decoder = decodeHeartbeat(INVALID_TAG_NUMBER_MESSAGE);


### PR DESCRIPTION
Currently, the `validate()` on a message decode only checks the child
fields of the message and none of it's descendants. This means the user
of a message decoder would have to call `validate()` on each group 
entry whilst iterating over the group.

This change updates  `validate()` on a message decoders. It now iterates 
through any repeating group entries (if there are any)
and call `validate()` on each entry.
