### PR TITLE
Reference Constants.ALL_FIELDS rather than copy.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -105,8 +105,6 @@ public class DecoderGenerator extends Generator
 
     private String generateAllFieldsDictionary()
     {
-        final int hashMapSize = sizeHashSet(dictionary.fields().values());
-
         return intHashSetCopy(ALL_FIELDS, "Constants.ALL_FIELDS");
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -107,20 +107,15 @@ public class DecoderGenerator extends Generator
     {
         final int hashMapSize = sizeHashSet(dictionary.fields().values());
 
-        return intHashSetCopy(hashMapSize, ALL_FIELDS, "Constants.ALL_FIELDS");
+        return intHashSetCopy(ALL_FIELDS, "Constants.ALL_FIELDS");
     }
 
     private String intHashSetCopy(
-        final int hashMapSize,
         final String name,
         final String from)
     {
         return String.format(
-            "    public final IntHashSet %2$s = new IntHashSet(%1$d);\n" +
-            "    {\n" +
-            "        %2$s.copy(%3$s);\n" +
-            "    }\n\n",
-            hashMapSize,
+            "    public final IntHashSet %1$s = %2$s;\n\n",
             name,
             from);
     }


### PR DESCRIPTION
As part of integrating with venues, we sometimes receive SecurityList messages with over 40,000 instruments within it's repeating group. This means we end up with over 40,000 copies of the allFields map that is roughly 8000 bytes each.

This commit changes the copy to a reference