### PR TITLE
Don't use "allFields" for flow control.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -923,11 +923,12 @@ public class DecoderGenerator extends Generator
             "                {\n" +
             "                    unknownFields.add(tag);\n" +
             "                }\n") +
-            // Skip the thing if it's a completely unknown field and you aren't validating messages
-            "                if (" + CODEC_VALIDATION_ENABLED + " || Constants.ALL_FIELDS.contains(tag))\n" +
+            (hasCommonCompounds ?
+            "                if (" + CODEC_VALIDATION_ENABLED + ")\n" +
             "                {\n" +
             decodeTrailerOrReturn(hasCommonCompounds, 5) +
-            "                }\n" +
+            "                }\n" :
+            decodeTrailerOrReturn(hasCommonCompounds, 5)) +
             "\n" +
             "            }\n\n" +
             "            if (position < (endOfField + 1))\n" +

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
@@ -805,20 +805,20 @@ public class DecoderGeneratorTest
     }
 
     @Test
-    public void shouldIgnoreInvalidTagNumberInGroupsWithoutValidation() throws Exception
+    public void shouldStopDecodingGroupIfInvalidTagNumberReachedIrrespectiveOfValidation() throws Exception
     {
         final Decoder decoder = decodeHeartbeatWithoutValidation(REPEATING_GROUP_MESSAGE_WITH_INVALID_TAG_NUMBER);
 
-        assertRepeatingGroupAndFieldsDecoded(decoder);
+        assertInvalidRepeatingGroupAndFieldsDecoded(decoder);
     }
 
     @Test
-    public void shouldIgnoreInvalidTagNumberInGroupsFieldAfterWithoutValidation() throws Exception
+    public void shouldStopDecodingGroupIfInvalidTAgReachedButDecodeMessageIrrespectiveOfValidation() throws Exception
     {
         final Decoder decoder = decodeHeartbeatWithoutValidation(
             REPEATING_GROUP_MESSAGE_WITH_INVALID_TAG_NUMBER_FIELDS_AFTER);
 
-        assertRepeatingGroupAndFieldsDecoded(decoder);
+        assertInvalidRepeatingGroupAndFieldsDecoded(decoder);
     }
 
     @Test
@@ -963,13 +963,13 @@ public class DecoderGeneratorTest
         assertEquals(highNumberField, 1);
     }
 
-    private void assertRepeatingGroupAndFieldsDecoded(final Decoder decoder) throws Exception
+    private void assertInvalidRepeatingGroupAndFieldsDecoded(final Decoder decoder) throws Exception
     {
         assertArrayEquals(ABC, getOnBehalfOfCompId(decoder));
         assertEquals(2, getIntField(decoder));
         assertEquals(new DecimalFloat(11, 1), getFloatField(decoder));
 
-        assertValidRepeatingGroupDecoded(decoder);
+        assertInValidRepeatingGroupDecoded(decoder);
     }
 
     private void assertOptionalDifferentFieldsNotDecoded(final Decoder decoder) throws Exception
@@ -1191,6 +1191,17 @@ public class DecoderGeneratorTest
         assertRepeatingGroupDecoded(decoder);
 
         assertValid(decoder);
+    }
+
+    private void assertInValidRepeatingGroupDecoded(final Decoder decoder) throws Exception
+    {
+        assertEquals(2, getNoEgGroupGroupCounter(decoder));
+
+        final Object group = getEgGroup(decoder);
+        assertEquals(
+            heartbeat.getName() + "$EgGroupGroupDecoder",
+            group.getClass().getName());
+        assertEquals(1, getGroupField(group));
     }
 
     private void assertRepeatingGroupDecoded(final Decoder decoder) throws Exception


### PR DESCRIPTION
If a Message decoder comes across an unknown field, it should exit if
validation is off or skip over the field if validation is on. For all
other aggregates, stop trying to decode the field and return the it's
parent. Checking if a field is in the FIX schema (unrelated to the
Message) for determine whether to skip it or not does not make sense