### PR TITLE
[Tom/Andrey] call reset on all repeating group entries

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -177,6 +177,40 @@ public class DecoderGenerator extends Generator
         return Decoder.class;
     }
 
+    @Override
+    protected String resetGroup(final Entry entry)
+    {
+        final Group group = (Group)entry.element();
+        final String name = group.name();
+
+        final Entry numberField = group.numberField();
+        return String.format(
+                "    public void %1$s()\n" +
+                "    {\n" +
+                "        for (final %2$s iterator : %5$s.iterator())\n" +
+                "        {\n" +
+                "            iterator.reset();\n" +
+                "        }\n" +
+                "        %3$s = 0;\n" +
+                "        has%4$s = false;\n" +
+                "    }\n\n",
+                nameOfResetMethod(name),
+                decoderClassName(name),
+                formatPropertyName(numberField.name()),
+                numberField.name(),
+                iteratorFieldName(group));
+    }
+
+    private static String iteratorClassName(final Group group)
+    {
+        return group.name() + "Iterator";
+    }
+
+    private static String iteratorFieldName(final Group group)
+    {
+        return formatPropertyName(iteratorClassName(group));
+    }
+
     protected String resetRequiredFloat(final String name)
     {
         return resetByMethod(name);
@@ -375,7 +409,7 @@ public class DecoderGenerator extends Generator
         final Group group = (Group)entry.element();
         final String numberFieldName = group.numberField().name();
         final String validationCode = String.format(
-            "        for (final %1$s iterator : %2$s)\n" +
+            "        for (final %1$s iterator : %2$s.iterator())\n" +
             "        {\n" +
             "            if (!iterator.validate())\n" +
             "            {\n" +
@@ -534,16 +568,6 @@ public class DecoderGenerator extends Generator
             "        this.trailer = trailer;\n" +
             "    }\n\n",
             decoderClassName(aggregate)));
-    }
-
-    private String iteratorClassName(final Group group)
-    {
-        return group.name() + "Iterator";
-    }
-
-    private String iteratorFieldName(final Group group)
-    {
-        return formatPropertyName(iteratorClassName(group));
     }
 
     private String messageType(final String fullType, final int packedType)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -153,6 +153,28 @@ public class EncoderGenerator extends Generator
         return Encoder.class;
     }
 
+    @Override
+    protected String resetGroup(final Entry entry)
+    {
+        final Group group = (Group)entry.element();
+        final String name = group.name();
+        final Entry numberField = group.numberField();
+        return String.format(
+                "    public void %1$s()\n" +
+                "    {\n" +
+                "        if (%2$s != null)\n" +
+                "        {\n" +
+                "            %2$s.reset();\n" +
+                "        }\n" +
+                "        %3$s = 0;\n" +
+                "        has%4$s = false;\n" +
+                "    }\n\n",
+                nameOfResetMethod(name),
+                formatPropertyName(name),
+                formatPropertyName(numberField.name()),
+                numberField.name());
+    }
+
     private void generateAggregateClass(
         final Aggregate aggregate,
         final AggregateType type,

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -252,26 +252,7 @@ public abstract class Generator
             this::callResetMethod);
     }
 
-    private String resetGroup(final Entry entry)
-    {
-        final Group group = (Group)entry.element();
-        final String name = group.name();
-        final Entry numberField = group.numberField();
-        return String.format(
-            "    public void %1$s()\n" +
-            "    {\n" +
-            "        if (%2$s != null)\n" +
-            "        {\n" +
-            "            %2$s.reset();\n" +
-            "        }\n" +
-            "        %3$s = 0;\n" +
-            "        has%4$s = false;\n" +
-            "    }\n\n",
-            nameOfResetMethod(name),
-            formatPropertyName(name),
-            formatPropertyName(numberField.name()),
-            numberField.name());
-    }
+    protected abstract String resetGroup(Entry entry);
 
     private String resetField(final boolean isRequired, final Field field)
     {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -105,6 +105,7 @@ public final class ExampleDictionary
     public static final String HAS_TEST_REQ_ID = "hasTestReqID";
     public static final String HAS_ON_BEHALF_OF_COMP_ID = "hasonBehalfOfCompID";
     public static final String HAS_BOOLEAN_FIELD = "hasBooleanField";
+    public static final String HAS_NESTED_FIELD = "hasNestedField";
     public static final String HAS_DATA_FIELD = "hasDataField";
     public static final String HAS_COMPONENT_FIELD = "hasComponentField";
 
@@ -202,6 +203,22 @@ public final class ExampleDictionary
     public static final String MISSING_REQUIRED_FIELDS_IN_REPEATING_GROUP_MESSAGE =
         "8=FIX.4.4\0019=53\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
         "\001136=1\001137=TOM\00110=043\001";
+
+    public static final String MULTIPLE_ENTRY_REPEATING_GROUP =
+        "8=FIX.4.4\0019=53\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\001136=2\001137=TOM\001138=2\001137=ANDREY\001138=13\00110=043\001";
+
+    public static final String MULTIPLE_ENTRY_REPEATING_GROUP_WITHOUT_OPTIONAL =
+        "8=FIX.4.4\0019=53\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\001136=2\001138=2\001138=13\00110=043\001";
+
+    public static final String MULTI_ENTRY_NESTED_GROUP_MESSAGE =
+        "8=FIX.4.4\0019=77\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\001120=2\001121=1\001122=2\001123=1\001123=2\001121=2\001122=2\001123=3\001123=4\00110=063\001";
+
+    public static final String MULTI_ENTRY_NESTED_GROUP_MESSAGE_WITHOUT_NESTED_FIELDS =
+        "8=FIX.4.4\0019=77\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\001120=2\001121=1\001121=2\00110=063\001";
 
     public static final String NO_MISSING_REQUIRED_FIELDS_IN_REPEATING_GROUP_MESSAGE =
         "8=FIX.4.4\0019=53\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
@@ -1531,15 +1531,15 @@ public class DecoderGeneratorTest
     }
 
     private void assertNestedRepeating(final Object group, final int groupField,
-                                       final int nestedValue1, final int nestedValue2)
-            throws Exception
+        final int nestedValue1, final int nestedValue2)
+        throws Exception
     {
         assertEquals(groupField, getGroupField(group));
 
         Object nestedGroup = getNestedGroup(group);
         assertEquals(
-                heartbeat.getName() + "$EgGroupGroupDecoder$NestedGroupGroupDecoder",
-                nestedGroup.getClass().getName());
+            heartbeat.getName() + "$EgGroupGroupDecoder$NestedGroupGroupDecoder",
+            nestedGroup.getClass().getName());
 
         final boolean expectingValue1 = nestedValue1 != CodecUtil.MISSING_INT;
         assertEquals(expectingValue1, get(nestedGroup, "hasNestedField"));


### PR DESCRIPTION
Currently, reset is only being called on the first entry of a repeating group, which can result in corrupt/invalid data when future messages are parsed. If you receive a message with 3 entries in a repeating group with all fields populated, and then parse another message (after calling reset) with 3 entries in the repeating group but those entries do not have optional fields set, then you will send up with a corrupt message as the optional fields are still set from the first message that was parsed.

This commit iterates over entries in a repeating group and resets all of them.
 