### PR TITLE
[Zam/Michael] Fix NPE when AsciiSequenceView::toString

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/AsciiSequenceView.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/AsciiSequenceView.java
@@ -19,6 +19,10 @@ public class AsciiSequenceView implements CharSequence
 
     public char charAt(final int index)
     {
+        if (buffer == null || index < 0 || index >= length)
+        {
+            throw new IndexOutOfBoundsException("AsciiSequenceView index out of range: " + index);
+        }
         return (char)buffer.getByte(offset + index);
     }
 
@@ -49,6 +53,10 @@ public class AsciiSequenceView implements CharSequence
 
     public String toString()
     {
+        if (buffer == null)
+        {
+            return "";
+        }
         return buffer.getStringWithoutLengthAscii(offset, length);
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/AsciiSequenceViewTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/AsciiSequenceViewTest.java
@@ -5,6 +5,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class AsciiSequenceViewTest
@@ -76,5 +77,43 @@ public class AsciiSequenceViewTest
 
         //Then
         assertThat(targetBuffer.getStringWithoutLengthAscii(targetBufferOffset, data.length()), is(data));
+    }
+
+    @Test
+    public void shouldReturnEmptyStringWhenBufferIsNull()
+    {
+        assertEquals(0, asciiSequenceView.length());
+        assertEquals("", asciiSequenceView.toString());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldThrowIndexOutOfBoundsExceptionWhenCharNotPresentAtGivenPosition()
+    {
+        //Given
+        final String data = "foo";
+        buffer.putStringWithoutLengthAscii(INDEX, data);
+        asciiSequenceView.wrap(buffer, INDEX, data.length());
+
+        //When
+        asciiSequenceView.charAt(4);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldThrowIndexOutOfBoundsExceptionWhenCharAtCalledWithNoBuffer()
+    {
+        //When
+        asciiSequenceView.charAt(0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldThrowIndexOutOfBoundsExceptionWhenCharAtCalledWithNegativeIndex()
+    {
+        //Given
+        final String data = "foo";
+        buffer.putStringWithoutLengthAscii(INDEX, data);
+        asciiSequenceView.wrap(buffer, INDEX, data.length());
+
+        //When
+        asciiSequenceView.charAt(-1);
     }
 }


### PR DESCRIPTION
Fixed NPE when AsciiSequenceView::toString and charAt inconsistencies.

* Followed the Liskov Substitution Principle

* AsciiSequenceView implements CharSequence and by its contract it should not throw NPE under any circumstances when toString called

* charAt should respect the boundaries