### PR TITLE
Do not throw IndexOutOfBoundsException from AsciiSequenceView

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/AsciiSequenceView.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/AsciiSequenceView.java
@@ -12,33 +12,88 @@ public class AsciiSequenceView implements CharSequence
     private int offset;
     private int length;
 
+    public AsciiSequenceView()
+    {
+    }
+
+    /**
+     * Construct a view over a {@link DirectBuffer} from an offset for a given length..
+     *
+     * @param buffer containing the ASCII sequence.
+     * @param offset at which the ASCII sequence begins.
+     * @param length of the ASCII sequence in bytes.
+     */
+    public AsciiSequenceView(final DirectBuffer buffer, final int offset, final int length)
+    {
+        this.buffer = buffer;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int length()
     {
         return length;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public char charAt(final int index)
     {
-        if (buffer == null || index < 0 || index >= length)
+        if (index < 0 || index >= length)
         {
-            throw new IndexOutOfBoundsException("AsciiSequenceView index out of range: " + index);
+            throw new StringIndexOutOfBoundsException("index=" + index + " length=" + length);
         }
+
         return (char)buffer.getByte(offset + index);
     }
 
-    public CharSequence subSequence(final int start, final int end)
+    /**
+     * {@inheritDoc}
+     */
+    public AsciiSequenceView subSequence(final int start, final int end)
     {
-        throw new UnsupportedOperationException();
+        if (start < 0)
+        {
+            throw new StringIndexOutOfBoundsException("start=" + start);
+        }
+
+        if (end > length)
+        {
+            throw new StringIndexOutOfBoundsException("end=" + end);
+        }
+
+        if (end - start < 0)
+        {
+            throw new StringIndexOutOfBoundsException("start=" + start + " end=" + end);
+        }
+
+        return new AsciiSequenceView(buffer, offset + start, end - start);
     }
 
+    /**
+     * Wrap a range of an existing buffer containing an ASCII sequence.
+     *
+     * @param buffer containing the ASCII sequence.
+     * @param offset at which the ASCII sequence begins.
+     * @param length of the ASCII sequence in bytes.
+     * @return this for a fluent API.
+     */
     public AsciiSequenceView wrap(final DirectBuffer buffer, final int offset, final int length)
     {
         this.buffer = buffer;
         this.offset = offset;
         this.length = length;
+
         return this;
     }
 
+    /**
+     * Reset the view to null.
+     */
     public void reset()
     {
         this.buffer = null;
@@ -53,10 +108,11 @@ public class AsciiSequenceView implements CharSequence
 
     public String toString()
     {
-        if (buffer == null)
+        if (null == buffer)
         {
             return "";
         }
+
         return buffer.getStringWithoutLengthAscii(offset, length);
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/AsciiSequenceViewTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/AsciiSequenceViewTest.java
@@ -17,14 +17,11 @@ public class AsciiSequenceViewTest
     @Test
     public void shouldBeAbleToGetChars()
     {
-        //Given
         final String data = "stringy";
         buffer.putStringWithoutLengthAscii(INDEX, data);
 
-        //When
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        //Then
         assertThat(asciiSequenceView.charAt(0), is('s'));
         assertThat(asciiSequenceView.charAt(1), is('t'));
         assertThat(asciiSequenceView.charAt(2), is('r'));
@@ -37,46 +34,49 @@ public class AsciiSequenceViewTest
     @Test
     public void shouldToString()
     {
-        //Given
         final String data = "a little bit of ascii";
         buffer.putStringWithoutLengthAscii(INDEX, data);
 
-        //When
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        //Then
         assertThat(asciiSequenceView.toString(), is(data));
     }
 
     @Test
     public void shouldReturnCorrectLength()
     {
-        //Given
         final String data = "a little bit of ascii";
         buffer.putStringWithoutLengthAscii(INDEX, data);
 
-        //When
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        //Then
         assertThat(asciiSequenceView.length(), is(data.length()));
     }
 
     @Test
     public void shouldCopyDataUnderTheView()
     {
-        //Given
         final String data = "a little bit of ascii";
         final int targetBufferOffset = 56;
         final MutableDirectBuffer targetBuffer = new UnsafeBuffer(new byte[128]);
         buffer.putStringWithoutLengthAscii(INDEX, data);
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        //When
         asciiSequenceView.getBytes(targetBuffer, targetBufferOffset);
 
-        //Then
         assertThat(targetBuffer.getStringWithoutLengthAscii(targetBufferOffset, data.length()), is(data));
+    }
+
+    @Test
+    public void shouldSubSequence()
+    {
+        final String data = "a little bit of ascii";
+        buffer.putStringWithoutLengthAscii(INDEX, data);
+
+        asciiSequenceView.wrap(buffer, INDEX, data.length());
+        final AsciiSequenceView subSequenceView = asciiSequenceView.subSequence(2, 8);
+
+        assertThat(subSequenceView.toString(), is("little"));
     }
 
     @Test
@@ -86,34 +86,29 @@ public class AsciiSequenceViewTest
         assertEquals("", asciiSequenceView.toString());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test(expected = StringIndexOutOfBoundsException.class)
     public void shouldThrowIndexOutOfBoundsExceptionWhenCharNotPresentAtGivenPosition()
     {
-        //Given
         final String data = "foo";
         buffer.putStringWithoutLengthAscii(INDEX, data);
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        //When
         asciiSequenceView.charAt(4);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void shouldThrowIndexOutOfBoundsExceptionWhenCharAtCalledWithNoBuffer()
+    @Test(expected = StringIndexOutOfBoundsException.class)
+    public void shouldThrowExceptionWhenCharAtCalledWithNoBuffer()
     {
-        //When
         asciiSequenceView.charAt(0);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void shouldThrowIndexOutOfBoundsExceptionWhenCharAtCalledWithNegativeIndex()
+    @Test(expected = StringIndexOutOfBoundsException.class)
+    public void shouldThrowExceptionWhenCharAtCalledWithNegativeIndex()
     {
-        //Given
         final String data = "foo";
         buffer.putStringWithoutLengthAscii(INDEX, data);
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        //When
         asciiSequenceView.charAt(-1);
     }
 }


### PR DESCRIPTION
Do not throw IndexOutOfBoundsException when AsciiSequenceView not initialised (NPE instead).

The current implementation of the AsciiSequenceView mirrors the org.agrona.AsciiSequenceView. Once the new version of the Agrona is released both AsciiSequenceView.java and AsciiSequenceViewTest.java should be removed and the Agrona's one should be used instead.