### PR TITLE
onFragment creates an iterator and thus creates garbage

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
@@ -145,9 +145,9 @@ public class Indexer implements Agent, ControlledFragmentHandler
             endPosition,
             streamId,
             aeronSessionId);
-        for (final Index index : indices)
+        for (int i = 0; i < indices.size(); i++) 
         {
-            index.onFragment(buffer, offset, length, header);
+            indices.get(i).onFragment(buffer, offset, length, header);
         }
 
         return CONTINUE;


### PR DESCRIPTION
To reproduce the issue modify the client sample to send a message in a loop