### PR TITLE
[Tom/Zam/Michael] Remove OP_CONNECT after connection succeeds.

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/TcpChannelSupplier.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/TcpChannelSupplier.java
@@ -106,6 +106,7 @@ public class TcpChannelSupplier implements AutoCloseable
                             if (channel.finishConnect())
                             {
                                 channelHandler.onInitiatedChannel(newTcpChannel(channel), null);
+                                selectionKey.interestOps(selectionKey.interestOps() & (~OP_CONNECT));
                                 it.remove();
                                 opensInFlight--;
                             }


### PR DESCRIPTION
If you do not remove OP_CONNECT the InitiatedChannelHandler can be called back in the case of a ConnectionResetByPeer. See https://github.com/netty/netty/issues/924 for a better explanation

We attempted to write a test for this but not sure how to write a test that creates a TCP connection in Artio. If you can point me in the right direction I am more than happy to do this