### PR TITLE
Provide a default DecimalFloat value in encoders.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -326,7 +326,7 @@ public class EncoderGenerator extends Generator
             case QTY:
             case PERCENTAGE:
             case AMT:
-                return generateSetter.apply("DecimalFloat");
+                return decimalFloatSetter(fieldName, hasField, className, hasAssign, enumSetter);
 
             case DATA:
             case XMLDATA:
@@ -475,6 +475,34 @@ public class EncoderGenerator extends Generator
             "%7$s",
             isBodyLength(name) ? "public" : "private",
             type,
+            fieldName,
+            optionalField,
+            className,
+            optionalAssign,
+            enumSetter);
+    }
+
+    private String decimalFloatSetter(
+        final String fieldName,
+        final String optionalField,
+        final String className,
+        final String optionalAssign,
+        final String enumSetter)
+    {
+        return String.format(
+            "    private DecimalFloat %1$s = new DecimalFloat();\n\n" +
+            "%2$s" +
+            "    public %3$s %1$s(DecimalFloat value)\n" +
+            "    {\n" +
+            "        %1$s = value;\n" +
+            "%4$s" +
+            "        return this;\n" +
+            "    }\n\n" +
+            "    public DecimalFloat %1$s()\n" +
+            "    {\n" +
+            "        return %1$s;\n" +
+            "    }\n\n" +
+            "%5$s",
             fieldName,
             optionalField,
             className,

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -498,6 +498,12 @@ public class EncoderGenerator extends Generator
             "%4$s" +
             "        return this;\n" +
             "    }\n\n" +
+            "    public %3$s %1$s(long value, int scale)\n" +
+            "    {\n" +
+            "        %1$s.set(value, scale);\n" +
+            "%4$s" +
+            "        return this;\n" +
+            "    }\n\n" +
             "    public DecimalFloat %1$s()\n" +
             "    {\n" +
             "        return %1$s;\n" +

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -239,6 +239,20 @@ public class EncoderGeneratorTest
     }
 
     @Test
+    public void encodeDecimalFloatUsingRawValueAndScale() throws Exception
+    {
+        final Encoder encoder = newHeartbeat();
+
+        setRequiredFields(encoder);
+        setFloatFieldRawValues(encoder);
+        setupHeader(encoder);
+        setupTrailer(encoder);
+
+        setOptionalFields(encoder);
+        assertEncodesTo(encoder, ENCODED_MESSAGE);
+    }
+
+    @Test
     public void ignoresMissingOptionalValues() throws Exception
     {
         final Encoder encoder = newHeartbeat();
@@ -735,6 +749,11 @@ public class EncoderGeneratorTest
     private void setFloatField(final Encoder encoder) throws Exception
     {
         setFloat(encoder, FLOAT_FIELD, new DecimalFloat(11, 1));
+    }
+
+    private void setFloatFieldRawValues(final Encoder encoder) throws Exception
+    {
+        ((DecimalFloat)getField(encoder, FLOAT_FIELD)).set(11, 1);
     }
 
     private void setIntField(final Encoder encoder) throws Exception

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -753,7 +753,7 @@ public class EncoderGeneratorTest
 
     private void setFloatFieldRawValues(final Encoder encoder) throws Exception
     {
-        ((DecimalFloat)getField(encoder, FLOAT_FIELD)).set(11, 1);
+        setFloat(encoder, FLOAT_FIELD, 11, 1);
     }
 
     private void setIntField(final Encoder encoder) throws Exception

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
@@ -62,6 +62,12 @@ public final class Reflection
         set(object, setter, DecimalFloat.class, value);
     }
 
+    public static void setFloat(final Object object, final String setter, final long value, final int scale)
+        throws Exception
+    {
+        set(object, setter, long.class, int.class, value, scale);
+    }
+
     public static void setCharSequence(final Object object, final String setter, final CharSequence value)
         throws Exception
     {
@@ -89,6 +95,19 @@ public final class Reflection
         object.getClass()
             .getMethod(setterName, type)
             .invoke(object, value);
+    }
+
+    private static void set(
+        final Object object,
+        final String setterName,
+        final Class<?> type1,
+        final Class<?> type2,
+        final Object value1,
+        final Object value2) throws Exception
+    {
+        object.getClass()
+            .getMethod(setterName, type1, type2)
+            .invoke(object, value1, value2);
     }
 
     public static void setField(


### PR DESCRIPTION
Following the same pattern as byte array backed fields, instantiate all fields that are DecimalFloat with an instance (rather than null). This allows users to pass in the scale and value rather than a DecimalFloat when encoding