### PR TITLE
When encoding message, use BeginString from header

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -15,23 +15,32 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
-import org.agrona.generation.OutputManager;
-import uk.co.real_logic.artio.builder.Encoder;
-import uk.co.real_logic.artio.dictionary.ir.*;
-import uk.co.real_logic.artio.dictionary.ir.Entry.Element;
-import uk.co.real_logic.artio.dictionary.ir.Field.Type;
-import uk.co.real_logic.artio.util.MutableAsciiBuffer;
-
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
+import org.agrona.generation.OutputManager;
+
+
+import uk.co.real_logic.artio.builder.Encoder;
+import uk.co.real_logic.artio.dictionary.ir.Aggregate;
+import uk.co.real_logic.artio.dictionary.ir.Component;
+import uk.co.real_logic.artio.dictionary.ir.Dictionary;
+import uk.co.real_logic.artio.dictionary.ir.Entry;
+import uk.co.real_logic.artio.dictionary.ir.Entry.Element;
+import uk.co.real_logic.artio.dictionary.ir.Field;
+import uk.co.real_logic.artio.dictionary.ir.Field.Type;
+import uk.co.real_logic.artio.dictionary.ir.Group;
+import uk.co.real_logic.artio.dictionary.ir.Message;
+import uk.co.real_logic.artio.util.MutableAsciiBuffer;
+
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static uk.co.real_logic.artio.dictionary.generation.AggregateType.GROUP;
+import static uk.co.real_logic.artio.dictionary.generation.AggregateType.HEADER;
 import static uk.co.real_logic.artio.dictionary.generation.EnumGenerator.hasEnumGenerated;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.util.MutableAsciiBuffer.LONGEST_INT_LENGTH;
@@ -46,15 +55,61 @@ public class EncoderGenerator extends Generator
         "%s";
 
     private static final String TRAILER_ENCODE_PREFIX =
-        "    public static final byte[] HEADER_PREFIX_STRING = \"%s\".getBytes(US_ASCII);\n\n" +
-        "    int realStart;\n\n" +
-        "    public int realStart()\n" +
+        "    // |10=...|\n" +
+        "    long finishMessage(final MutableAsciiBuffer buffer, final int messageStart, final int offset)\n" +
         "    {\n" +
-        "        return realStart;\n" +
-        "    }\n\n" +
-        "    public int encode(final MutableAsciiBuffer buffer, final int offset, final int bodyStart)\n" +
+        "        int position = offset;\n" +
+        "\n" +
+        "        final int checkSum = buffer.computeChecksum(messageStart, position);\n" +
+        "        buffer.putBytes(position, checkSumHeader, 0, checkSumHeaderLength);\n" +
+        "        position += checkSumHeaderLength;\n" +
+        "        buffer.putNatural(position, 3, checkSum);\n" +
+        "        position += 3;\n" +
+        "        buffer.putSeparator(position);\n" +
+        "        position++;\n" +
+        "\n" +
+        "        return Encoder.result(position - messageStart, messageStart);\n" +
+        "    }" +
+        "\n" +
+        "    // Optional trailer fields\n" +
+        "    int startTrailer(final MutableAsciiBuffer buffer, final int offset)\n" +
         "    {\n" +
-        "        int position = offset;\n\n";
+        "        final int start = offset;\n" +
+        "        int position = start;\n" +
+        "\n";
+
+    // returns offset where message starts
+    private static final String HEADER_ENCODE_PREFIX =
+        "    // 8=...|9=...|\n" +
+        "    int finishHeader(final MutableAsciiBuffer buffer, final int bodyStart, final int bodyLength)\n" +
+        "    {\n" +
+        "        int position = bodyStart - 1;\n" +
+        "\n" +
+        "        buffer.putSeparator(position);\n" +
+        "        position = buffer.putNaturalFromEnd(bodyLength, position);\n" +
+        "        position -= bodyLengthHeaderLength;\n" +
+        "        buffer.putBytes(position, bodyLengthHeader, 0, bodyLengthHeaderLength);\n" +
+        "\n" +
+        "        if (beginStringLength > 0) {\n" +
+        "        position--;\n" +
+        "        buffer.putSeparator(position);\n" +
+        "        position -= beginStringLength;\n" +
+        "        buffer.putBytes(position, beginString, beginStringOffset, beginStringLength);\n" +
+        "        position -= beginStringHeaderLength;\n" +
+        "        buffer.putBytes(position, beginStringHeader, 0, beginStringHeaderLength);\n" +
+        "        } else if (" + CODEC_VALIDATION_ENABLED + ")\n" +
+        "        {\n" +
+        "            throw new EncodingException(\"Missing Field: BeginString\");\n" +
+        "        }\n" +
+        "\n" +
+        "        return position;\n" +
+        "    }\n" +
+        "\n" +
+        "    // 35=...| + other header fields\n" +
+        "    long startMessage(final MutableAsciiBuffer buffer, final int offset)\n" +
+        "    {\n" +
+        "        final int start = offset + beginStringLength + 16;\n" +
+        "        int position = start;";
 
     private static final String GROUP_ENCODE_PREFIX =
         "    public int encode(final MutableAsciiBuffer buffer, final int offset, final int remainingElements)\n" +
@@ -67,12 +122,12 @@ public class EncoderGenerator extends Generator
 
     // returns (offset, length) as long
     private static final String MESSAGE_ENCODE_PREFIX =
-        "    public static int MAX_HEADER_PREFIX_LENGTH = %d;\n" +
         "    public long encode(final MutableAsciiBuffer buffer, final int offset)\n" +
         "    {\n" +
-        "        int start = offset + MAX_HEADER_PREFIX_LENGTH;\n\n" +
-        "        int position = start;\n\n" +
-        "        position += header.encode(buffer, position);\n";
+        "        final long startMessageResult = header.startMessage(buffer, offset);\n" +
+        "        final int bodyStart = Encoder.offset(startMessageResult);\n" +
+        "        int position = bodyStart + Encoder.length(startMessageResult);\n" +
+        "\n";
 
     // returns length as int
     private static final String OTHER_ENCODE_PREFIX =
@@ -86,7 +141,6 @@ public class EncoderGenerator extends Generator
         "            next.reset();\n" +
         "        }\n";
 
-    private static final int MAX_BODY_LENGTH_FIELD_LENGTH = String.valueOf(Integer.MAX_VALUE).length();
     public static final String METHOD_DELIMITER = "\n\n";
 
     private static String encoderClassName(final String name)
@@ -100,9 +154,7 @@ public class EncoderGenerator extends Generator
 
     private final int initialArraySize;
 
-    // Header prefix strings are of the form: "8=FIX.4.49="
-    private final String headerPrefixString;
-    private final int maxHeaderPrefixLength;
+    private final String beginString;  // e.g. "FIX.4.4"
 
     public EncoderGenerator(
         final Dictionary dictionary,
@@ -120,12 +172,10 @@ public class EncoderGenerator extends Generator
         validateHasField(header, BODY_LENGTH);
 
         this.initialArraySize = initialArraySize;
-        headerPrefixString = String.format("8=%s.%d.%d\0019=",
-            dictionary.specType(),
-            dictionary.majorVersion(),
-            dictionary.minorVersion());
-
-        maxHeaderPrefixLength = headerPrefixString.length() + MAX_BODY_LENGTH_FIELD_LENGTH;
+        beginString = String.format("%s.%d.%d",
+                                    dictionary.specType(),
+                                    dictionary.majorVersion(),
+                                    dictionary.minorVersion());
     }
 
     private void validateHasField(final Component header, final String fieldName)
@@ -186,7 +236,7 @@ public class EncoderGenerator extends Generator
         final boolean isMessage = type == AggregateType.MESSAGE;
         final List<String> interfaces = isMessage ? singletonList(Encoder.class.getSimpleName()) : emptyList();
         out.append(classDeclaration(className, interfaces, type == GROUP));
-        out.append(constructor(aggregate, dictionary));
+        out.append(constructor(aggregate, type, dictionary));
         if (isMessage)
         {
             out.append(commonCompoundImports("Encoder", false, ""));
@@ -195,6 +245,15 @@ public class EncoderGenerator extends Generator
         {
             final Group group = (Group)aggregate;
             out.append(nextMethod(group));
+        }
+        else if (type == HEADER)
+        {
+            out.append(
+                String.format("\n" +
+                "    private static final byte[] DEFAULT_BEGIN_STRING=\"%s\".getBytes(StandardCharsets.US_ASCII);" +
+                "\n\n",
+                beginString));
+
         }
 
         precomputedHeaders(out, aggregate.entries());
@@ -208,7 +267,18 @@ public class EncoderGenerator extends Generator
     private String completeResetMethod(
         final Aggregate aggregate, final boolean isMessage, final AggregateType type)
     {
-        final String additionalReset = type == GROUP ? RESET_NEXT_GROUP : "";
+        final String additionalReset;
+        switch (type)
+        {
+            case GROUP:
+                additionalReset = RESET_NEXT_GROUP;
+                break;
+            case HEADER:
+                additionalReset = "        beginString(DEFAULT_BEGIN_STRING);\n";
+                break;
+            default:
+                additionalReset = "";
+        }
         return super.completeResetMethod(isMessage, aggregate.entries(), additionalReset);
     }
 
@@ -234,9 +304,9 @@ public class EncoderGenerator extends Generator
         );
     }
 
-    private String constructor(final Aggregate aggregate, final Dictionary dictionary)
+    private String constructor(final Aggregate aggregate, final AggregateType type, final Dictionary dictionary)
     {
-        if (aggregate instanceof Message)
+        if (type == AggregateType.MESSAGE)
         {
             final Component header = dictionary.header();
             final Message message = (Message)aggregate;
@@ -255,11 +325,23 @@ public class EncoderGenerator extends Generator
                 "%s" +
                 "    }\n\n",
                 packedType,
-                message.name(),
+                aggregate.name(),
                 msgType);
         }
+        else if (type == AggregateType.HEADER)
+        {
+            return String.format(
+                "    public %sEncoder()\n" +
+                "    {\n" +
+                "        beginString(DEFAULT_BEGIN_STRING);\n" +
+                "    }\n\n",
+                aggregate.name());
+        }
+        else
+        {
+            return "";
+        }
 
-        return "";
     }
 
     private void setters(final Writer out, final String className, final List<Entry> entries) throws IOException
@@ -532,13 +614,11 @@ public class EncoderGenerator extends Generator
 
     private String encodeMethod(final List<Entry> entries, final AggregateType aggregateType)
     {
-        final boolean hasCommonCompounds = aggregateType == AggregateType.MESSAGE;
-
         final String prefix;
         switch (aggregateType)
         {
             case TRAILER:
-                prefix = String.format(TRAILER_ENCODE_PREFIX, headerPrefixString);
+                prefix = TRAILER_ENCODE_PREFIX;
                 break;
 
             case GROUP:
@@ -546,7 +626,11 @@ public class EncoderGenerator extends Generator
                 break;
 
             case MESSAGE:
-                prefix = String.format(MESSAGE_ENCODE_PREFIX, maxHeaderPrefixLength);
+                prefix = MESSAGE_ENCODE_PREFIX;
+                break;
+
+            case HEADER:
+                prefix = HEADER_ENCODE_PREFIX;
                 break;
 
             default:
@@ -559,12 +643,26 @@ public class EncoderGenerator extends Generator
             .collect(joining("\n"));
 
         String suffix;
-        if (hasCommonCompounds)
+        if (aggregateType == AggregateType.MESSAGE)
         {
             suffix =
-                "        position += trailer.encode(buffer, position, start);\n" +
-                "        final int realStart = trailer.realStart;" +
-                "        return Encoder.result(position - realStart, realStart);\n" +
+                "        position += trailer.startTrailer(buffer, position);\n" +
+                "\n" +
+                "        final int messageStart = header.finishHeader(buffer, bodyStart, position - bodyStart);\n" +
+                "        return trailer.finishMessage(buffer, messageStart, position);\n" +
+                "    }\n\n";
+        }
+        else if (aggregateType == AggregateType.HEADER)
+        {
+            suffix =
+                "\n" +
+                "        return Encoder.result(position - start, start);\n" +
+                "    }\n\n";
+        }
+        else if (aggregateType == AggregateType.TRAILER)
+        {
+            suffix =
+                "        return position - start;\n" +
                 "    }\n\n";
         }
         else
@@ -588,37 +686,14 @@ public class EncoderGenerator extends Generator
 
     private String encodeEntry(final Entry entry)
     {
-        if (isBodyLength(entry) || isBeginString(entry))
+        if (isBodyLength(entry) || isBeginString(entry) || isCheckSum(entry))
         {
             return "";
-        }
-        else if (isCheckSum(entry))
-        {
-            return encodeChecksum();
         }
         else
         {
             return entry.matchEntry(this::encodeField, this::encodeGroup, this::encodeComponent);
         }
-    }
-
-    private String encodeChecksum()
-    {
-        return
-            "        final int bodyLength = position - bodyStart;\n" +
-            "        buffer.putSeparator(bodyStart - 1);\n" +
-            "        final int bodyLengthStart = buffer.putNaturalFromEnd(bodyLength, bodyStart - 1);\n" +
-            "        final int realStart = bodyLengthStart - HEADER_PREFIX_STRING.length;\n" +
-            "        this.realStart = realStart;" +
-            "        buffer.putBytes(realStart, HEADER_PREFIX_STRING);\n" +
-            formatTag("checkSum", "") +
-            // 17 to account for the common sized prefix size before bodyStart.
-            // position - 3, to get back to the point before the checksum, ie skip behind (10)
-            "        final int checkSum = buffer.computeChecksum(realStart, position - 3);\n" +
-            "        buffer.putNatural(position, 3, checkSum);\n" +
-            "        position += 3;\n" +
-            "        buffer.putSeparator(position);\n" +
-            "        position++;\n";
     }
 
     private String encodeField(final Entry entry)
@@ -780,18 +855,15 @@ public class EncoderGenerator extends Generator
     {
         for (final Entry entry : entries)
         {
-            if (!isBodyLength(entry))
+            final Element element = entry.element();
+            if (element instanceof Field)
             {
-                final Element element = entry.element();
-                if (element instanceof Field)
-                {
-                    precomputedFieldHeader(out, (Field)element);
-                }
-                else if (element instanceof Group)
-                {
-                    final Group group = (Group)element;
-                    precomputedFieldHeader(out, (Field)group.numberField().element());
-                }
+                precomputedFieldHeader(out, (Field)element);
+            }
+            else if (element instanceof Group)
+            {
+                final Group group = (Group)element;
+                precomputedFieldHeader(out, (Field)group.numberField().element());
             }
         }
     }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -188,6 +188,14 @@ public final class ExampleDictionary
         "8=FIX.4.4\0019=75\00135=0\001115=abc\001112=abc\001116=2\001117=1.1" +
         "\001118=Y\001119=123\001127=19700101-00:00:00.001\00110=199\001";
 
+    public static final String ENCODED_MESSAGE_FIXT11 =
+        "8=FIXT.1.1\0019=75\00135=0\001115=abc\001112=abc\001116=2\001117=1.1" +
+        "\001118=Y\001119=123\001127=19700101-00:00:00.001\00110=021\001";
+
+    public static final String ENCODED_MESSAGE_WITH_SIGNATURE =
+        "8=FIX.4.4\0019=96\00135=0\001115=abc\001112=abc\001116=2\001117=1.1" +
+        "\001118=Y\001119=123\001127=19700101-00:00:00.001\00193=11\00189=Good to go!\00110=040\001";
+
     public static final String ONLY_TESTREQ_ENCODED_MESSAGE =
         "8=FIX.4.4\0019=61\00135=0\001115=abc\001112=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
         "\00110=034\001";
@@ -403,6 +411,8 @@ public final class ExampleDictionary
         final Field bodyLength = registerField(messageEgFields, 9, "BodyLength", INT);
         final Field msgType = registerField(messageEgFields, 35, "MsgType", Type.STRING);
 
+        final Field signatureLength = registerField(messageEgFields, 93, "SignatureLength", Type.LENGTH);
+        final Field signature = registerField(messageEgFields, 89, "Signature", Type.DATA);
         final Field checkSum = registerField(messageEgFields, 10, "CheckSum", Type.STRING);
 
         final Field onBehalfOfCompID = registerField(messageEgFields, 115, "OnBehalfOfCompID", Type.STRING)
@@ -490,6 +500,8 @@ public final class ExampleDictionary
             .requiredEntry(msgType);
 
         final Component trailer = new Component("Trailer");
+        trailer.optionalEntry(signatureLength);
+        trailer.optionalEntry(signature);
         trailer.requiredEntry(checkSum);
 
         final Message otherMessage = new Message("OtherMessage", OTHER_MESSAGE_TYPE, ADMIN);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -26,6 +26,8 @@ import uk.co.real_logic.artio.fields.UtcTimestampEncoder;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 import uk.co.real_logic.artio.util.Reflection;
 
+
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static java.lang.reflect.Modifier.isAbstract;
@@ -55,6 +57,7 @@ public class EncoderGeneratorTest
         {
             System.out.println(sources);
         }
+
         otherMessage = compileInMemory(OTHER_MESSAGE_ENCODER, sources);
 
         final Map<String, CharSequence> sourcesWithoutValidation = generateSources(false);
@@ -236,6 +239,32 @@ public class EncoderGeneratorTest
 
         setOptionalFields(encoder);
         assertEncodesTo(encoder, ENCODED_MESSAGE);
+    }
+
+    @Test
+    public void encodesValuesWithOptionalTrailerFields() throws Exception
+    {
+        final Encoder encoder = newHeartbeat();
+
+        setRequiredFields(encoder);
+        setupHeader(encoder);
+        setupTrailer(encoder, "Good to go!");
+
+        setOptionalFields(encoder);
+        assertEncodesTo(encoder, ENCODED_MESSAGE_WITH_SIGNATURE);
+    }
+
+    @Test
+    public void encodesValuesWithBeginString() throws Exception
+    {
+        final Encoder encoder = newHeartbeat();
+
+        setRequiredFields(encoder);
+        setupHeader(encoder, "FIXT.1.1");
+        setupTrailer(encoder);
+
+        setOptionalFields(encoder);
+        assertEncodesTo(encoder, ENCODED_MESSAGE_FIXT11);
     }
 
     @Test
@@ -464,6 +493,23 @@ public class EncoderGeneratorTest
     {
         final Encoder encoder = newHeartbeat();
 
+        setRequiredFields(encoder);
+        setEgGroupToTwoElements(encoder);
+
+        reset(encoder);
+
+        setRequiredFields(encoder);
+        setEgGroupToOneElement(encoder);
+
+        assertEncodesTo(encoder, SINGLE_REPEATING_GROUP_MESSAGE);
+    }
+
+    @Test
+    public void shouldEncodeDefaultBeginStringAfterReset() throws Exception
+    {
+        final Encoder encoder = newHeartbeat();
+
+        setupHeader(encoder, "FIXT.1.1");
         setRequiredFields(encoder);
         setEgGroupToTwoElements(encoder);
 
@@ -723,8 +769,13 @@ public class EncoderGeneratorTest
 
     private void setupHeader(final Encoder encoder) throws Exception
     {
+        setupHeader(encoder, "FIX.4.4");
+    }
+
+    private void setupHeader(final Encoder encoder, final String beginString) throws Exception
+    {
         final Object header = Reflection.get(encoder, "header");
-        setCharSequence(header, "beginString", "FIX.4.4");
+        setCharSequence(header, "beginString", beginString);
         setCharSequence(header, MSG_TYPE, "0");
     }
 
@@ -779,7 +830,19 @@ public class EncoderGeneratorTest
 
     private void setupTrailer(final Encoder encoder) throws Exception
     {
+        setupTrailer(encoder, "");
+    }
+
+    private void setupTrailer(final Encoder encoder, final String signature) throws Exception
+    {
         final Object trailer = Reflection.get(encoder, "trailer");
+
+        if (signature.length() > 0)
+        {
+            setByteArray(trailer, "signature", signature.getBytes(StandardCharsets.US_ASCII));
+            setInt(trailer, "signatureLength", signature.length());
+        }
+
         setCharSequence(trailer, "checkSum", "12");
     }
 


### PR DESCRIPTION
When encoding message, use BeginString from header (which now can be overriden). This allows using same encoders for multiple FIX versions, with 'session' layer enforcing correct header values when sending the message.
For backward compatibility when header is constructed / reset, the field is set to default value from dictionary.