### PR TITLE
[Zam/Andrey] Extracted interface for header encoders 

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/builder/Encoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/builder/Encoder.java
@@ -55,7 +55,7 @@ public interface Encoder
 
     int messageType();
 
-    Object header();
+    SessionHeaderEncoder header();
 
     void resetMessage();
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/builder/SessionHeaderEncoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/builder/SessionHeaderEncoder.java
@@ -1,0 +1,151 @@
+package uk.co.real_logic.artio.builder;
+
+// Partial FIX header - only fields used by session layer (see session_dictionary.xml).
+// The expectation is that every realistic dictionary will have those defined with the right names.
+public interface SessionHeaderEncoder
+{
+    SessionHeaderEncoder beginString(byte[] value, int length);
+
+    SessionHeaderEncoder beginString(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder beginString(byte[] value);
+
+    SessionHeaderEncoder beginString(CharSequence value);
+
+    SessionHeaderEncoder beginString(char[] value);
+
+    SessionHeaderEncoder beginString(char[] value, int length);
+
+    SessionHeaderEncoder beginString(char[] value, int offset, int length);
+
+    boolean hasBeginString();
+
+    SessionHeaderEncoder senderCompID(byte[] value, int length);
+
+    SessionHeaderEncoder senderCompID(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder senderCompID(byte[] value);
+
+    SessionHeaderEncoder senderCompID(CharSequence value);
+
+    SessionHeaderEncoder senderCompID(char[] value);
+
+    SessionHeaderEncoder senderCompID(char[] value, int length);
+
+    SessionHeaderEncoder senderCompID(char[] value, int offset, int length);
+
+    boolean hasSenderCompID();
+
+    SessionHeaderEncoder targetCompID(byte[] value, int length);
+
+    SessionHeaderEncoder targetCompID(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder targetCompID(byte[] value);
+
+    SessionHeaderEncoder targetCompID(CharSequence value);
+
+    SessionHeaderEncoder targetCompID(char[] value);
+
+    SessionHeaderEncoder targetCompID(char[] value, int length);
+
+    SessionHeaderEncoder targetCompID(char[] value, int offset, int length);
+
+    boolean hasTargetCompID();
+
+    SessionHeaderEncoder msgSeqNum(int value);
+
+    boolean hasMsgSeqNum();
+
+    SessionHeaderEncoder senderSubID(byte[] value, int length);
+
+    SessionHeaderEncoder senderSubID(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder senderSubID(byte[] value);
+
+    SessionHeaderEncoder senderSubID(CharSequence value);
+
+    SessionHeaderEncoder senderSubID(char[] value);
+
+    SessionHeaderEncoder senderSubID(char[] value, int length);
+
+    SessionHeaderEncoder senderSubID(char[] value, int offset, int length);
+
+    boolean hasSenderSubID();
+
+    SessionHeaderEncoder senderLocationID(byte[] value, int length);
+
+    SessionHeaderEncoder senderLocationID(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder senderLocationID(byte[] value);
+
+    SessionHeaderEncoder senderLocationID(CharSequence value);
+
+    SessionHeaderEncoder senderLocationID(char[] value);
+
+    SessionHeaderEncoder senderLocationID(char[] value, int length);
+
+    SessionHeaderEncoder senderLocationID(char[] value, int offset, int length);
+
+    boolean hasSenderLocationID();
+
+    SessionHeaderEncoder targetSubID(byte[] value, int length);
+
+    SessionHeaderEncoder targetSubID(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder targetSubID(byte[] value);
+
+    SessionHeaderEncoder targetSubID(CharSequence value);
+
+    SessionHeaderEncoder targetSubID(char[] value);
+
+    SessionHeaderEncoder targetSubID(char[] value, int length);
+
+    SessionHeaderEncoder targetSubID(char[] value, int offset, int length);
+
+    boolean hasTargetSubID();
+
+    SessionHeaderEncoder targetLocationID(byte[] value, int length);
+
+    SessionHeaderEncoder targetLocationID(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder targetLocationID(byte[] value);
+
+    SessionHeaderEncoder targetLocationID(CharSequence value);
+
+    SessionHeaderEncoder targetLocationID(char[] value);
+
+    SessionHeaderEncoder targetLocationID(char[] value, int length);
+
+    SessionHeaderEncoder targetLocationID(char[] value, int offset, int length);
+
+    boolean hasTargetLocationID();
+
+    SessionHeaderEncoder possDupFlag(boolean value);
+
+    boolean hasPossDupFlag();
+
+    SessionHeaderEncoder possResend(boolean value);
+
+    boolean hasPossResend();
+
+    SessionHeaderEncoder sendingTime(byte[] value, int length);
+
+    SessionHeaderEncoder sendingTime(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder sendingTime(byte[] value);
+
+    boolean hasSendingTime();
+
+    SessionHeaderEncoder origSendingTime(byte[] value, int length);
+
+    SessionHeaderEncoder origSendingTime(byte[] value, int offset, int length);
+
+    SessionHeaderEncoder origSendingTime(byte[] value);
+
+    boolean hasOrigSendingTime();
+
+    SessionHeaderEncoder lastMsgSeqNumProcessed(int value);
+
+    boolean hasLastMsgSeqNumProcessed();
+
+}

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -25,6 +25,7 @@ import org.agrona.generation.OutputManager;
 
 
 import uk.co.real_logic.artio.builder.Encoder;
+import uk.co.real_logic.artio.builder.SessionHeaderEncoder;
 import uk.co.real_logic.artio.dictionary.ir.Aggregate;
 import uk.co.real_logic.artio.dictionary.ir.Component;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
@@ -233,8 +234,21 @@ public class EncoderGenerator extends Generator
         final String className,
         final Writer out) throws IOException
     {
+        final boolean isHeader = type == AggregateType.HEADER;
         final boolean isMessage = type == AggregateType.MESSAGE;
-        final List<String> interfaces = isMessage ? singletonList(Encoder.class.getSimpleName()) : emptyList();
+        final List<String> interfaces;
+        if (isMessage)
+        {
+            interfaces = singletonList(Encoder.class.getSimpleName());
+        }
+        else if (isHeader)
+        {
+            interfaces = singletonList(SessionHeaderEncoder.class.getName());
+        }
+        else
+        {
+            interfaces = emptyList();
+        }
         out.append(classDeclaration(className, interfaces, type == GROUP));
         out.append(constructor(aggregate, type, dictionary));
         if (isMessage)

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -410,6 +410,18 @@ public final class ExampleDictionary
         final Field beginString = registerField(messageEgFields, 8, "BeginString", Type.STRING);
         final Field bodyLength = registerField(messageEgFields, 9, "BodyLength", INT);
         final Field msgType = registerField(messageEgFields, 35, "MsgType", Type.STRING);
+        final Field senderCompID = registerField(messageEgFields, 49, "SenderCompID", Type.STRING);
+        final Field targetCompID = registerField(messageEgFields, 56, "TargetCompID", Type.STRING);
+        final Field msgSeqNum = registerField(messageEgFields, 34, "MsgSeqNum", Type.SEQNUM);
+        final Field senderSubID = registerField(messageEgFields, 50, "SenderSubID", Type.STRING);
+        final Field senderLocationID = registerField(messageEgFields, 142, "SenderLocationID", Type.STRING);
+        final Field targetSubID = registerField(messageEgFields, 57, "TargetSubID", Type.STRING);
+        final Field targetLocationID = registerField(messageEgFields, 143, "TargetLocationID", Type.STRING);
+        final Field possDupFlag = registerField(messageEgFields, 43, "PossDupFlag", Type.BOOLEAN);
+        final Field possResend = registerField(messageEgFields, 97, "PossResend", Type.BOOLEAN);
+        final Field sendingTime = registerField(messageEgFields, 52, "SendingTime", Type.UTCTIMESTAMP);
+        final Field origSendingTime = registerField(messageEgFields, 122, "OrigSendingTime", Type.UTCTIMESTAMP);
+        final Field lastMsgSeqNumProcessed = registerField(messageEgFields, 369, "LastMsgSeqNumProcessed", Type.SEQNUM);
 
         final Field signatureLength = registerField(messageEgFields, 93, "SignatureLength", Type.LENGTH);
         final Field signature = registerField(messageEgFields, 89, "Signature", Type.DATA);
@@ -497,7 +509,20 @@ public final class ExampleDictionary
         header
             .requiredEntry(beginString)
             .requiredEntry(bodyLength)
-            .requiredEntry(msgType);
+            .requiredEntry(msgType)
+            .optionalEntry(senderCompID)
+            .optionalEntry(targetCompID)
+            .optionalEntry(msgSeqNum)
+            .optionalEntry(senderSubID)
+            .optionalEntry(senderLocationID)
+            .optionalEntry(targetSubID)
+            .optionalEntry(targetLocationID)
+            .optionalEntry(possDupFlag)
+            .optionalEntry(possResend)
+            .optionalEntry(sendingTime)
+            .optionalEntry(origSendingTime)
+            .optionalEntry(lastMsgSeqNumProcessed);
+
 
         final Component trailer = new Component("Trailer");
         trailer.optionalEntry(signatureLength);

--- a/artio-samples/src/main/java/uk/co/real_logic/artio/builder/OrderSingleEncoder.java
+++ b/artio-samples/src/main/java/uk/co/real_logic/artio/builder/OrderSingleEncoder.java
@@ -114,7 +114,7 @@ public class OrderSingleEncoder implements Encoder
         return 0;
     }
 
-    public Object header()
+    public SessionHeaderEncoder header()
     {
         return null;
     }


### PR DESCRIPTION
Allows common session logic to operate on all generated artio code.
The interface is based on session_dictionary.xml (which Artio's FIX engine relies on). We haven't got as far as swapping HeaderEncoder for interface in artio-core - but quick evaluation shows this is doable; if implemented this should allow using multiple FIX dialects from different packages in the same process.