### PR TITLE
Duplicate sessionId assignment fix

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContexts.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContexts.java
@@ -335,9 +335,6 @@ public class SessionContexts
     {
         if (messageType == LogonDecoder.MESSAGE_TYPE && recordedSessions.add(sessionId))
         {
-            // Ensure no future collision if you take over as leader of the cluster.
-            counter = sessionId + 1;
-
             asciiBuffer.wrap(buffer);
             logonDecoder.decode(asciiBuffer, offset, length);
 

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionContextsTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionContextsTest.java
@@ -241,6 +241,7 @@ public class SessionContextsTest
         final SessionContext cContext = sessionContexts.onLogon(cSession);
 
         assertNotEquals(DUPLICATE_SESSION, cContext);
+        assertEquals(3, cContext.sessionId());
     }
 
     private void verifyNoBackUp()


### PR DESCRIPTION
fixes #233 

- do not decrement SessionContexts.counter so incoming composite keys never clash with currently authenticated sessionIds
- real-logic/fix-integration green (+fixVersion=0.21-SNAPSHOT )
