### PR TITLE
Need to be able to cope with corrupt archive

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
@@ -106,6 +106,7 @@ public class Indexer implements Agent, ControlledFragmentHandler
                             while (subscription.imageCount() != 1)
                             {
                                 idle(idleStrategy, aeronInvoker);
+                                aeronArchive.checkForErrorResponse();
                             }
                             idleStrategy.reset();
 


### PR DESCRIPTION
If archive gets corrupt, Indexer gets stuck indefinitely so we need to check that while we wait for messages to arrive