### PR TITLE
Thread factory for archivingRunner, framerRunner in engine scheduler through EngineConfiguration

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/DefaultEngineScheduler.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/DefaultEngineScheduler.java
@@ -21,6 +21,8 @@ import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.AgentRunner;
 import uk.co.real_logic.artio.dictionary.generation.Exceptions;
 
+import java.util.concurrent.ThreadFactory;
+
 import static org.agrona.concurrent.AgentRunner.startOnThread;
 import static uk.co.real_logic.artio.CommonConfiguration.backoffIdleStrategy;
 
@@ -54,8 +56,9 @@ public class DefaultEngineScheduler implements EngineScheduler
         archivingRunner = new AgentRunner(
             configuration.archiverIdleStrategy(), errorHandler, null, indexingAgent);
 
-        startOnThread(framerRunner);
-        startOnThread(archivingRunner);
+        final ThreadFactory threadFactory = configuration.threadFactory();
+        startOnThread(framerRunner, threadFactory);
+        startOnThread(archivingRunner, threadFactory);
 
         if (monitoringAgent != null)
         {

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
 
 import static java.lang.Integer.getInteger;
@@ -176,6 +177,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     private MappedFile sessionIdBuffer;
     private Set<String> gapfillOnReplayMessageTypes = new HashSet<>(DEFAULT_GAPFILL_ON_REPLAY_MESSAGE_TYPES);
     private final AeronArchive.Context archiveContext = new AeronArchive.Context();
+    private ThreadFactory threadFactory;
 
     private int outboundLibraryFragmentLimit =
         getInteger(OUTBOUND_LIBRARY_FRAGMENT_LIMIT_PROP, DEFAULT_OUTBOUND_LIBRARY_FRAGMENT_LIMIT);
@@ -771,6 +773,17 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
         return this;
     }
 
+    /**
+     * Sets factory for threads such as framer, archivingRunner, etc in EngineScheduler
+     * @param threadFactory factory for custom thread creating
+     * @return this
+     */
+    public EngineConfiguration threadFactory(final ThreadFactory threadFactory)
+    {
+        this.threadFactory = threadFactory;
+        return this;
+    }
+
     public AeronArchive.Context aeronArchiveContext()
     {
         return archiveContext;
@@ -804,6 +817,11 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     public boolean acceptedEnableLastMsgSeqNumProcessed()
     {
         return acceptedEnableLastMsgSeqNumProcessed;
+    }
+
+    public ThreadFactory threadFactory()
+    {
+        return threadFactory;
     }
 
     public EngineConfiguration conclude()
@@ -852,6 +870,11 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
         if (sessionPersistenceStrategy() == null)
         {
             sessionPersistenceStrategy(alwaysUnindexed());
+        }
+
+        if (threadFactory == null)
+        {
+            threadFactory = Thread::new;
         }
 
         return this;

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/LockStepFramerEngineScheduler.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/LockStepFramerEngineScheduler.java
@@ -54,7 +54,7 @@ public class LockStepFramerEngineScheduler implements EngineScheduler
         archivingRunner = new AgentRunner(
             configuration.archiverIdleStrategy(), errorHandler, null, indexingAgent);
 
-        startOnThread(archivingRunner);
+        startOnThread(archivingRunner, configuration.threadFactory());
 
         if (monitoringAgent != null)
         {

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/LowResourceEngineScheduler.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/LowResourceEngineScheduler.java
@@ -70,7 +70,7 @@ public class LowResourceEngineScheduler implements EngineScheduler
             errorHandler,
             null,
             new CompositeAgent(agents));
-        startOnThread(runner);
+        startOnThread(runner, configuration.threadFactory());
     }
 
     public void close()

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/LowResourceEngineSchedulerTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/LowResourceEngineSchedulerTest.java
@@ -39,6 +39,7 @@ public class LowResourceEngineSchedulerTest
     public void shouldPrintErrorIfRepeatedlyThrown() throws Exception
     {
         when(configuration.framerIdleStrategy()).thenReturn(new BusySpinIdleStrategy());
+        when(configuration.threadFactory()).thenReturn(Thread::new);
         when(framer.doWork()).thenThrow(IOException.class);
 
         try (EngineScheduler scheduler = new LowResourceEngineScheduler())


### PR DESCRIPTION
Sorry, reopen #253, can't make one-commit previous PR. 

I need to create threads in a custom way with https://github.com/peter-lawrey/Java-Thread-Affinity for bind threads to cores. The only way to do this in affinity is by using try-with-resources from target thread.

Javadoc has done, LowResourceEngineScheduler already [supported](https://github.com/real-logic/artio/pull/254/commits/6ec5383025b42476e4fd2f58877557c922014df8#diff-5132d1267fb24dad1bd951e5c0600abc).