### PR TITLE
All groups to be iterated on components

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -512,11 +512,24 @@ public class DecoderGenerator extends Generator
             {
                 out.append(fileHeader(builderPackage));
 
+                final List<String> interfaces = component.entries()
+                    .stream()
+                    .flatMap(e -> e.isComponent() ? Stream.concat(Stream.of(e),
+                    ((Component)e.element()).entries().stream()) :
+                    Stream.of(e))
+                    .filter(e -> e.element() instanceof Component)
+                    .map((comp) -> decoderClassName((Aggregate)comp.element()))
+                    .collect(toList());
+
+                final String interfaceExtension = interfaces.isEmpty() ? "" : " extends " +
+                    String.join(", ", interfaces);
+
                 generateImports("Decoder", AggregateType.COMPONENT, out);
                 out.append(String.format(
-                    "\npublic interface %1$s\n" +
+                    "\npublic interface %1$s %2$s\n" +
                     "{\n\n",
-                    className));
+                    className,
+                    interfaceExtension));
 
                 for (final Entry entry : component.entries())
                 {
@@ -551,7 +564,14 @@ public class DecoderGenerator extends Generator
     private void componentInterfaceGetter(final Component component, final Writer out)
         throws IOException
     {
-        wrappedForEachEntry(component, out, (entry) -> interfaceGetter(component, entry, out));
+//        final String fieldName = formatPropertyName(component.name());
+//
+//        out.append(String.format(
+//                "    public %1$s %2$s();\n",
+//                decoderClassName(component),
+//                fieldName
+//        ));
+//        wrappedForEachEntry(component, out, (entry) -> interfaceGetter(component, entry, out));
     }
 
     private void wrappedForEachEntry(

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -553,6 +553,7 @@ public class DecoderGenerator extends Generator
         generateGroupIterator(parent, out, group);
 
         final Entry numberField = group.numberField();
+        out.append(String.format("public %1$s %2$s();\n", iteratorClassName(group), iteratorFieldName(group)));
         out.append(fieldInterfaceGetter(numberField, (Field)numberField.element()));
 
         out.append(String.format(

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -520,23 +520,25 @@ public class DecoderGenerator extends Generator
 
                 for (final Entry entry : component.entries())
                 {
-                    interfaceGetter(entry, out);
+                    interfaceGetter(component, entry, out);
                 }
                 out.append("\n}\n");
             });
     }
 
-    private void interfaceGetter(final Entry entry, final Writer out) throws IOException
+    private void interfaceGetter(final Aggregate parent, final Entry entry, final Writer out) throws IOException
     {
         entry.forEach(
             (field) -> out.append(fieldInterfaceGetter(entry, field)),
-            (group) -> groupInterfaceGetter(group, out),
+            (group) -> groupInterfaceGetter(parent, group, out),
             (component) -> componentInterfaceGetter(component, out));
     }
 
-    private void groupInterfaceGetter(final Group group, final Writer out) throws IOException
+    private void groupInterfaceGetter(final Aggregate parent, final Group group, final Writer out) throws IOException
     {
         groupClass(group, out);
+        generateGroupIterator(parent, out, group);
+
         final Entry numberField = group.numberField();
         out.append(fieldInterfaceGetter(numberField, (Field)numberField.element()));
 
@@ -549,7 +551,7 @@ public class DecoderGenerator extends Generator
     private void componentInterfaceGetter(final Component component, final Writer out)
         throws IOException
     {
-        wrappedForEachEntry(component, out, (entry) -> interfaceGetter(entry, out));
+        wrappedForEachEntry(component, out, (entry) -> interfaceGetter(component, entry, out));
     }
 
     private void wrappedForEachEntry(
@@ -680,6 +682,7 @@ public class DecoderGenerator extends Generator
         if (!(currentAggregate instanceof Component))
         {
             groupClass(group, out);
+            generateGroupIterator(currentAggregate, out, group);
         }
 
         final Entry numberField = group.numberField();
@@ -692,41 +695,53 @@ public class DecoderGenerator extends Generator
             "    {\n" +
             "        return %2$s;\n" +
             "    }\n\n" +
-            "%3$s",
+            "%3$s\n" +
+            "    private %4$s %5$s = new %4$s(this);\n" +
+            "    public %4$s %5$s()\n" +
+            "    {\n" +
+            "        return %5$s.iterator();\n" +
+            "    }\n\n",
             decoderClassName(group),
             formatPropertyName(group.name()),
-            prefix));
-
-        generateGroupIterator(out, group);
+            prefix,
+            iteratorClassName(group),
+            iteratorFieldName(group)));
     }
 
-    private void generateGroupIterator(final Writer out, final Group group) throws IOException
+    private void generateGroupIterator(final Aggregate parent, final Writer out, final Group group) throws IOException
     {
+        final String numberFieldName = group.numberField().name();
+        final String formattedNumberFieldName = formatPropertyName(numberFieldName);
+        final String numberFieldReset =
+            group.numberField().required() ?
+            String.format("parent.%1$s()", formattedNumberFieldName) :
+            String.format("parent.has%1$s() ? parent.%2$s() : 0", numberFieldName, formattedNumberFieldName);
+
         out.append(String.format(
-            "    private %1$s %2$s = new %1$s();\n\n" +
-            "    public %1$s %2$s()\n" +
+            "    public class %1$s implements Iterable<%2$s>, java.util.Iterator<%2$s>\n" +
             "    {\n" +
-            "        return %2$s.iterator();\n" +
-            "    }\n\n" +
-            "    public class %1$s implements Iterable<%4$s>, java.util.Iterator<%4$s>\n" +
-            "    {\n" +
+            "        private final %3$s parent;\n" +
             "        private int remainder;\n" +
-            "        private %4$s current;\n" +
+            "        private %2$s current;\n\n" +
+            "        public %1$s(final %3$s parent)\n" +
+            "        {\n\n" +
+            "            this.parent = parent;\n" +
+            "        }\n\n" +
             "        public boolean hasNext()\n" +
             "        {\n" +
             "            return remainder > 0;\n" +
             "        }\n" +
-            "        public %4$s next()\n" +
+            "        public %2$s next()\n" +
             "        {\n" +
             "            remainder--;\n" +
-            "            final %4$s value = current;\n" +
+            "            final %2$s value = current;\n" +
             "            current = current.next();\n" +
             "            return value;\n" +
             "        }\n" +
             "        public void reset()\n" +
             "        {\n" +
-            "            remainder = %3$s;\n" +
-            "            current = %5$s();\n" +
+            "            remainder = %4$s;\n" +
+            "            current = parent.%5$s();\n" +
             "        }\n" +
             "        public %1$s iterator()\n" +
             "        {\n" +
@@ -735,9 +750,9 @@ public class DecoderGenerator extends Generator
             "        }\n" +
             "    }\n\n",
             iteratorClassName(group),
-            iteratorFieldName(group),
-            formatPropertyName(group.numberField().name()),
             decoderClassName(group),
+            decoderClassName(parent),
+            numberFieldReset,
             formatPropertyName(group.name())));
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Aggregate.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Aggregate.java
@@ -52,14 +52,25 @@ public abstract class Aggregate
     /**
      * @return all entries including those of nested components
      */
-    public Stream<Entry> allChildEntries()
+    public Stream<Entry> allFieldsIncludingComponents()
     {
         return entries.stream()
             .flatMap(
                 (entry) -> entry.match(
                     (ele, field) -> Stream.of(ele),
                     (ele, group) -> Stream.empty(),
-                    (ele, component) -> component.allChildEntries()
+                    (ele, component) -> component.allFieldsIncludingComponents()
+                ));
+    }
+
+    public Stream<Entry> allComponents()
+    {
+        return entries.stream()
+            .flatMap(
+                (entry) -> entry.match(
+                    (e, field) -> Stream.empty(),
+                    (e, group) -> Stream.empty(),
+                    (e, component) -> Stream.concat(Stream.of(e), component.allComponents())
                 ));
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -63,6 +63,7 @@ public final class ExampleDictionary
     public static final String FIELDS_MESSAGE_DECODER = TEST_PACKAGE + "." + FIELDS_MESSAGE + "Decoder";
     public static final String HEADER_DECODER = TEST_PACKAGE + ".HeaderDecoder";
     public static final String COMPONENT_DECODER = TEST_PACKAGE + "." + EG_COMPONENT + "Decoder";
+    public static final String NESTED_COMPONENT_DECODER = TEST_PACKAGE + "." + EG_NESTED_COMPONENT + "Decoder";
     public static final String OTHER_MESSAGE_DECODER = TEST_PACKAGE + ".OtherMessageDecoder";
     public static final String OTHER_MESSAGE_ENCODER = TEST_PACKAGE + ".OtherMessageEncoder";
     public static final String ENUM_TEST_MESSAGE_DECODER = TEST_PACKAGE + ".EnumTestMessageDecoder";

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -41,7 +41,9 @@ public final class ExampleDictionary
     public static final String NO_SECOND_EG_GROUP = "NoSecondEgGroup";
     public static final String NO_ADMIN_EG_GROUP = "NoAdminEgGroup";
     public static final String NO_COMPONENT_GROUP = "NoComponentGroup";
+    public static final String NO_NESTED_COMPONENT_GROUP = "NoNestedComponentGroup";
     public static final String EG_COMPONENT = "EgComponent";
+    public static final String EG_NESTED_COMPONENT = "EgNestedComponent";
     public static final String FIELDS_MESSAGE = "FieldsMessage";
 
     public static final String EG_ENUM = PARENT_PACKAGE + "." + "EgEnum";
@@ -182,6 +184,9 @@ public final class ExampleDictionary
         "      \"ComponentGroupField\": \"2\",\n" +
         "    }\n" +
         "    ]\n" +
+        "    \"EgNestedComponent\":  {\n" +
+        "      \"MessageName\": \"EgNestedComponent\",\n" +
+        "    }\n" +
         "  }";
 
     public static final String ENCODED_MESSAGE =
@@ -355,6 +360,10 @@ public final class ExampleDictionary
         "8=FIX.4.4\0019=77\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
         "\001124=2\001130=2\001131=1\001131=2\00110=069\001";
 
+    public static final String NESTED_COMPONENT_MESSAGE =
+        "8=FIX.4.4\0019=77\00135=0\001115=abc\001116=2\001117=1.1\001127=19700101-00:00:00.001" +
+        "\001124=2\001130=2\001131=1\001131=2\001141=180\001142=2\001143=99\001143=100\00110=069\001";
+
     public static final String SHORT_TIMESTAMP_MESSAGE =
         "8=FIX.4.4\0019=49\00135=0\001115=abc\001116=2\001117=1.1" +
         "\001127=19700101-00:00:00\00110=113\001";
@@ -476,9 +485,18 @@ public final class ExampleDictionary
         final Group componentGroup = Group.of(registerField(messageEgFields, 130, NO_COMPONENT_GROUP, INT));
         componentGroup.optionalEntry(registerField(messageEgFields, 131, "ComponentGroupField", INT));
 
+        final Group nestedComponentGroup = Group.of(registerField(messageEgFields, 142,
+            NO_NESTED_COMPONENT_GROUP, INT));
+        nestedComponentGroup.optionalEntry(registerField(messageEgFields, 143, "NestedComponentGroupField", INT));
+
+        final Component nestedComponent = new Component(EG_NESTED_COMPONENT);
+        nestedComponent.optionalEntry(registerField(messageEgFields, 141, "NestedComponentField", INT));
+        nestedComponent.optionalEntry(nestedComponentGroup);
+
         final Component egComponent = new Component(EG_COMPONENT);
         egComponent.optionalEntry(registerField(messageEgFields, 124, "ComponentField", INT));
         egComponent.optionalEntry(componentGroup);
+        egComponent.optionalEntry(nestedComponent);
 
         final Group groupForAdmin = Group.of(registerField(messageEgFields, 139, NO_ADMIN_EG_GROUP, INT));
         groupForAdmin.optionalEntry(registerField(messageEgFields, 140, "AdminFirstGroupField", STRING));
@@ -541,6 +559,7 @@ public final class ExampleDictionary
         fieldsMessage.optionalEntry(registerField(messageEgFields, 1006, "OptionalCountryField", COUNTRY));
         fieldsMessage.optionalEntry(registerField(messageEgFields, 9001, "HighNumberField", INT));
         fieldsMessage.optionalEntry(groupForAdmin);
+        fieldsMessage.optionalEntry(nestedComponent);
 
         final Message enumTestMessage = new Message(ENUM_TEST_MESSAGE, ENUM_TEST_MESSAGE_TYPE, APP);
         enumTestMessage.optionalEntry(registerField(messageEgFields, 501, "CharEnumOpt", CHAR)
@@ -581,6 +600,7 @@ public final class ExampleDictionary
 
         final Map<String, Component> components = new HashMap<>();
         components.put(EG_COMPONENT, egComponent);
+        components.put(EG_NESTED_COMPONENT, nestedComponent);
 
         return new Dictionary(messages, messageEgFields, components, header, trailer, "FIX", 4, 4);
     }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
@@ -132,8 +132,7 @@ public class DecoderGeneratorTest
     @Test
     public void generatesGetters() throws NoSuchMethodException
     {
-        final Method onBehalfOfCompID = heartbeat.getMethod(ON_BEHALF_OF_COMP_ID);
-        assertEquals(char[].class, onBehalfOfCompID.getReturnType());
+        assertHasMethod(ON_BEHALF_OF_COMP_ID, char[].class, heartbeat);
     }
 
     @Test
@@ -509,6 +508,12 @@ public class DecoderGeneratorTest
 
         assertEquals(2, get(decoder, "componentField"));
         assertEquals(180, get(decoder, "nestedComponentField"));
+        assertEquals(2, get(decoder, "noNestedComponentGroupGroupCounter"));
+        assertNotNull(get(decoder, "nestedComponentGroupGroupIterator"));
+        final Class<?> nestedComponent = heartbeat.getClassLoader().loadClass(NESTED_COMPONENT_DECODER);
+
+        assertHasMethod("nestedComponentField", int.class, nestedComponent);
+        assertHasMethod("noNestedComponentGroupGroupCounter", int.class, nestedComponent);
 
         assertValid(decoder);
     }
@@ -1433,16 +1438,17 @@ public class DecoderGeneratorTest
 
     private void assertHasComponentFieldGetter() throws NoSuchMethodException, ClassNotFoundException
     {
-        assertHasMethod("componentField", int.class);
-        assertHasMethod(HAS_COMPONENT_FIELD, boolean.class);
+        assertHasMethod("componentField", int.class, component);
+        assertHasMethod(HAS_COMPONENT_FIELD, boolean.class, component);
 
         final Class<?> clazz = heartbeat.getClassLoader().loadClass(
             "uk.co.real_logic.artio.builder.test.EgComponentDecoder$ComponentGroupGroupDecoder");
 
-        assertHasMethod("componentGroupGroup", clazz);
+        assertHasMethod("componentGroupGroup", clazz, component);
     }
 
-    private void assertHasMethod(final String name, final Class<?> expectedReturnType) throws NoSuchMethodException
+    private void assertHasMethod(final String name, final Class<?> expectedReturnType, final Class<?> component)
+        throws NoSuchMethodException
     {
         final Method method = component.getMethod(name);
         assertEquals(expectedReturnType, method.getReturnType());

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorTest.java
@@ -503,6 +503,17 @@ public class DecoderGeneratorTest
     }
 
     @Test
+    public void shouldDecodeNestedComponentsWithRepeatingGroups() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(NESTED_COMPONENT_MESSAGE);
+
+        assertEquals(2, get(decoder, "componentField"));
+        assertEquals(180, get(decoder, "nestedComponentField"));
+
+        assertValid(decoder);
+    }
+
+    @Test
     public void shouldGenerateComponentToString() throws Exception
     {
         final Decoder decoder = decodeHeartbeat(COMPONENT_MESSAGE);


### PR DESCRIPTION
This is a follow up to a pull request made before.

The aim of this change is to move the implementation of repeating group iterators, and provide a method for accessing them, onto the interface of any Component they belong to. Previously, if a repeating group belong to a component then the decoder for that group would move to the generated interface but the iterator would stay in the implementations for said interface. This made code re-use more difficult.

This change involves altering how the Component interfaces are generated. Before all fields for that component (and any fields for nested Components) would be put onto the top level Component's interface; this could no longer be supported due to how Iterators are instantiated (plus it doesn't really make sense exposing fields on aggregates that do not own said fields). Instead, a Component interface will now extend the interface of any nested Components in the same way that an Aggregate with a Component implements the interface for that Component.

This change passes the `fix-integration` tests and is running as a fork in our system