### PR TITLE
[Tom] Fix infinite loop  when decoding malformed FIX messages.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -1003,6 +1003,7 @@ public class DecoderGenerator extends Generator
             endGroupCheck +
             "            final int valueOffset = equalsPosition + 1;\n" +
             "            final int endOfField = buffer.scan(valueOffset, end, START_OF_HEADER);\n" +
+            malformedMessageCheck() +
             "            final int valueLength = endOfField - valueOffset;\n" +
             "            if (" + CODEC_VALIDATION_ENABLED + ")\n" +
             "            {\n" +
@@ -1070,6 +1071,16 @@ public class DecoderGenerator extends Generator
             "    }\n\n";
 
         return prefix + body + suffix;
+    }
+
+    private String malformedMessageCheck()
+    {
+        return "            if (endOfField == AsciiBuffer.UNKNOWN_INDEX || " +
+               "equalsPosition == AsciiBuffer.UNKNOWN_INDEX)\n" +
+               "            {\n" +
+               "                rejectReason = " + VALUE_IS_INCORRECT + ";\n" +
+               "                break;\n" +
+               "            }\n";
     }
 
     private String decodeTrailerOrReturn(final boolean hasCommonCompounds, final int indent)


### PR DESCRIPTION
If a decoder receives a malformed FIX message (not complete tag / value
combo or missing pipes) then the decoders will get stuck in an infinite
loop trying to find the whole message.

This scenario does not occur if using the whole artio library due to
how message delimitation works in the TCP layer but is problem for anyone
just using the artio-codecs library.

All fix Integration tests passed.