### PR TITLE
[Tom] Don't set DecimalFloat reference when encoding.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -586,11 +586,11 @@ public class EncoderGenerator extends Generator
         final String enumSetter)
     {
         return String.format(
-            "    private DecimalFloat %1$s = new DecimalFloat();\n\n" +
+            "    private final DecimalFloat %1$s = new DecimalFloat();\n\n" +
             "%2$s" +
             "    public %3$s %1$s(DecimalFloat value)\n" +
             "    {\n" +
-            "        %1$s = value;\n" +
+            "        %1$s.set(value);\n" +
             "%4$s" +
             "        return this;\n" +
             "    }\n\n" +

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -282,6 +282,22 @@ public class EncoderGeneratorTest
     }
 
     @Test
+    public void encodeDecimalFloatWithoutAlteringSentinelValue() throws Exception
+    {
+        //Given
+        final Encoder encoder = newHeartbeat();
+        final DecimalFloat zero = DecimalFloat.ZERO;
+
+        setFloat(encoder, FLOAT_FIELD, zero);
+
+        //When
+        setFloatFieldRawValues(encoder);
+
+        //Then
+        assertThat(zero, is(new DecimalFloat()));
+    }
+
+    @Test
     public void ignoresMissingOptionalValues() throws Exception
     {
         final Encoder encoder = newHeartbeat();


### PR DESCRIPTION
If a DecimalFloat object is passed in when encoding a decimal field, use DecimalFloat::set internally rather than changing the reference of the field.

Using a reference *can* cause an issue in the following scenario:

encoder.avgPx(DecimalFloat.ZERO);
encoder.avgPx(1, 3);

In this case, DecimalFloat.ZERO has been changed to no longer be zero