### PR TITLE
outboundPublication in the FramerContext may not have anything to record

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixArchiveScanner.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixArchiveScanner.java
@@ -135,18 +135,21 @@ public class FixArchiveScanner implements AutoCloseable
                     length = stopPosition - archiveLocation.startPosition;
                 }
 
-                final int sessionId = (int)aeronArchive.startReplay(
-                    recordingId,
-                    archiveLocation.startPosition,
-                    length,
-                    IPC_CHANNEL,
-                    archiveScannerStreamId);
-
-                final Image image = lookupImage(replaySubscription, sessionId);
-
-                while (stopPosition == NULL_POSITION || image.position() < stopPosition)
+                if (length != 0)
                 {
-                    idleStrategy.idle(image.poll(fragmentAssembler, 10));
+                    final int sessionId = (int)aeronArchive.startReplay(
+                        recordingId,
+                        archiveLocation.startPosition,
+                        length,
+                        IPC_CHANNEL,
+                        archiveScannerStreamId);
+
+                    final Image image = lookupImage(replaySubscription, sessionId);
+
+                    while (stopPosition == NULL_POSITION || image.position() < stopPosition)
+                    {
+                        idleStrategy.idle(image.poll(fragmentAssembler, 10));
+                    }
                 }
             });
         }


### PR DESCRIPTION
"outboundPublication" in the FramerContext may not have anything to record.

This will cause below exception

io.aeron.archive.client.ArchiveException: response for correlationId=14, error: requested replay start position 0 must be less than highest recorded position 0 for recording 2

at io.aeron.archive.client.AeronArchive.pollForResponse(AeronArchive.java:1097)
	at io.aeron.archive.client.AeronArchive.startReplay(AeronArchive.java:647)
	at uk.co.real_logic.artio.engine.logger.FixArchiveScanner.lambda$scan$0(FixArchiveScanner.java:138)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at uk.co.real_logic.artio.engine.logger.FixArchiveScanner.scan(FixArchiveScanner.java:112)