### PR TITLE
Checksum is wrong for the IndexedPositionWriter in the SequenceNumberIndexWriter

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/ChecksumFramer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/ChecksumFramer.java
@@ -70,11 +70,12 @@ public class ChecksumFramer extends SectorFramer
     {
         final byte[] inMemoryBytes = buffer.byteArray();
         final ByteBuffer inMemoryByteBuffer = buffer.byteBuffer();
+        final int wrapAdjustment = buffer.wrapAdjustment();
         final int capacity = this.capacity;
 
         for (int sectorEnd = SECTOR_SIZE; sectorEnd <= capacity; sectorEnd += SECTOR_SIZE)
         {
-            final int sectorStart = sectorEnd - SECTOR_SIZE;
+            final int sectorStart = sectorEnd - SECTOR_SIZE + wrapAdjustment;
             final int checksumOffset = sectorEnd - CHECKSUM_SIZE;
 
             crc32.reset();


### PR DESCRIPTION
SequenceNumberIndexWriter only pass a slice of the underlying buffer to IndexedPositionWriter.

https://github.com/real-logic/artio/blob/585043becbad5372346c4ea59d79c525cce40655/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/SequenceNumberIndexWriter.java#L109

This will cause the checksum is wrong for the "Positions Table" segment.