### PR TITLE
output windows line endings when generating code on windows

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
@@ -92,8 +92,7 @@ public class AcceptorGenerator
         acceptorOutput.append(String.format(
             "    void on%1$s(final %2$s decoder);%n%n",
             message.name(),
-            decoderClassName(message)
-        ));
+            decoderClassName(message)));
     }
 
     private void generateDefaultAcceptorCallback(final Writer acceptorOutput, final Message message) throws IOException
@@ -102,8 +101,7 @@ public class AcceptorGenerator
             "    @Override%n" +
             "    public void on%1$s(final %2$s decoder) {};%n%n",
             message.name(),
-            decoderClassName(message)
-        ));
+            decoderClassName(message)));
     }
 
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
@@ -90,7 +90,7 @@ public class AcceptorGenerator
     private void generateAcceptorCallback(final Writer acceptorOutput, final Message message) throws IOException
     {
         acceptorOutput.append(String.format(
-            "    void on%1$s(final %2$s decoder);\n\n",
+            "    void on%1$s(final %2$s decoder);%n%n",
             message.name(),
             decoderClassName(message)
         ));
@@ -99,8 +99,8 @@ public class AcceptorGenerator
     private void generateDefaultAcceptorCallback(final Writer acceptorOutput, final Message message) throws IOException
     {
         acceptorOutput.append(String.format(
-            "    @Override\n" +
-            "    public void on%1$s(final %2$s decoder) {};\n\n",
+            "    @Override%n" +
+            "    public void on%1$s(final %2$s decoder) {};%n%n",
             message.name(),
             decoderClassName(message)
         ));
@@ -109,33 +109,31 @@ public class AcceptorGenerator
 
     private void generateAcceptorSuffix(final Writer acceptorOutput) throws IOException
     {
-        acceptorOutput.append("\n}\n");
+        acceptorOutput.append(String.format("%n}%n"));
     }
 
     private void generateDefaultAcceptorSuffix(final Writer acceptorOutput) throws IOException
     {
-        acceptorOutput.append("\n}\n");
+        acceptorOutput.append(String.format("%n}%n"));
     }
 
 
     private void generateAcceptorClass(final Writer acceptorOutput) throws IOException
     {
         acceptorOutput.append(fileHeader(packageName));
-        acceptorOutput.append(
-            "\n" +
-            "public interface " + DICTIONARY_ACCEPTOR + "\n" +
-            "{\n"
-        );
+        acceptorOutput.append(String.format(
+            "%n" +
+            "public interface " + DICTIONARY_ACCEPTOR + "%n" +
+            "{%n"));
     }
 
     private void generateDefaultAcceptorClass(final Writer acceptorOutput) throws IOException
     {
         acceptorOutput.append(fileHeader(packageName));
-        acceptorOutput.append(
-            "\n" +
-            "public class " + DEFAULT_DICTIONARY_ACCEPTOR + " implements " + DICTIONARY_ACCEPTOR + "\n" +
-            "{\n"
-        );
+        acceptorOutput.append(String.format(
+            "%n" +
+            "public class " + DEFAULT_DICTIONARY_ACCEPTOR + " implements " + DICTIONARY_ACCEPTOR + "%n" +
+            "{%n"));
     }
 
 
@@ -163,39 +161,41 @@ public class AcceptorGenerator
 
     private void generateDecoderSuffix(final Writer decoderOutput) throws IOException
     {
-        decoderOutput.append(
-            "        }\n" +
-            "    }\n\n");
+        decoderOutput.append(String.format(
+            "        }%n" +
+            "    }%n%n"
+        ));
 
-        decoderOutput.append("}\n");
+        decoderOutput.append(String.format("}%n"));
     }
 
     private void generateDecoderOnMessage(final Writer decoderOutput) throws IOException
     {
-        decoderOutput.append(
-            "\n" +
-            "    public " + DICTIONARY_DECODER + "(final " + DICTIONARY_ACCEPTOR + " acceptor)\n" +
-            "    {\n" +
-            "        this.acceptor = acceptor;\n" +
-            "    }\n\n" +
-            "    public void " + ON_MESSAGE + "(\n" +
-            "        final AsciiBuffer buffer,\n" +
-            "        final int offset,\n" +
-            "        final int length,\n" +
-            "        final int messageType)\n" +
-            "    {\n" +
-            "        switch(messageType)\n" +
-            "        {\n\n");
+        decoderOutput.append(String.format(
+            "%n" +
+            "    public " + DICTIONARY_DECODER + "(final " + DICTIONARY_ACCEPTOR + " acceptor)%n" +
+            "    {%n" +
+            "        this.acceptor = acceptor;%n" +
+            "    }%n%n" +
+            "    public void " + ON_MESSAGE + "(%n" +
+            "        final AsciiBuffer buffer,%n" +
+            "        final int offset,%n" +
+            "        final int length,%n" +
+            "        final int messageType)%n" +
+            "    {%n" +
+            "        switch(messageType)%n" +
+            "        {%n%n"
+        ));
     }
 
     private void generateDecoderCase(final Writer decoderOutput, final Message message) throws IOException
     {
         decoderOutput.append(String.format(
-            "        case %1$s.MESSAGE_TYPE:\n" +
-            "            %2$s.decode(buffer, offset, length);\n" +
-            "            acceptor.on%3$s(%2$s);\n" +
-            "            %2$s.reset();\n" +
-            "            break;\n\n",
+            "        case %1$s.MESSAGE_TYPE:%n" +
+            "            %2$s.decode(buffer, offset, length);%n" +
+            "            acceptor.on%3$s(%2$s);%n" +
+            "            %2$s.reset();%n" +
+            "            break;%n%n",
             decoderClassName(message),
             formatPropertyName(message.name()),
             message.name()
@@ -205,7 +205,7 @@ public class AcceptorGenerator
     private void generateDecoderField(final Writer decoderOutput, final Message message) throws IOException
     {
         decoderOutput.append(String.format(
-            "    private final %1$s %2$s = new %1$s();\n",
+            "    private final %1$s %2$s = new %1$s();%n",
             decoderClassName(message),
             formatPropertyName(message.name())
         ));
@@ -215,11 +215,12 @@ public class AcceptorGenerator
     {
         decoderOutput.append(fileHeader(packageName));
         decoderOutput.append(importFor(AsciiBuffer.class));
-        decoderOutput.append(
-            "\n" +
-            "public final class " + DICTIONARY_DECODER + "\n" +
-            "{\n\n" +
-            "    private final " + DICTIONARY_ACCEPTOR + " acceptor;\n\n");
+        decoderOutput.append(String.format(
+            "%n" +
+            "public final class " + DICTIONARY_DECODER + "%n" +
+            "{%n%n" +
+            "    private final " + DICTIONARY_ACCEPTOR + " acceptor;%n%n"
+        ));
     }
 
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/ConstantGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/ConstantGenerator.java
@@ -32,7 +32,7 @@ public class ConstantGenerator
 {
     static final String CLASS_NAME = "Constants";
 
-    private static final String BODY = "public class " + CLASS_NAME + "\n" + "{\n\n";
+    private static final String BODY = String.format("public class " + CLASS_NAME + "%n" + "{%n%n");
     static final String VERSION = "VERSION";
 
     private final Dictionary dictionary;
@@ -59,7 +59,7 @@ public class ConstantGenerator
             out.append(generateMessageTypes());
             out.append(generateFieldTags());
             out.append(generateAllFieldsDictionary());
-            out.append("}\n");
+            out.append(String.format("}%n"));
         });
     }
 
@@ -77,11 +77,11 @@ public class ConstantGenerator
 
         final int hashMapSize = sizeHashSet(fields);
         return String.format(
-            "    public static final IntHashSet %3$s = new IntHashSet(%1$d);\n" +
-            "    static\n" +
-            "    {\n" +
+            "    public static final IntHashSet %3$s = new IntHashSet(%1$d);%n" +
+            "    static%n" +
+            "    {%n" +
             "%2$s" +
-            "    }\n\n",
+            "    }%n%n",
             hashMapSize,
             addFields,
             name);
@@ -90,8 +90,8 @@ public class ConstantGenerator
     private String generateVersion()
     {
         return String.format(
-            "    public static String VERSION = \"%s.%d.%d\";\n" +
-            "    public static char[] VERSION_CHARS = VERSION.toCharArray();\n\n",
+            "    public static String VERSION = \"%s.%d.%d\";%n" +
+            "    public static char[] VERSION_CHARS = VERSION.toCharArray();%n%n",
             dictionary.specType(),
             dictionary.majorVersion(),
             dictionary.minorVersion());
@@ -145,7 +145,7 @@ public class ConstantGenerator
         }
 
         return String.format(
-            "    public static final String %1$s = \"%2$s\";\n",
+            "    public static final String %1$s = \"%2$s\";%n",
             stringConstantName,
             new String(chars));
     }
@@ -153,7 +153,7 @@ public class ConstantGenerator
     private String generateIntConstant(final String name, final int number)
     {
         return String.format(
-            "    public static final int %1$s = %2$d;\n\n",
+            "    public static final int %1$s = %2$d;%n%n",
             name,
             number);
     }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -44,105 +44,106 @@ import static uk.co.real_logic.artio.dictionary.generation.AggregateType.GROUP;
 import static uk.co.real_logic.artio.dictionary.generation.AggregateType.HEADER;
 import static uk.co.real_logic.artio.dictionary.generation.EnumGenerator.hasEnumGenerated;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.NEWLINE;
 import static uk.co.real_logic.artio.util.MutableAsciiBuffer.LONGEST_INT_LENGTH;
 import static uk.co.real_logic.sbe.generation.java.JavaUtil.formatClassName;
 import static uk.co.real_logic.sbe.generation.java.JavaUtil.formatPropertyName;
 
 public class EncoderGenerator extends Generator
 {
-    private static final String SUFFIX =
-        "        buffer.putSeparator(position);\n" +
-        "        position++;\n" +
-        "%s";
+    private static final String SUFFIX = String.format(
+        "        buffer.putSeparator(position);%n" +
+        "        position++;%n" +
+        "%%s");
 
-    private static final String TRAILER_ENCODE_PREFIX =
-        "    // |10=...|\n" +
-        "    long finishMessage(final MutableAsciiBuffer buffer, final int messageStart, final int offset)\n" +
-        "    {\n" +
-        "        int position = offset;\n" +
-        "\n" +
-        "        final int checkSum = buffer.computeChecksum(messageStart, position);\n" +
-        "        buffer.putBytes(position, checkSumHeader, 0, checkSumHeaderLength);\n" +
-        "        position += checkSumHeaderLength;\n" +
-        "        buffer.putNaturalPaddedIntAscii(position, 3, checkSum);\n" +
-        "        position += 3;\n" +
-        "        buffer.putSeparator(position);\n" +
-        "        position++;\n" +
-        "\n" +
-        "        return Encoder.result(position - messageStart, messageStart);\n" +
+    private static final String TRAILER_ENCODE_PREFIX = String.format(
+        "    // |10=...|%n" +
+        "    long finishMessage(final MutableAsciiBuffer buffer, final int messageStart, final int offset)%n" +
+        "    {%n" +
+        "        int position = offset;%n" +
+        "%n" +
+        "        final int checkSum = buffer.computeChecksum(messageStart, position);%n" +
+        "        buffer.putBytes(position, checkSumHeader, 0, checkSumHeaderLength);%n" +
+        "        position += checkSumHeaderLength;%n" +
+        "        buffer.putNaturalPaddedIntAscii(position, 3, checkSum);%n" +
+        "        position += 3;%n" +
+        "        buffer.putSeparator(position);%n" +
+        "        position++;%n" +
+        "%n" +
+        "        return Encoder.result(position - messageStart, messageStart);%n" +
         "    }" +
-        "\n" +
-        "    // Optional trailer fields\n" +
-        "    int startTrailer(final MutableAsciiBuffer buffer, final int offset)\n" +
-        "    {\n" +
-        "        final int start = offset;\n" +
-        "        int position = start;\n" +
-        "\n";
+        "%n" +
+        "    // Optional trailer fields%n" +
+        "    int startTrailer(final MutableAsciiBuffer buffer, final int offset)%n" +
+        "    {%n" +
+        "        final int start = offset;%n" +
+        "        int position = start;%n" +
+        "%n");
 
     // returns offset where message starts
-    private static final String HEADER_ENCODE_PREFIX =
-        "    // 8=...|9=...|\n" +
-        "    int finishHeader(final MutableAsciiBuffer buffer, final int bodyStart, final int bodyLength)\n" +
-        "    {\n" +
-        "        int position = bodyStart - 1;\n" +
-        "\n" +
-        "        buffer.putSeparator(position);\n" +
-        "        position = buffer.putNaturalIntAsciiFromEnd(bodyLength, position);\n" +
-        "        position -= bodyLengthHeaderLength;\n" +
-        "        buffer.putBytes(position, bodyLengthHeader, 0, bodyLengthHeaderLength);\n" +
-        "\n" +
-        "        if (beginStringLength > 0) {\n" +
-        "        position--;\n" +
-        "        buffer.putSeparator(position);\n" +
-        "        position -= beginStringLength;\n" +
-        "        buffer.putBytes(position, beginString, beginStringOffset, beginStringLength);\n" +
-        "        position -= beginStringHeaderLength;\n" +
-        "        buffer.putBytes(position, beginStringHeader, 0, beginStringHeaderLength);\n" +
-        "        } else if (" + CODEC_VALIDATION_ENABLED + ")\n" +
-        "        {\n" +
-        "            throw new EncodingException(\"Missing Field: BeginString\");\n" +
-        "        }\n" +
-        "\n" +
-        "        return position;\n" +
-        "    }\n" +
-        "\n" +
-        "    // 35=...| + other header fields\n" +
-        "    public long startMessage(final MutableAsciiBuffer buffer, final int offset)\n" +
-        "    {\n" +
-        "        final int start = offset + beginStringLength + 16;\n" +
-        "        int position = start;";
+    private static final String HEADER_ENCODE_PREFIX = String.format(
+        "    // 8=...|9=...|%n" +
+        "    int finishHeader(final MutableAsciiBuffer buffer, final int bodyStart, final int bodyLength)%n" +
+        "    {%n" +
+        "        int position = bodyStart - 1;%n" +
+        "%n" +
+        "        buffer.putSeparator(position);%n" +
+        "        position = buffer.putNaturalIntAsciiFromEnd(bodyLength, position);%n" +
+        "        position -= bodyLengthHeaderLength;%n" +
+        "        buffer.putBytes(position, bodyLengthHeader, 0, bodyLengthHeaderLength);%n" +
+        "%n" +
+        "        if (beginStringLength > 0) {%n" +
+        "        position--;%n" +
+        "        buffer.putSeparator(position);%n" +
+        "        position -= beginStringLength;%n" +
+        "        buffer.putBytes(position, beginString, beginStringOffset, beginStringLength);%n" +
+        "        position -= beginStringHeaderLength;%n" +
+        "        buffer.putBytes(position, beginStringHeader, 0, beginStringHeaderLength);%n" +
+        "        } else if (" + CODEC_VALIDATION_ENABLED + ")%n" +
+        "        {%n" +
+        "            throw new EncodingException(\"Missing Field: BeginString\");%n" +
+        "        }%n" +
+        "%n" +
+        "        return position;%n" +
+        "    }%n" +
+        "%n" +
+        "    // 35=...| + other header fields%n" +
+        "    public long startMessage(final MutableAsciiBuffer buffer, final int offset)%n" +
+        "    {%n" +
+        "        final int start = offset + beginStringLength + 16;%n" +
+        "        int position = start;");
 
-    private static final String GROUP_ENCODE_PREFIX =
-        "    public int encode(final MutableAsciiBuffer buffer, final int offset, final int remainingElements)\n" +
-        "    {\n" +
-        "        if (remainingElements == 0)\n" +
-        "        {\n" +
-        "            return 0;\n" +
-        "        }\n\n" +
-        "        int position = offset;\n\n";
+    private static final String GROUP_ENCODE_PREFIX = String.format(
+        "    public int encode(final MutableAsciiBuffer buffer, final int offset, final int remainingElements)%n" +
+        "    {%n" +
+        "        if (remainingElements == 0)%n" +
+        "        {%n" +
+        "            return 0;%n" +
+        "        }%n%n" +
+        "        int position = offset;%n%n");
 
     // returns (offset, length) as long
-    private static final String MESSAGE_ENCODE_PREFIX =
-        "    public long encode(final MutableAsciiBuffer buffer, final int offset)\n" +
-        "    {\n" +
-        "        final long startMessageResult = header.startMessage(buffer, offset);\n" +
-        "        final int bodyStart = Encoder.offset(startMessageResult);\n" +
-        "        int position = bodyStart + Encoder.length(startMessageResult);\n" +
-        "\n";
+    private static final String MESSAGE_ENCODE_PREFIX = String.format(
+        "    public long encode(final MutableAsciiBuffer buffer, final int offset)%n" +
+        "    {%n" +
+        "        final long startMessageResult = header.startMessage(buffer, offset);%n" +
+        "        final int bodyStart = Encoder.offset(startMessageResult);%n" +
+        "        int position = bodyStart + Encoder.length(startMessageResult);%n" +
+        "%n");
 
     // returns length as int
-    private static final String OTHER_ENCODE_PREFIX =
-        "    public int encode(final MutableAsciiBuffer buffer, final int offset)\n" +
-        "    {\n" +
-        "        int position = offset;\n\n";
+    private static final String OTHER_ENCODE_PREFIX = String.format(
+        "    public int encode(final MutableAsciiBuffer buffer, final int offset)%n" +
+        "    {%n" +
+        "        int position = offset;%n%n");
 
-    private static final String RESET_NEXT_GROUP =
+    private static final String RESET_NEXT_GROUP = String.format(
         "        if (next != null)" +
-        "        {\n" +
-        "            next.reset();\n" +
-        "        }\n";
+        "        {%n" +
+        "            next.reset();%n" +
+        "        }%n");
 
-    public static final String METHOD_DELIMITER = "\n\n";
+    public static final String METHOD_DELIMITER = String.format("%n%n");
 
     private static String encoderClassName(final String name)
     {
@@ -213,15 +214,15 @@ public class EncoderGenerator extends Generator
         final String name = group.name();
         final Entry numberField = group.numberField();
         return String.format(
-                "    public void %1$s()\n" +
-                "    {\n" +
-                "        if (%2$s != null)\n" +
-                "        {\n" +
-                "            %2$s.reset();\n" +
-                "        }\n" +
-                "        %3$s = 0;\n" +
-                "        has%4$s = false;\n" +
-                "    }\n\n",
+                "    public void %1$s()%n" +
+                "    {%n" +
+                "        if (%2$s != null)%n" +
+                "        {%n" +
+                "            %2$s.reset();%n" +
+                "        }%n" +
+                "        %3$s = 0;%n" +
+                "        has%4$s = false;%n" +
+                "    }%n%n",
                 nameOfResetMethod(name),
                 formatPropertyName(name),
                 formatPropertyName(numberField.name()),
@@ -263,9 +264,9 @@ public class EncoderGenerator extends Generator
         else if (type == HEADER)
         {
             out.append(
-                String.format("\n" +
+                String.format("%n" +
                 "    private static final byte[] DEFAULT_BEGIN_STRING=\"%s\".getBytes(StandardCharsets.US_ASCII);" +
-                "\n\n",
+                "%n%n",
                 beginString));
 
         }
@@ -275,7 +276,7 @@ public class EncoderGenerator extends Generator
         out.append(encodeMethod(aggregate.entries(), type));
         out.append(completeResetMethod(aggregate, isMessage, type));
         out.append(toString(aggregate, isMessage));
-        out.append("}\n");
+        out.append(String.format("}%n"));
     }
 
     private String completeResetMethod(
@@ -288,7 +289,7 @@ public class EncoderGenerator extends Generator
                 additionalReset = RESET_NEXT_GROUP;
                 break;
             case HEADER:
-                additionalReset = "        beginString(DEFAULT_BEGIN_STRING);\n";
+                additionalReset = String.format("        beginString(DEFAULT_BEGIN_STRING);%n");
                 break;
             default:
                 additionalReset = "";
@@ -305,15 +306,15 @@ public class EncoderGenerator extends Generator
     private String nextMethod(final Group group)
     {
         return String.format(
-            "    private %1$s next = null;\n\n" +
-            "    public %1$s next()\n" +
-            "    {\n" +
-            "        if (next == null)\n" +
-            "        {\n" +
-            "            next = new %1$s();\n" +
-            "        }\n" +
-            "        return next;\n" +
-            "    }\n\n",
+            "    private %1$s next = null;%n%n" +
+            "    public %1$s next()%n" +
+            "    {%n" +
+            "        if (next == null)%n" +
+            "        {%n" +
+            "            next = new %1$s();%n" +
+            "        }%n" +
+            "        return next;%n" +
+            "    }%n%n",
             encoderClassName(group.name())
         );
     }
@@ -327,17 +328,17 @@ public class EncoderGenerator extends Generator
             final int packedType = message.packedType();
             final String fullType = message.fullType();
             final String msgType = header.hasField(MSG_TYPE) ?
-                String.format("        header.msgType(\"%s\");\n", fullType) : "";
+                String.format("        header.msgType(\"%s\");%n", fullType) : "";
 
             return String.format(
-                "    public int messageType()\n" +
-                "    {\n" +
-                "        return %s;\n" +
-                "    }\n\n" +
-                "    public %sEncoder()\n" +
-                "    {\n" +
+                "    public int messageType()%n" +
+                "    {%n" +
+                "        return %s;%n" +
+                "    }%n%n" +
+                "    public %sEncoder()%n" +
+                "    {%n" +
                 "%s" +
-                "    }\n\n",
+                "    }%n%n",
                 packedType,
                 aggregate.name(),
                 msgType);
@@ -345,10 +346,10 @@ public class EncoderGenerator extends Generator
         else if (type == AggregateType.HEADER)
         {
             return String.format(
-                "    public %sEncoder()\n" +
-                "    {\n" +
-                "        beginString(DEFAULT_BEGIN_STRING);\n" +
-                "    }\n\n",
+                "    public %sEncoder()%n" +
+                "    {%n" +
+                "        beginString(DEFAULT_BEGIN_STRING);%n" +
+                "    }%n%n",
                 aggregate.name());
         }
         else
@@ -382,9 +383,9 @@ public class EncoderGenerator extends Generator
         final String name = field.name();
         final String fieldName = formatPropertyName(name);
         final String hasField =
-            String.format("    private boolean has%1$s;\n\n", name) + hasGetter(name);
+            String.format("    private boolean has%1$s;%n%n", name) + hasGetter(name);
 
-        final String hasAssign = String.format("        has%s = true;\n", name);
+        final String hasAssign = String.format("        has%s = true;%n", name);
 
         final String enumSetter = hasEnumGenerated(field) && !field.type().isMultiValue() ?
             enumSetter(className, fieldName, field.name()) : "";
@@ -450,18 +451,18 @@ public class EncoderGenerator extends Generator
         setter(className, numberField, out);
 
         out.append(String.format(
-            "\n" +
-            "    private %1$s %2$s = null;\n\n" +
-            "    public %1$s %2$s(final int numberOfElements)\n" +
-            "    {\n" +
-            "        has%3$s = true;\n" +
-            "        %4$s = numberOfElements;\n" +
-            "        if (%2$s == null)\n" +
-            "        {\n" +
-            "            %2$s = new %1$s();\n" +
-            "        }\n" +
-            "        return %2$s;\n" +
-            "    }\n\n",
+            "%n" +
+            "    private %1$s %2$s = null;%n%n" +
+            "    public %1$s %2$s(final int numberOfElements)%n" +
+            "    {%n" +
+            "        has%3$s = true;%n" +
+            "        %4$s = numberOfElements;%n" +
+            "        if (%2$s == null)%n" +
+            "        {%n" +
+            "            %2$s = new %1$s();%n" +
+            "        }%n" +
+            "        return %2$s;%n" +
+            "    }%n%n",
             encoderClassName(group.name()),
             formatPropertyName(group.name()),
             numberField.name(),
@@ -471,35 +472,35 @@ public class EncoderGenerator extends Generator
     private String generateByteArraySetter(final String className, final String fieldName, final String name)
     {
         return String.format(
-            "    private byte[] %1$s = new byte[%3$d];\n\n" +
-            "    private int %1$sOffset = 0;\n\n" +
-            "    private int %1$sLength = 0;\n\n" +
-            "    public %2$s %1$s(final byte[] value, final int length)\n" +
-            "    {\n" +
-            "        %1$s = value;\n" +
-            "        %1$sOffset = 0;\n" +
-            "        %1$sLength = length;\n" +
-            "        return this;\n" +
-            "    }\n\n" +
-            "    public %2$s %1$s(final byte[] value, final int offset, final int length)\n" +
-            "    {\n" +
-            "        %1$s = value;\n" +
-            "        %1$sOffset = offset;\n" +
-            "        %1$sLength = length;\n" +
-            "        return this;\n" +
-            "    }\n\n" +
-            "    public %2$s %1$s(final byte[] value)\n" +
-            "    {\n" +
-            "        return %1$s(value, value.length);\n" +
-            "    }\n\n" +
-            "    public boolean has%4$s()\n" +
-            "    {\n" +
-            "        return %1$sLength > 0;\n" +
-            "    }\n\n" +
-            "    public byte[] %1$s()\n" +
-            "    {\n" +
-            "        return %1$s;\n" +
-            "    }\n\n",
+            "    private byte[] %1$s = new byte[%3$d];%n%n" +
+            "    private int %1$sOffset = 0;%n%n" +
+            "    private int %1$sLength = 0;%n%n" +
+            "    public %2$s %1$s(final byte[] value, final int length)%n" +
+            "    {%n" +
+            "        %1$s = value;%n" +
+            "        %1$sOffset = 0;%n" +
+            "        %1$sLength = length;%n" +
+            "        return this;%n" +
+            "    }%n%n" +
+            "    public %2$s %1$s(final byte[] value, final int offset, final int length)%n" +
+            "    {%n" +
+            "        %1$s = value;%n" +
+            "        %1$sOffset = offset;%n" +
+            "        %1$sLength = length;%n" +
+            "        return this;%n" +
+            "    }%n%n" +
+            "    public %2$s %1$s(final byte[] value)%n" +
+            "    {%n" +
+            "        return %1$s(value, value.length);%n" +
+            "    }%n%n" +
+            "    public boolean has%4$s()%n" +
+            "    {%n" +
+            "        return %1$sLength > 0;%n" +
+            "    }%n%n" +
+            "    public byte[] %1$s()%n" +
+            "    {%n" +
+            "        return %1$s;%n" +
+            "    }%n%n",
             fieldName,
             className,
             initialArraySize,
@@ -514,31 +515,31 @@ public class EncoderGenerator extends Generator
     {
         return String.format(
             "%2$s" +
-            "    public %3$s %1$s(final CharSequence value)\n" +
-            "    {\n" +
-            "        %1$s = toBytes(value, %1$s);\n" +
-            "        %1$sOffset = 0;\n" +
-            "        %1$sLength = value.length();\n" +
-            "        return this;\n" +
-            "    }\n\n" +
-            "    public %3$s %1$s(final char[] value)\n" +
-            "    {\n" +
-            "        return %1$s(value, value.length);\n" +
-            "    }\n\n" +
-            "    public %3$s %1$s(final char[] value, final int length)\n" +
-            "    {\n" +
-            "        %1$s = toBytes(value, %1$s, length);\n" +
-            "        %1$sOffset = 0;\n" +
-            "        %1$sLength = length;\n" +
-            "        return this;\n" +
-            "    }\n\n" +
-            "    public %3$s %1$s(final char[] value, final int offset, final int length)\n" +
-            "    {\n" +
-            "        %1$s = toBytes(value, %1$s, offset, length);\n" +
-            "        %1$sOffset = 0;\n" +
-            "        %1$sLength = length;\n" +
-            "        return this;\n" +
-            "    }\n\n" +
+            "    public %3$s %1$s(final CharSequence value)%n" +
+            "    {%n" +
+            "        %1$s = toBytes(value, %1$s);%n" +
+            "        %1$sOffset = 0;%n" +
+            "        %1$sLength = value.length();%n" +
+            "        return this;%n" +
+            "    }%n%n" +
+            "    public %3$s %1$s(final char[] value)%n" +
+            "    {%n" +
+            "        return %1$s(value, value.length);%n" +
+            "    }%n%n" +
+            "    public %3$s %1$s(final char[] value, final int length)%n" +
+            "    {%n" +
+            "        %1$s = toBytes(value, %1$s, length);%n" +
+            "        %1$sOffset = 0;%n" +
+            "        %1$sLength = length;%n" +
+            "        return this;%n" +
+            "    }%n%n" +
+            "    public %3$s %1$s(final char[] value, final int offset, final int length)%n" +
+            "    {%n" +
+            "        %1$s = toBytes(value, %1$s, offset, length);%n" +
+            "        %1$sOffset = 0;%n" +
+            "        %1$sLength = length;%n" +
+            "        return this;%n" +
+            "    }%n%n" +
             "%4$s",
             fieldName,
             generateByteArraySetter(className, fieldName, name),
@@ -556,18 +557,18 @@ public class EncoderGenerator extends Generator
         final String enumSetter)
     {
         return String.format(
-            "    %s %s %s;\n\n" +
+            "    %s %s %s;%n%n" +
             "%s" +
-            "    public %s %3$s(%2$s value)\n" +
-            "    {\n" +
-            "        %3$s = value;\n" +
+            "    public %s %3$s(%2$s value)%n" +
+            "    {%n" +
+            "        %3$s = value;%n" +
             "%s" +
-            "        return this;\n" +
-            "    }\n\n" +
-            "    public %2$s %3$s()\n" +
-            "    {\n" +
-            "        return %3$s;\n" +
-            "    }\n\n" +
+            "        return this;%n" +
+            "    }%n%n" +
+            "    public %2$s %3$s()%n" +
+            "    {%n" +
+            "        return %3$s;%n" +
+            "    }%n%n" +
             "%7$s",
             isBodyLength(name) ? "public" : "private",
             type,
@@ -586,24 +587,24 @@ public class EncoderGenerator extends Generator
         final String enumSetter)
     {
         return String.format(
-            "    private final DecimalFloat %1$s = new DecimalFloat();\n\n" +
+            "    private final DecimalFloat %1$s = new DecimalFloat();%n%n" +
             "%2$s" +
-            "    public %3$s %1$s(DecimalFloat value)\n" +
-            "    {\n" +
-            "        %1$s.set(value);\n" +
+            "    public %3$s %1$s(DecimalFloat value)%n" +
+            "    {%n" +
+            "        %1$s.set(value);%n" +
             "%4$s" +
-            "        return this;\n" +
-            "    }\n\n" +
-            "    public %3$s %1$s(long value, int scale)\n" +
-            "    {\n" +
-            "        %1$s.set(value, scale);\n" +
+            "        return this;%n" +
+            "    }%n%n" +
+            "    public %3$s %1$s(long value, int scale)%n" +
+            "    {%n" +
+            "        %1$s.set(value, scale);%n" +
             "%4$s" +
-            "        return this;\n" +
-            "    }\n\n" +
-            "    public DecimalFloat %1$s()\n" +
-            "    {\n" +
-            "        return %1$s;\n" +
-            "    }\n\n" +
+            "        return this;%n" +
+            "    }%n%n" +
+            "    public DecimalFloat %1$s()%n" +
+            "    {%n" +
+            "        return %1$s;%n" +
+            "    }%n%n" +
             "%5$s",
             fieldName,
             optionalField,
@@ -618,10 +619,10 @@ public class EncoderGenerator extends Generator
         final String enumType)
     {
         return String.format(
-            "    public %s %2$s(%3$s value)\n" +
-            "    {\n" +
-            "        return %2$s(value.representation());\n" +
-            "    }\n\n",
+            "    public %s %2$s(%3$s value)%n" +
+            "    {%n" +
+            "        return %2$s(value.representation());%n" +
+            "    }%n%n",
             className, fieldName, enumType
         );
     }
@@ -654,44 +655,44 @@ public class EncoderGenerator extends Generator
 
         final String body = entries.stream()
             .map(this::encodeEntry)
-            .collect(joining("\n"));
+            .collect(joining(NEWLINE));
 
         String suffix;
         if (aggregateType == AggregateType.MESSAGE)
         {
-            suffix =
-                "        position += trailer.startTrailer(buffer, position);\n" +
-                "\n" +
-                "        final int messageStart = header.finishHeader(buffer, bodyStart, position - bodyStart);\n" +
-                "        return trailer.finishMessage(buffer, messageStart, position);\n" +
-                "    }\n\n";
+            suffix = String.format(
+                "        position += trailer.startTrailer(buffer, position);%n" +
+                "%n" +
+                "        final int messageStart = header.finishHeader(buffer, bodyStart, position - bodyStart);%n" +
+                "        return trailer.finishMessage(buffer, messageStart, position);%n" +
+                "    }%n%n");
         }
         else if (aggregateType == AggregateType.HEADER)
         {
-            suffix =
-                "\n" +
-                "        return Encoder.result(position - start, start);\n" +
-                "    }\n\n";
+            suffix = String.format(
+                "%n" +
+                "        return Encoder.result(position - start, start);%n" +
+                "    }%n%n");
         }
         else if (aggregateType == AggregateType.TRAILER)
         {
-            suffix =
-                "        return position - start;\n" +
-                "    }\n\n";
+            suffix = String.format(
+                "        return position - start;%n" +
+                "    }%n%n");
         }
         else
         {
-            suffix =
-                "        return position - offset;\n" +
-                "    }\n\n";
+            suffix = String.format(
+                "        return position - offset;%n" +
+                "    }%n%n");
 
             if (aggregateType == GROUP)
             {
-                suffix =
-                    "        if (next != null)\n" +
-                    "        {\n" +
-                    "            position += next.encode(buffer, position, remainingElements - 1);\n" +
-                    "        }\n" + suffix;
+                suffix = String.format(
+                    "        if (next != null)%n" +
+                    "        {%n" +
+                    "            position += next.encode(buffer, position, remainingElements - 1);%n" +
+                    "        }%n") + suffix;
             }
         }
 
@@ -725,25 +726,25 @@ public class EncoderGenerator extends Generator
         final String enablingPrefix;
         if (mustCheckFlag)
         {
-            enablingPrefix = String.format("        if (has%s) {\n", name);
+            enablingPrefix = String.format("        if (has%s) {%n", name);
         }
         else if (mustCheckLength)
         {
-            enablingPrefix = String.format("        if (%sLength > 0) {\n", fieldName);
+            enablingPrefix = String.format("        if (%sLength > 0) {%n", fieldName);
         }
         else
         {
             enablingPrefix = "";
         }
-        String enablingSuffix = mustCheckFlag || mustCheckLength ? "        }\n" : "";
+        String enablingSuffix = mustCheckFlag || mustCheckLength ? String.format("        }%n") : "";
 
         if (needsMissingThrow)
         {
-            enablingSuffix = enablingSuffix +
-                "        else if (" + CODEC_VALIDATION_ENABLED + ")\n" +
-                "        {\n" +
-                "            throw new EncodingException(\"Missing Field: " + name + "\");\n" +
-                "        }\n";
+            enablingSuffix = enablingSuffix + String.format(
+                "        else if (" + CODEC_VALIDATION_ENABLED + ")%n" +
+                "        {%n" +
+                "            throw new EncodingException(\"Missing Field: " + name + "\");%n" +
+                "        }%n");
         }
 
         final String tag = formatTag(fieldName, enablingPrefix);
@@ -792,8 +793,8 @@ public class EncoderGenerator extends Generator
             case XMLDATA:
                 return String.format(
                     "%s" +
-                    "        buffer.putBytes(position, %s);\n" +
-                    "        position += %2$s.length;\n" +
+                    "        buffer.putBytes(position, %s);%n" +
+                    "        position += %2$s.length;%n" +
                     SUFFIX,
                     tag,
                     fieldName,
@@ -807,8 +808,8 @@ public class EncoderGenerator extends Generator
     private String stringPut(final String fieldName, final String optionalSuffix, final String tag)
     {
         return formatEncoder(fieldName, optionalSuffix, tag,
-        "        buffer.putBytes(position, %s, %2$sOffset, %2$sLength);\n" +
-            "        position += %2$sLength;\n");
+        "        buffer.putBytes(position, %s, %2$sOffset, %2$sLength);%n" +
+            "        position += %2$sLength;%n");
     }
 
     private String formatEncoder(
@@ -825,11 +826,11 @@ public class EncoderGenerator extends Generator
     {
         final Group group = (Group)entry.element();
         return String.format(
-            "%1$s\n" +
-            "        if (%2$s != null)\n" +
-            "        {\n" +
-            "            position += %2$s.encode(buffer, position, %3$s);\n" +
-            "        }\n",
+            "%1$s%n" +
+            "        if (%2$s != null)%n" +
+            "        {%n" +
+            "            position += %2$s.encode(buffer, position, %3$s);%n" +
+            "        }%n",
             encodeField(group.numberField()),
             formatPropertyName(group.name()),
             formatPropertyName(group.numberField().name()));
@@ -839,7 +840,7 @@ public class EncoderGenerator extends Generator
     {
         // TODO: make component return int, split encode prefix
         return String.format(
-            "            position += %1$s.encode(buffer, position);\n",
+            "            position += %1$s.encode(buffer, position);%n",
             formatPropertyName(entry.name()));
     }
 
@@ -847,8 +848,8 @@ public class EncoderGenerator extends Generator
     {
         return String.format(
             "%s" +
-            "        buffer.putBytes(position, %sHeader, 0, %2$sHeaderLength);\n" +
-            "        position += %2$sHeaderLength;\n",
+            "        buffer.putBytes(position, %sHeader, 0, %2$sHeaderLength);%n" +
+            "        position += %2$sHeaderLength;%n",
             optionalPrefix,
             fieldName);
     }
@@ -857,7 +858,7 @@ public class EncoderGenerator extends Generator
     {
         return String.format(
             "%s" +
-            "        position += buffer.put%sAscii(position, %s);\n" +
+            "        position += buffer.put%sAscii(position, %s);%n" +
             SUFFIX,
             tag,
             type,
@@ -893,8 +894,8 @@ public class EncoderGenerator extends Generator
             .collect(joining(", ", "", ", (byte) '='"));
 
         out.append(String.format(
-            "    private static final int %sHeaderLength = %d;\n" +
-            "    private static final byte[] %1$sHeader = new byte[] {%s};\n\n",
+            "    private static final int %sHeaderLength = %d;%n" +
+            "    private static final byte[] %1$sHeader = new byte[] {%s};%n%n",
             fieldName,
             length + 1,
             bytes));
@@ -917,11 +918,11 @@ public class EncoderGenerator extends Generator
     private void componentField(final String className, final Component element, final Writer out) throws IOException
     {
         out.append(String.format(
-            "    private final %1$s %2$s = new %1$s();\n" +
-            "    public %1$s %2$s()\n" +
-            "    {\n" +
-            "        return %2$s;\n" +
-            "    }\n\n",
+            "    private final %1$s %2$s = new %1$s();%n" +
+            "    public %1$s %2$s()%n" +
+            "    {%n" +
+            "        return %2$s;%n" +
+            "    }%n%n",
             className,
             formatPropertyName(element.name())));
     }
@@ -943,11 +944,11 @@ public class EncoderGenerator extends Generator
 
     protected String toStringGroupSuffix()
     {
-        return
-            "        if (remainingEntries > 1)\n" +
-            "        {\n" +
-            "            entries += \",\\n\" + next.toString(remainingEntries - 1);\n" +
-            "        }\n";
+        return String.format(
+            "        if (remainingEntries > 1)%n" +
+            "        {%n" +
+            "            entries += \",\\n\" + next.toString(remainingEntries - 1);%n" +
+            "        }%n");
     }
 
     protected boolean hasFlag(final Entry entry, final Field field)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
@@ -148,7 +148,7 @@ public final class EnumGenerator
             }
             finally
             {
-                out.append("}\n");
+                out.append(String.format("}%n"));
             }
         });
     }
@@ -160,7 +160,7 @@ public final class EnumGenerator
 
     private String generateEnumDeclaration(final String name, final String interfaceToImplement)
     {
-        final String format = "public enum " + name + " implements %sRepresentable\n{\n";
+        final String format = "public enum " + name + " implements %sRepresentable%n{%n";
         return String.format(format, interfaceToImplement);
     }
 
@@ -169,14 +169,14 @@ public final class EnumGenerator
         return allValues
             .stream()
             .map((value) -> format("%s%s(%s)", INDENT, value.description(), literal(value, type)))
-            .collect(joining(",\n"));
+            .collect(joining(format(",%n")));
     }
 
     private String generateEnumBody(final String name, final Type type)
     {
         final Var representation = representation(type);
 
-        return ";\n\n" +
+        return String.format(";%n%n") +
                representation.field() +
                constructor(name, representation) +
                representation.getter();
@@ -196,21 +196,21 @@ public final class EnumGenerator
 
         final String cases = allValues
             .stream()
-            .map((value) -> format("        case %s: return %s;\n", literal(value, type), value.description()))
+            .map((value) -> format("        case %s: return %s;%n", literal(value, type), value.description()))
             .collect(joining());
 
         return format(
             "%s" +
             "%s" +
-            "    public static %s decode(%s)\n" +
-            "    {\n" +
-            "        switch(representation)\n" +
-            "        {\n" +
+            "    public static %s decode(%s)%n" +
+            "    {%n" +
+            "        switch(representation)%n" +
+            "        {%n" +
             "%s" +
-            "        default:\n" +
-            "            return %s;\n" +
-            "        }\n" +
-            "    }\n",
+            "        default:%n" +
+            "            return %s;%n" +
+            "        }%n" +
+            "    }%n",
             optionalCharArrayDecode,
             enumValidation,
             name,
@@ -224,66 +224,68 @@ public final class EnumGenerator
         switch (type)
         {
             case STRING:
-                return "    public static boolean isValid(final char[] representation, final int length)\n" +
-                       "    {\n" +
-                       "        return charMap.containsKey(representation, length);\n" +
-                       "    }\n";
+                return format(
+                    "    public static boolean isValid(final char[] representation, final int length)%n" +
+                    "    {%n" +
+                    "        return charMap.containsKey(representation, length);%n" +
+                    "    }%n");
 
             case MULTIPLEVALUESTRING:
             case MULTIPLESTRINGVALUE:
-                return "    public static boolean isValid(final char[] representation, final int length)\n" +
-                       "    {\n" +
-                       "        int offset = 0;\n" +
-                       "        for (int i = 0; i < length; i++)\n" +
-                       "        {\n" +
-                       "            if (representation[i] == ' ')\n" +
-                       "            {\n" +
-                       "                if (! charMap.containsKey(representation, offset, i - offset))\n" +
-                       "                    return false;\n" +
-                       "                offset = i + 1;\n" +
-                       "            }\n" +
-                       "        }\n" +
-                       "        return charMap.containsKey(representation, offset, length - offset);\n" +
-                       "    }\n";
+                return format(
+                    "    public static boolean isValid(final char[] representation, final int length)%n" +
+                    "    {%n" +
+                    "        int offset = 0;%n" +
+                    "        for (int i = 0; i < length; i++)%n" +
+                    "        {%n" +
+                    "            if (representation[i] == ' ')%n" +
+                    "            {%n" +
+                    "                if (! charMap.containsKey(representation, offset, i - offset))%n" +
+                    "                    return false;%n" +
+                    "                offset = i + 1;%n" +
+                    "            }%n" +
+                    "        }%n" +
+                    "        return charMap.containsKey(representation, offset, length - offset);%n" +
+                    "    }%n");
 
             case MULTIPLECHARVALUE:
                 final String multiCharValues = allValues
                     .stream()
                     .map(Field.Value::representation)
-                    .map((repr) -> String.format("'%1$s'", repr))
-                    .map((repr) -> String.format("        intSet.add(%1$s);\n", repr))
+                    .map((repr) -> format("'%1$s'", repr))
+                    .map((repr) -> format("        intSet.add(%1$s);%n", repr))
                     .collect(joining());
 
                 return format(
-                    "    private static final IntHashSet intSet = new IntHashSet(%2$s);\n" +
-                    "    %1$s\n" +
-                    "\n" +
-                    "    public static boolean isValid(final char[] representation, final int length)\n" +
-                    "    {\n" +
-                    "        for (int i = 0; i < length; i+=2)\n" +
-                    "        {\n" +
-                    "            if (! intSet.contains(representation[i]))\n" +
-                    "                return false;\n" +
-                    "        }\n" +
-                    "        return true;\n" +
-                    "    }\n",
+                    "    private static final IntHashSet intSet = new IntHashSet(%2$s);%n" +
+                    "    %1$s%n" +
+                    "%n" +
+                    "    public static boolean isValid(final char[] representation, final int length)%n" +
+                    "    {%n" +
+                    "        for (int i = 0; i < length; i+=2)%n" +
+                    "        {%n" +
+                    "            if (! intSet.contains(representation[i]))%n" +
+                    "                return false;%n" +
+                    "        }%n" +
+                    "        return true;%n" +
+                    "    }%n",
                     optionalStaticInit(multiCharValues),
                     ConstantGenerator.sizeHashSet(allValues));
             default:
                 final String primitiveValues = allValues
                     .stream()
                     .map(value -> literal(value, type))
-                    .map((repr) -> String.format("        intSet.add(%1$s);\n", repr))
+                    .map((repr) -> format("        intSet.add(%1$s);%n", repr))
                     .collect(joining());
 
                 return format(
-                    "    private static final IntHashSet intSet = new IntHashSet(%2$s);\n" +
-                    "    %1$s\n" +
-                    "\n" +
-                    "    public static boolean isValid(final int representation)\n" +
-                    "    {\n" +
-                    "        return intSet.contains(representation);\n" +
-                    "    }\n",
+                    "    private static final IntHashSet intSet = new IntHashSet(%2$s);%n" +
+                    "    %1$s%n" +
+                    "%n" +
+                    "    public static boolean isValid(final int representation)%n" +
+                    "    {%n" +
+                    "        return intSet.contains(representation);%n" +
+                    "    }%n",
                     optionalStaticInit(primitiveValues),
                     ConstantGenerator.sizeHashSet(allValues));
         }
@@ -298,42 +300,42 @@ public final class EnumGenerator
             case MULTIPLESTRINGVALUE:
                 final String entries = allValues
                     .stream()
-                    .map((v) -> format("        stringMap.put(%s, %s);\n", literal(v, type), v.description()))
+                    .map((v) -> format("        stringMap.put(%s, %s);%n", literal(v, type), v.description()))
                     .collect(joining());
 
                 return format(
-                    "    private static final CharArrayMap<%1$s> charMap;\n" +
-                    "    static\n" +
-                    "    {\n" +
-                    "        final Map<String, %1$s> stringMap = new HashMap<>();\n" +
+                    "    private static final CharArrayMap<%1$s> charMap;%n" +
+                    "    static%n" +
+                    "    {%n" +
+                    "        final Map<String, %1$s> stringMap = new HashMap<>();%n" +
                     "%2$s" +
-                    "        charMap = new CharArrayMap<>(stringMap);\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public static %1$s decode(final char[] representation, final int length)\n" +
-                    "    {\n" +
-                            "        final %1$s value = charMap.get(representation, length);\n" +
-                            "        if (value == null)\n" +
-                            "        {\n" +
-                            "            return %3$s;\n" +
-                            "        }\n" +
-                            "        return value;\n" +
-                    "    }\n",
+                    "        charMap = new CharArrayMap<>(stringMap);%n" +
+                    "    }%n" +
+                    "%n" +
+                    "    public static %1$s decode(final char[] representation, final int length)%n" +
+                    "    {%n" +
+                            "        final %1$s value = charMap.get(representation, length);%n" +
+                            "        if (value == null)%n" +
+                            "        {%n" +
+                            "            return %3$s;%n" +
+                            "        }%n" +
+                            "        return value;%n" +
+                    "    }%n",
                     typeName,
                     entries,
                     UNKNOWN_NAME);
             case MULTIPLECHARVALUE:
 
                 return format(
-                    "    public static %1$s decode(String representation)\n" +
-                    "    {\n" +
-                    "        return decode(representation.charAt(0));\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public static %1$s decode(final char[] representation, final int length)\n" +
-                    "    {\n" +
-                    "        return decode(representation[0]);\n" +
-                    "    }\n",
+                    "    public static %1$s decode(String representation)%n" +
+                    "    {%n" +
+                    "        return decode(representation.charAt(0));%n" +
+                    "    }%n" +
+                    "%n" +
+                    "    public static %1$s decode(final char[] representation, final int length)%n" +
+                    "    {%n" +
+                    "        return decode(representation[0]);%n" +
+                    "    }%n",
                     typeName);
             default:
                 return "";

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -31,6 +31,7 @@ public final class GenerationUtil
     public static final String ENCODER_PACKAGE = PARENT_PACKAGE + ".builder";
     public static final String DECODER_PACKAGE = PARENT_PACKAGE + ".decoder";
     public static final String INDENT = "    ";
+    public static final String NEWLINE = String.format("%n");
 
     private GenerationUtil()
     {
@@ -39,8 +40,8 @@ public final class GenerationUtil
     public static String fileHeader(final String packageName)
     {
         return String.format(
-            "/* Generated Fix Gateway message codec */\n" +
-            "package %s;\n\n",
+            "/* Generated Fix Gateway message codec */%n" +
+            "package %s;%n%n",
             packageName);
     }
 
@@ -83,12 +84,12 @@ public final class GenerationUtil
 
         public String field()
         {
-            return String.format("%sprivate final %s %s;\n\n", INDENT, type, name);
+            return String.format("%sprivate final %s %s;%n%n", INDENT, type, name);
         }
 
         public String getter()
         {
-            return String.format("%spublic final %s %s() { return %3$s; }\n\n", INDENT, type, name);
+            return String.format("%spublic final %s %s() { return %3$s; }%n%n", INDENT, type, name);
         }
 
         public String declaration()
@@ -107,9 +108,9 @@ public final class GenerationUtil
 
         final String binding = Stream.of(parameters)
             .map(var -> String.format("%1$s%1$s this.%2$s = %2$s;", INDENT, var.name))
-            .collect(joining("\n"));
+            .collect(joining("%n"));
 
-        return String.format("%s%s(%s)\n%1$s{\n%s\n%1$s}\n\n", INDENT, name, paramDeclaration(parameters), binding);
+        return String.format("%s%s(%s)%n%1$s{%n%s%n%1$s}%n%n", INDENT, name, paramDeclaration(parameters), binding);
     }
 
     public static String paramDeclaration(final Var[] parameters)
@@ -121,32 +122,32 @@ public final class GenerationUtil
 
     public static String importFor(final Class<?> cls)
     {
-        return String.format("import %s;\n", cls.getCanonicalName());
+        return String.format("import %s;%n", cls.getCanonicalName());
     }
 
     public static String importFor(final String className)
     {
-        return String.format("import %s;\n", className);
+        return String.format("import %s;%n", className);
     }
 
 
     public static String importStaticFor(final Class<?> cls)
     {
-        return String.format("import static %s.*;\n", cls.getCanonicalName());
+        return String.format("import static %s.*;%n", cls.getCanonicalName());
     }
 
     public static String importStaticFor(final Class<?> cls, final String name)
     {
         Verify.notNull(name, "name");
-        return String.format("import static %s.%s;\n", cls.getCanonicalName(), name);
+        return String.format("import static %s.%s;%n", cls.getCanonicalName(), name);
     }
 
     public static String optionalStaticInit(final String containing)
     {
-        return containing.isEmpty() ? "\n" :
-            "    static\n" +
-            "    {\n" +
+        return containing.isEmpty() ? NEWLINE : String.format(
+            "    static%n" +
+            "    {%n" +
             containing +
-            "    }\n\n";
+            "    }%n%n");
     }
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -105,10 +105,9 @@ public final class GenerationUtil
 
     public static String constructor(final String name, final Var... parameters)
     {
-
         final String binding = Stream.of(parameters)
             .map(var -> String.format("%1$s%1$s this.%2$s = %2$s;", INDENT, var.name))
-            .collect(joining("%n"));
+            .collect(joining(NEWLINE));
 
         return String.format("%s%s(%s)%n%1$s{%n%s%n%1$s}%n%n", INDENT, name, paramDeclaration(parameters), binding);
     }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -62,25 +62,25 @@ public abstract class Generator
         final String headerParameter = headerWrapsTrailer ? "trailer" : "";
         return String.format(
             "    %3$s" +
-            "    private Trailer%1$s trailer = new Trailer%1$s();\n\n" +
-            "    public Trailer%1$s trailer()\n" +
-            "    {\n" +
-            "        return trailer;\n" +
-            "    }\n\n" +
+            "    private Trailer%1$s trailer = new Trailer%1$s();%n%n" +
+            "    public Trailer%1$s trailer()%n" +
+            "    {%n" +
+            "        return trailer;%n" +
+            "    }%n%n" +
 
-            "    private Header%1$s header = new Header%1$s(%2$s);\n\n" +
-            "    public Header%1$s header()\n" +
-            "    {\n" +
-            "        return header;\n" +
-            "    }\n\n",
+            "    private Header%1$s header = new Header%1$s(%2$s);%n%n" +
+            "    public Header%1$s header()%n" +
+            "    {%n" +
+            "        return header;%n" +
+            "    }%n%n",
             form,
             headerParameter,
             messageFieldsSet);
     }
 
     private static final String COMMON_COMPOUND_IMPORTS =
-        "import %1$s.Header%2$s;\n" +
-        "import %1$s.Trailer%2$s;\n";
+        "import %1$s.Header%2$s;%n" +
+        "import %1$s.Trailer%2$s;%n";
 
     protected final Dictionary dictionary;
     protected final String builderPackage;
@@ -164,8 +164,8 @@ public abstract class Generator
         final String interfaceList = interfaces.isEmpty() ? "" : " implements " + String.join(", ", interfaces);
 
         return String.format(
-            "\n\npublic %3$sclass %1$s%2$s\n" +
-            "{\n",
+            "%n%npublic %3$sclass %1$s%2$s%n" +
+            "{%n",
             className,
             interfaceList,
             isStatic ? "static " : "");
@@ -183,17 +183,17 @@ public abstract class Generator
         if (isMessage)
         {
             return String.format(
-                "    public void reset()\n" +
-                "    {\n" +
-                "        header.reset();\n" +
-                "        trailer.reset();\n" +
-                "        resetMessage();\n" +
+                "    public void reset()%n" +
+                "    {%n" +
+                "        header.reset();%n" +
+                "        trailer.reset();%n" +
+                "        resetMessage();%n" +
                 "%2$s" +
-                "    }\n\n" +
-                "    public void resetMessage()\n" +
-                "    {\n" +
+                "    }%n%n" +
+                "    public void resetMessage()%n" +
+                "    {%n" +
                 "%1$s" +
-                "    }\n\n" +
+                "    }%n%n" +
                 "%3$s",
                 resetEntries,
                 additionalReset,
@@ -202,11 +202,11 @@ public abstract class Generator
         else
         {
             return String.format(
-                "    public void reset()\n" +
-                "    {\n" +
+                "    public void reset()%n" +
+                "    {%n" +
                 "%s" +
                 "%s" +
-                "    }\n\n" +
+                "    }%n%n" +
                 "%s",
                 resetEntries,
                 additionalReset,
@@ -351,14 +351,14 @@ public abstract class Generator
         }
 
         return String.format(
-            "        %1$s();\n",
+            "        %1$s();%n",
             nameOfResetMethod(entry.name()));
     }
 
     protected String callComponentReset(final Entry entry)
     {
         return String.format(
-            "        %1$s.reset();\n",
+            "        %1$s.reset();%n",
             formatPropertyName(entry.name()));
     }
 
@@ -367,15 +367,15 @@ public abstract class Generator
         final String name = entry.name();
         return entry.required() ?
             "" :
-            String.format("    private boolean has%1$s;\n\n", name);
+            String.format("    private boolean has%1$s;%n%n", name);
     }
 
     protected String resetNothing(final String name)
     {
         return String.format(
-            "    public void %1$s()\n" +
-            "    {\n" +
-            "    }\n\n",
+            "    public void %1$s()%n" +
+            "    {%n" +
+            "    }%n%n",
             nameOfResetMethod(name));
     }
 
@@ -399,10 +399,10 @@ public abstract class Generator
     protected String resetLength(final String name)
     {
         return String.format(
-            "    public void %1$s()\n" +
-            "    {\n" +
-            "        %2$sLength = 0;\n" +
-            "    }\n\n",
+            "    public void %1$s()%n" +
+            "    {%n" +
+            "        %2$sLength = 0;%n" +
+            "    }%n%n",
             nameOfResetMethod(name),
             formatPropertyName(name));
     }
@@ -410,10 +410,10 @@ public abstract class Generator
     protected String resetByFlag(final String name)
     {
         return String.format(
-            "    public void %2$s()\n" +
-            "    {\n" +
-            "        has%1$s = false;\n" +
-            "    }\n\n",
+            "    public void %2$s()%n" +
+            "    {%n" +
+            "        has%1$s = false;%n" +
+            "    }%n%n",
             name,
             nameOfResetMethod(name));
     }
@@ -421,10 +421,10 @@ public abstract class Generator
     protected String resetByMethod(final String name)
     {
         return String.format(
-            "    public void %2$s()\n" +
-            "    {\n" +
-            "        %1$s.reset();\n" +
-            "    }\n\n",
+            "    public void %2$s()%n" +
+            "    {%n" +
+            "        %1$s.reset();%n" +
+            "    }%n%n",
             formatPropertyName(name),
             nameOfResetMethod(name));
     }
@@ -432,10 +432,10 @@ public abstract class Generator
     protected String resetFieldValue(final String name, final String resetValue)
     {
         return String.format(
-            "    public void %1$s()\n" +
-            "    {\n" +
-            "        %2$s = %3$s;\n" +
-            "    }\n\n",
+            "    public void %1$s()%n" +
+            "    {%n" +
+            "        %2$s = %3$s;%n" +
+            "    }%n%n",
             nameOfResetMethod(name),
             formatPropertyName(name),
             resetValue);
@@ -447,10 +447,10 @@ public abstract class Generator
             .entries()
             .stream()
             .map(this::entryToString)
-            .collect(joining(" + \n"));
+            .collect(joining(String.format(" + %n")));
 
         final String prefix = !hasCommonCompounds ?
-            "" : "\"  \\\"header\\\": \" + header" + EXPAND_INDENT + " + \"\\n\" + ";
+            "" : String.format("\"  \\\"header\\\": \" + header" + EXPAND_INDENT + " + \"\\n\" + ");
 
         final String suffix;
         final String parameters;
@@ -467,14 +467,14 @@ public abstract class Generator
         }
 
         return String.format(
-            "    public String toString(%5$s)\n" +
-            "    {\n" +
-            "        String entries = %1$s\n" +
-            "%2$s;\n\n" +
-            "        entries = \"{\\n  \\\"MessageName\\\": \\\"%4$s\\\",\\n\" + entries + \"}\";\n" +
+            "    public String toString(%5$s)%n" +
+            "    {%n" +
+            "        String entries = %1$s%n" +
+            "%2$s;%n%n" +
+            "        entries = \"{\\n  \\\"MessageName\\\": \\\"%4$s\\\",\\n\" + entries + \"}\";%n" +
             "%3$s" +
-            "        return entries;\n" +
-            "    }\n\n",
+            "        return entries;%n" +
+            "    }%n%n",
             prefix,
             entriesToString,
             suffix,
@@ -488,7 +488,7 @@ public abstract class Generator
 
     protected String entryToString(final Entry entry)
     {
-        //"  \"OnBehalfOfCompID\": \"abc\",\n" +
+        //"  \"OnBehalfOfCompID\": \"abc\",%n" +
 
         if (isBodyLength(entry))
         {
@@ -532,10 +532,10 @@ public abstract class Generator
     protected String hasGetter(final String name)
     {
         return String.format(
-            "    public boolean has%s()\n" +
-            "    {\n" +
-            "        return has%1$s;\n" +
-            "    }\n\n",
+            "    public boolean has%s()%n" +
+            "    {%n" +
+            "        return has%1$s;%n" +
+            "    }%n%n",
             name);
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/PrinterGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/PrinterGenerator.java
@@ -30,6 +30,7 @@ import static java.util.stream.Collectors.joining;
 import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.decoderClassName;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.NEWLINE;
 
 public class PrinterGenerator
 {
@@ -37,8 +38,8 @@ public class PrinterGenerator
     private static final String CLASS_DECLARATION =
         importFor(Printer.class) +
         importFor(AsciiBuffer.class) +
-        "\npublic class PrinterImpl implements Printer\n" +
-        "{\n\n";
+        String.format("%npublic class PrinterImpl implements Printer%n") +
+        String.format("{%n%n");
 
     private final Dictionary dictionary;
     private final String builderPackage;
@@ -60,7 +61,7 @@ public class PrinterGenerator
                 out.append(CLASS_DECLARATION);
                 out.append(generateDecoderFields());
                 out.append(generateToString());
-                out.append("}\n");
+                out.append(String.format("}%n"));
             });
     }
 
@@ -68,13 +69,13 @@ public class PrinterGenerator
     {
         return messages()
             .map(this::generateDecoderField)
-            .collect(joining()) + "\n";
+            .collect(joining()) + NEWLINE;
     }
 
     private String generateDecoderField(final Aggregate aggregate)
     {
         return String.format(
-            "    private final %s %s = new %1$s();\n",
+            "    private final %s %s = new %1$s();%n",
             decoderClassName(aggregate),
             decoderFieldName(aggregate)
         );
@@ -88,28 +89,28 @@ public class PrinterGenerator
     private String generateToString()
     {
         final Function<Message, String> mapper = (aggregate) -> String.format(
-            "            case %s:\n" +
-            "            %s.decode(input, offset, length);\n" +
-            "            return %2$s.toString();\n\n",
+            "            case %s:%n" +
+            "            %s.decode(input, offset, length);%n" +
+            "            return %2$s.toString();%n%n",
             aggregate.packedType(),
             decoderFieldName(aggregate));
 
         final String cases = messages().map(mapper).collect(joining());
 
-        return
-            "    public String toString(\n" +
-            "        final AsciiBuffer input,\n" +
-            "        final int offset,\n" +
-            "        final int length,\n" +
-            "        final int messageType)\n" +
-            "    {\n" +
-            "        switch(messageType)\n" +
-            "        {\n" +
+        return String.format(
+            "    public String toString(%n" +
+            "        final AsciiBuffer input,%n" +
+            "        final int offset,%n" +
+            "        final int length,%n" +
+            "        final int messageType)%n" +
+            "    {%n" +
+            "        switch(messageType)%n" +
+            "        {%n" +
             cases +
-            "            default:\n" +
+            "            default:%n" +
             "            throw new IllegalArgumentException(\"Unknown Message Type: \" + messageType);" +
-            "        }\n" +
-            "    }\n\n";
+            "        }%n" +
+            "    }%n%n");
     }
 
     private Stream<Message> messages()

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/LineEndingsTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/LineEndingsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.dictionary.generation;
+
+import org.agrona.generation.StringWriterOutputManager;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.Map;
+
+import static uk.co.real_logic.artio.dictionary.ExampleDictionary.*;
+
+public class LineEndingsTest
+{
+    private static StringWriterOutputManager outputManager = new StringWriterOutputManager();
+
+    @Test
+    public void constantGenerator()
+    {
+        final ConstantGenerator constantGenerator =
+            new ConstantGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+        constantGenerator.generate();
+        final Map<String, CharSequence> sources = outputManager.getSources();
+        sources.keySet().stream().forEach((key) ->
+        {
+            final String strippedSource = sources.get(key).toString().replace(System.lineSeparator(), "");
+            assertFalse(key + " contains hard-coded line-ending", strippedSource.contains("\n"));
+        });
+    }
+
+    @Test
+    public void enumGenerator()
+    {
+        final EnumGenerator enumGenerator =
+            new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+        enumGenerator.generate();
+        final Map<String, CharSequence> sources = outputManager.getSources();
+        sources.keySet().stream().forEach((key) ->
+        {
+            final String strippedSource = sources.get(key).toString().replace(System.lineSeparator(), "");
+            assertFalse(key + " contains hard-coded line-ending", strippedSource.contains("\n"));
+        });
+    }
+
+    @Test
+    public void encoderGenerator()
+    {
+        final EncoderGenerator encoderGenerator =
+            new EncoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager,
+            ValidationOn.class, RejectUnknownFieldOff.class);
+        encoderGenerator.generate();
+        final Map<String, CharSequence> sources = outputManager.getSources();
+        sources.keySet().stream().forEach((key) ->
+        {
+            final String strippedSource = sources.get(key).toString().replace(System.lineSeparator(), "");
+            assertFalse(key + " contains hard-coded line-ending", strippedSource.contains("\n"));
+        });
+    }
+
+    @Test
+    public void decoderGenerator()
+    {
+        final DecoderGenerator decoderGenerator =
+            new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE,
+            outputManager, ValidationOn.class, RejectUnknownFieldOff.class);
+        decoderGenerator.generate();
+        final Map<String, CharSequence> sources = outputManager.getSources();
+        sources.keySet().stream().forEach((key) ->
+        {
+            final String strippedSource = sources.get(key).toString().replace(System.lineSeparator(), "");
+            assertFalse(key + " contains hard-coded line-ending", strippedSource.contains("\n"));
+        });
+    }
+
+    @Test
+    public void acceptorGenerator()
+    {
+        final AcceptorGenerator acceptorGenerator =
+            new AcceptorGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
+        acceptorGenerator.generate();
+        final Map<String, CharSequence> sources = outputManager.getSources();
+        sources.keySet().stream().forEach((key) ->
+        {
+            final String strippedSource = sources.get(key).toString().replace(System.lineSeparator(), "");
+            assertFalse(key + " contains hard-coded line-ending", strippedSource.contains("\n"));
+        });
+    }
+}


### PR DESCRIPTION
Because git converts from `\n` to `\r\n` when checking out code to a windows machine, after running the build process all the code-generated files are marked as modified (because they have been rewritten with `\n`).

This change uses `%n` to output the correct line-ending in the code generated file based upon the platform.

It should NOT change runtime behaviour at all, ie. fix messages should still contain `\n` where they did before and that will NOT change depending on platform.