### PR TITLE
[Tom] add a check to only write the contents of AsciiSequenceView if there is data to be written.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -536,9 +536,10 @@ public class EncoderGenerator extends Generator
             "    }\n\n" +
             "    public %3$s %1$s(final AsciiSequenceView value)\n" +
             "    {\n" +
-            "        if (value.length() > 0)\n" +
+            "        final DirectBuffer buffer = value.buffer();\n" +
+            "        if (buffer != null)\n" +
             "        {\n" +
-            "            %1$s.wrap(value.buffer());\n" +
+            "            %1$s.wrap(buffer);\n" +
             "            %1$sOffset = value.offset();\n" +
             "            %1$sLength = value.length();\n" +
             "        }\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -502,13 +502,6 @@ public class EncoderGenerator extends Generator
             "    {\n" +
             "        return %1$s(value, 0, value.length);\n" +
             "    }\n\n" +
-            "    public %2$s %1$s(final AsciiSequenceView value)\n" +
-            "    {\n" +
-            "        %1$s.wrap(value.buffer());\n" +
-            "        %1$sOffset = value.offset();\n" +
-            "        %1$sLength = value.length();\n" +
-            "        return this;\n" +
-            "    }\n\n" +
             "    public boolean has%3$s()\n" +
             "    {\n" +
             "        return %1$sLength > 0;\n" +
@@ -539,6 +532,16 @@ public class EncoderGenerator extends Generator
             "        toBytes(value, %1$s);\n" +
             "        %1$sOffset = 0;\n" +
             "        %1$sLength = value.length();\n" +
+            "        return this;\n" +
+            "    }\n\n" +
+            "    public %3$s %1$s(final AsciiSequenceView value)\n" +
+            "    {\n" +
+            "        if (value.length() > 0)\n" +
+            "        {\n" +
+            "            %1$s.wrap(value.buffer());\n" +
+            "            %1$sOffset = value.offset();\n" +
+            "            %1$sLength = value.length();\n" +
+            "        }\n" +
             "        return this;\n" +
             "    }\n\n" +
             "    public %3$s %1$s(final char[] value)\n" +

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -117,6 +117,32 @@ public class EncoderGeneratorTest
     }
 
     @Test
+    public void shouldNotWriteDataForEmptyCharSequence() throws Exception
+    {
+        final Object encoder = heartbeat.getConstructor().newInstance();
+
+        setTestReqIdTo(encoder, "");
+
+        assertArrayEquals(new byte[0], getTestReqIdBytes(encoder));
+        assertTestReqIdOffset(0, encoder);
+        assertTestReqIdLength(0, encoder);
+    }
+
+    @Test
+    public void shouldNotWriteDataForEmptyAsciiSequenceView() throws Exception
+    {
+        final Object encoder = heartbeat.getConstructor().newInstance();
+
+        heartbeat
+                .getMethod(TEST_REQ_ID, AsciiSequenceView.class)
+                .invoke(encoder, new AsciiSequenceView());
+
+        assertArrayEquals(new byte[0], getTestReqIdBytes(encoder));
+        assertTestReqIdOffset(0, encoder);
+        assertTestReqIdLength(0, encoder);
+    }
+
+    @Test
     public void stringSettersResizeByteArray() throws Exception
     {
         final Encoder encoder = newHeartbeat();


### PR DESCRIPTION


This keeps the functionality inline with what currently happens for
encoding a Charsequence, where an empty charsequence is just ignored