### PR TITLE
System property for configuring enum values

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/builder/RejectUnknownEnumValue.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/builder/RejectUnknownEnumValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.builder;
+
+public final class RejectUnknownEnumValue
+{
+    private static final String CODEC_DISABLE_REJECT_UNKNOWN_ENUM_VALUE_PROP =
+        "fix.codecs.disable_reject_unknown_enum_value";
+    private static final boolean CODEC_DISABLE_REJECT_UNKNOWN_ENUM_VALUE_ENABLED =
+        Boolean.getBoolean(CODEC_DISABLE_REJECT_UNKNOWN_ENUM_VALUE_PROP);
+    public static final boolean CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED =
+        !CODEC_DISABLE_REJECT_UNKNOWN_ENUM_VALUE_ENABLED;
+}

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
@@ -16,6 +16,9 @@
 package uk.co.real_logic.artio.dictionary;
 
 import org.agrona.generation.PackageOutputManager;
+
+
+import uk.co.real_logic.artio.builder.RejectUnknownEnumValue;
 import uk.co.real_logic.artio.builder.RejectUnknownField;
 import uk.co.real_logic.artio.builder.Validation;
 import uk.co.real_logic.artio.dictionary.generation.*;
@@ -64,7 +67,8 @@ public final class CodecGenerationTool
             PARENT_PACKAGE,
             encoderOutput,
             Validation.class,
-            RejectUnknownField.class);
+            RejectUnknownField.class,
+            RejectUnknownEnumValue.class);
 
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             dictionary,
@@ -74,6 +78,7 @@ public final class CodecGenerationTool
             decoderOutput,
             Validation.class,
             RejectUnknownField.class,
+            RejectUnknownEnumValue.class,
             false);
         final PrinterGenerator printerGenerator = new PrinterGenerator(dictionary, DECODER_PACKAGE, decoderOutput);
         final AcceptorGenerator acceptorGenerator = new AcceptorGenerator(dictionary, DECODER_PACKAGE, decoderOutput);
@@ -100,6 +105,7 @@ public final class CodecGenerationTool
                 flyweightDecoderOutput,
                 Validation.class,
                 RejectUnknownField.class,
+                RejectUnknownEnumValue.class,
                 true);
 
             flyweightDecoderGenerator.generate();

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -464,7 +464,7 @@ public class DecoderGenerator extends Generator
         final boolean isPrimitive = type.isIntBased() || type == Type.CHAR;
 
         final String enumValidation = String.format(
-            "        if (!%1$s.isValid(%2$s%4$s))\n" +
+            "        if (!%1$s.isValid(%2$s%4$s) && " + CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED + ")\n" +
             "        {\n" +
             "            invalidTagId = %3$s;\n" +
             "            rejectReason = " + VALUE_IS_INCORRECT + ";\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -100,11 +100,12 @@ public class DecoderGenerator extends Generator
         final String commonPackage,
         final OutputManager outputManager,
         final Class<?> validationClass,
-        final Class<?> rejectUnknownClass,
+        final Class<?> rejectUnknownFieldClass,
+        final Class<?> rejectUnknownEnumValueClass,
         final boolean flyweightsEnabled)
     {
-        super(dictionary, thisPackage, commonPackage, outputManager, validationClass, rejectUnknownClass,
-            flyweightsEnabled);
+        super(dictionary, thisPackage, commonPackage, outputManager, validationClass, rejectUnknownFieldClass,
+            rejectUnknownEnumValueClass, flyweightsEnabled);
         this.initialBufferSize = initialBufferSize;
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -464,7 +464,7 @@ public class DecoderGenerator extends Generator
         final boolean isPrimitive = type.isIntBased() || type == Type.CHAR;
 
         final String enumValidation = String.format(
-            "        if (!%1$s.isValid(%2$s%4$s) && " + CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED + ")\n" +
+            "        if (" + CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED + " && !%1$s.isValid(%2$s%4$s))\n" +
             "        {\n" +
             "            invalidTagId = %3$s;\n" +
             "            rejectReason = " + VALUE_IS_INCORRECT + ";\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -155,10 +155,11 @@ public class EncoderGenerator extends Generator
         final String builderCommonPackage,
         final OutputManager outputManager,
         final Class<?> validationClass,
-        final Class<?> rejectUnknownClass)
+        final Class<?> rejectUnknownFieldClass,
+        final Class<?> rejectUnknownEnumValueClass)
     {
-        super(dictionary, builderPackage, builderCommonPackage, outputManager, validationClass, rejectUnknownClass,
-            false);
+        super(dictionary, builderPackage, builderCommonPackage, outputManager, validationClass, rejectUnknownFieldClass,
+            rejectUnknownEnumValueClass, false);
 
         final Component header = dictionary.header();
         validateHasField(header, BEGIN_STRING);

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -55,6 +55,7 @@ public abstract class Generator
     public static final String EXPAND_INDENT = ".toString().replace(\"\\n\", \"\\n  \")";
     public static final String CODEC_VALIDATION_ENABLED = "CODEC_VALIDATION_ENABLED";
     public static final String CODEC_REJECT_UNKNOWN_FIELD_ENABLED = "CODEC_REJECT_UNKNOWN_FIELD_ENABLED";
+    public static final String CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED = "CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED";
     public static final String MESSAGE_FIELDS = "messageFields";
 
     protected String commonCompoundImports(final String form, final boolean headerWrapsTrailer,
@@ -88,7 +89,8 @@ public abstract class Generator
     private String builderCommonPackage;
     protected final OutputManager outputManager;
     protected final Class<?> validationClass;
-    protected final Class<?> rejectUnknownClass;
+    protected final Class<?> rejectUnknownFieldClass;
+    private final Class<?> rejectUnknownEnumValueClass;
     protected final boolean flyweightsEnabled;
 
     protected Generator(
@@ -97,7 +99,8 @@ public abstract class Generator
         final String commonPackage,
         final OutputManager outputManager,
         final Class<?> validationClass,
-        final Class<?> rejectUnknownClass,
+        final Class<?> rejectUnknownFieldClass,
+        final Class<?> rejectUnknownEnumValueClass,
         final boolean flyweightsEnabled)
     {
         this.dictionary = dictionary;
@@ -105,7 +108,8 @@ public abstract class Generator
         this.builderCommonPackage = commonPackage;
         this.outputManager = outputManager;
         this.validationClass = validationClass;
-        this.rejectUnknownClass = rejectUnknownClass;
+        this.rejectUnknownFieldClass = rejectUnknownFieldClass;
+        this.rejectUnknownEnumValueClass = rejectUnknownEnumValueClass;
         this.flyweightsEnabled = flyweightsEnabled;
     }
 
@@ -160,7 +164,8 @@ public abstract class Generator
 
         out .append(importStaticFor(StandardCharsets.class, "US_ASCII"))
             .append(importStaticFor(validationClass, CODEC_VALIDATION_ENABLED))
-            .append(importStaticFor(rejectUnknownClass, CODEC_REJECT_UNKNOWN_FIELD_ENABLED));
+            .append(importStaticFor(rejectUnknownFieldClass, CODEC_REJECT_UNKNOWN_FIELD_ENABLED))
+            .append(importStaticFor(rejectUnknownEnumValueClass, CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED));
 
         if (!builderPackage.equals(builderCommonPackage) && !builderCommonPackage.isEmpty())
         {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -786,6 +786,8 @@ public abstract class AbstractDecoderGeneratorTest
         final Decoder decoder = decodeHeartbeatWithoutEnumValue(TAG_SPECIFIED_WHERE_INT_VALUE_IS_INCORRECT_MESSAGE);
 
         assertTrue("Should be no validation for incorrect enum value", decoder.validate());
+        final Object intFieldEnum = get(decoder, "intFieldAsEnum");
+        assertEquals(ENUM_UNKNOWN_INT, getRepresentation(intFieldEnum));
     }
 
     @Test
@@ -794,6 +796,8 @@ public abstract class AbstractDecoderGeneratorTest
         final Decoder decoder = decodeHeartbeatWithoutEnumValue(TAG_SPECIFIED_WHERE_STRING_VALUE_IS_INCORRECT_MESSAGE);
 
         assertTrue("Should be no validation for incorrect enum value", decoder.validate());
+        final Object onBehalfEnum = get(decoder, "onBehalfOfCompIDAsEnum");
+        assertEquals(ENUM_UNKNOWN_STRING, getRepresentation(onBehalfEnum));
     }
 
     @Test

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractDecoderGeneratorTest
     private static final String STRING_ENUM_REQ = "stringEnumReq";
 
     private static Class<?> heartbeatWithoutValidation;
+    private static Class<?> heartbeatWithoutEnumValueValidation;
     private static Class<?> heartbeatWithRejectingUnknownFields;
     private static Class<?> heartbeat;
     private static Class<?> component;
@@ -79,6 +80,8 @@ public abstract class AbstractDecoderGeneratorTest
     {
         final Map<String, CharSequence> sourcesWithValidation = generateSources(
             true, false, true, flyweightStringsEnabled);
+        final Map<String, CharSequence> sourcesWithNoEnumValueValidation = generateSources(
+            true, false, false, flyweightStringsEnabled);
         final Map<String, CharSequence> sourcesWithoutValidation = generateSources(
             false, false, true, flyweightStringsEnabled);
         final Map<String, CharSequence> sourcesRejectingUnknownFields = generateSources(
@@ -95,6 +98,7 @@ public abstract class AbstractDecoderGeneratorTest
         enumTestMessage = compileInMemory(ENUM_TEST_MESSAGE_DECODER, sourcesWithValidation);
 
         heartbeatWithoutValidation = compileInMemory(HEARTBEAT_DECODER, sourcesWithoutValidation);
+        heartbeatWithoutEnumValueValidation = compileInMemory(HEARTBEAT_DECODER, sourcesWithNoEnumValueValidation);
         heartbeatWithRejectingUnknownFields = compileInMemory(HEARTBEAT_DECODER, sourcesRejectingUnknownFields);
         allReqFieldTypesMessage = compileInMemory(ALL_REQ_FIELD_TYPES_MESSAGE_DECODER, sourcesWithoutValidation);
         if (heartbeatWithoutValidation == null || CODEC_LOGGING)
@@ -764,6 +768,32 @@ public abstract class AbstractDecoderGeneratorTest
         assertFalse("Passed validation with incorrect value", decoder.validate());
         assertEquals("Wrong tag id", 115, decoder.invalidTagId());
         assertEquals("Wrong reject reason", VALUE_IS_INCORRECT, decoder.rejectReason());
+    }
+
+    @Test
+    public void shouldValidateEnumMissingValueIfEnumValidationDisabled() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeatWithoutEnumValue(TAG_SPECIFIED_WITHOUT_A_VALUE_MESSAGE);
+
+        assertFalse("Passed validation with missing value", decoder.validate());
+        assertEquals("Wrong tag id", 116, decoder.invalidTagId());
+        assertEquals("Wrong reject reason", TAG_SPECIFIED_WITHOUT_A_VALUE, decoder.rejectReason());
+    }
+
+    @Test
+    public void shouldNotValidateIntBasedEnumIfDisabled() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeatWithoutEnumValue(TAG_SPECIFIED_WHERE_INT_VALUE_IS_INCORRECT_MESSAGE);
+
+        assertTrue("Should be no validation for incorrect enum value", decoder.validate());
+    }
+
+    @Test
+    public void shouldValidateStringBasedEnumIfDisabled() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeatWithoutEnumValue(TAG_SPECIFIED_WHERE_STRING_VALUE_IS_INCORRECT_MESSAGE);
+
+        assertTrue("Should be no validation for incorrect enum value", decoder.validate());
     }
 
     @Test
@@ -1542,6 +1572,13 @@ public abstract class AbstractDecoderGeneratorTest
     private Decoder decodeHeartbeat(final String example) throws Exception
     {
         final Decoder decoder = (Decoder)heartbeat.getConstructor().newInstance();
+        decode(example, decoder);
+        return decoder;
+    }
+
+    private Decoder decodeHeartbeatWithoutEnumValue(final String example) throws Exception
+    {
+        final Decoder decoder = (Decoder)heartbeatWithoutEnumValueValidation.getConstructor().newInstance();
         decode(example, decoder);
         return decoder;
     }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -78,11 +78,11 @@ public abstract class AbstractDecoderGeneratorTest
     static void generate(final boolean flyweightStringsEnabled) throws Exception
     {
         final Map<String, CharSequence> sourcesWithValidation = generateSources(
-            true, false, flyweightStringsEnabled);
+            true, false, true, flyweightStringsEnabled);
         final Map<String, CharSequence> sourcesWithoutValidation = generateSources(
-            false, false, flyweightStringsEnabled);
+            false, false, true, flyweightStringsEnabled);
         final Map<String, CharSequence> sourcesRejectingUnknownFields = generateSources(
-            true, true, flyweightStringsEnabled);
+            true, true, true, flyweightStringsEnabled);
         heartbeat = compileInMemory(HEARTBEAT_DECODER, sourcesWithValidation);
         if (heartbeat == null || CODEC_LOGGING)
         {
@@ -104,18 +104,21 @@ public abstract class AbstractDecoderGeneratorTest
     }
 
     static Map<String, CharSequence> generateSources(
-        final boolean validation, final boolean rejectingUnknownFields, final boolean flyweightStringsEnabled)
+        final boolean validation, final boolean rejectingUnknownFields, final boolean rejectingUnknownEnumValue,
+        final boolean flyweightStringsEnabled)
     {
         final Class<?> validationClass = validation ? ValidationOn.class : ValidationOff.class;
         final Class<?> rejectUnknownField = rejectingUnknownFields ?
             RejectUnknownFieldOn.class : RejectUnknownFieldOff.class;
+        final Class<?> rejectUnknownEnumValue = rejectingUnknownEnumValue ?
+            RejectUnknownEnumValueOn.class : RejectUnknownEnumValueOff.class;
         final StringWriterOutputManager outputManager = new StringWriterOutputManager();
         final ConstantGenerator constantGenerator = new ConstantGenerator(
             MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
         final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass, rejectUnknownField,
-            flyweightStringsEnabled);
+            rejectUnknownEnumValue, flyweightStringsEnabled);
 
         constantGenerator.generate();
         enumGenerator.generate();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
@@ -39,7 +39,7 @@ public class AcceptorGeneratorTest
         new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class,
-        RejectUnknownFieldOff.class, false);
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false);
     private static AcceptorGenerator acceptorGenerator =
         new AcceptorGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> acceptor;

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -76,11 +76,12 @@ public class EncoderGeneratorTest
     {
         final Class<?> validationClass = validation ? ValidationOn.class : ValidationOff.class;
         final Class<?> rejectUnknownField = RejectUnknownFieldOff.class;
+        final Class<?> rejectUnknownEnumValue = RejectUnknownEnumValueOn.class;
         final StringWriterOutputManager outputManager = new StringWriterOutputManager();
         final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final EncoderGenerator encoderGenerator =
             new EncoderGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass,
-            rejectUnknownField);
+            rejectUnknownField, rejectUnknownEnumValue);
         enumGenerator.generate();
         encoderGenerator.generate();
         return outputManager.getSources();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
@@ -39,7 +39,7 @@ public class PrinterGeneratorTest
 
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class,
-        RejectUnknownFieldOff.class, false);
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false);
     private static PrinterGenerator printerGenerator =
         new PrinterGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> printer;

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/RejectUnknownEnumValueOff.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/RejectUnknownEnumValueOff.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.dictionary.generation;
+
+public final class RejectUnknownEnumValueOff
+{
+    public static final boolean CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED = false;
+}

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/RejectUnknownEnumValueOn.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/RejectUnknownEnumValueOn.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.dictionary.generation;
+
+public final class RejectUnknownEnumValueOn
+{
+    public static final boolean CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED = true;
+}


### PR DESCRIPTION
Use the fix.codecs.disable_reject_unknown_enum_value system property
to disable enum value validation. This maintains the default behaviour
of rejecting if an unknown enum value is received but now gives the
option of to opt out of this.

We've found that venues will add new enum values without warning,
which we don't want to reject on. If we don't support the enum value
then we can just ignore it rather than rejecting the whole
fix message