### PR TITLE
allow compile time alternative for RejectUnknownEnumValue

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
@@ -67,6 +67,12 @@ public final class CodecGenerationTool
             DECODER_PACKAGE,
             PARENT_PACKAGE);
 
+        final boolean newMode = false;
+        final String newModeValue = "true";
+        final String codecRejectUnknownEnumValueEnabled;
+
+        codecRejectUnknownEnumValueEnabled = fetchRejectionMode(newMode, newModeValue);
+
         final EncoderGenerator encoderGenerator = new EncoderGenerator(
             dictionary,
             ENCODER_PACKAGE,
@@ -74,7 +80,8 @@ public final class CodecGenerationTool
             encoderOutput,
             Validation.class,
             RejectUnknownField.class,
-            RejectUnknownEnumValue.class);
+            RejectUnknownEnumValue.class,
+            codecRejectUnknownEnumValueEnabled);
 
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             dictionary,
@@ -85,7 +92,8 @@ public final class CodecGenerationTool
             Validation.class,
             RejectUnknownField.class,
             RejectUnknownEnumValue.class,
-            false);
+            false,
+            codecRejectUnknownEnumValueEnabled);
         final PrinterGenerator printerGenerator = new PrinterGenerator(dictionary, DECODER_PACKAGE, decoderOutput);
         final AcceptorGenerator acceptorGenerator = new AcceptorGenerator(dictionary, DECODER_PACKAGE, decoderOutput);
 
@@ -113,10 +121,25 @@ public final class CodecGenerationTool
                 Validation.class,
                 RejectUnknownField.class,
                 RejectUnknownEnumValue.class,
-                true);
+                true,
+                codecRejectUnknownEnumValueEnabled);
 
             flyweightDecoderGenerator.generate();
         }
+    }
+
+    private static String fetchRejectionMode(final boolean newMode, final String newModeValue)
+    {
+        final String codecRejectUnknownEnumValueEnabled;
+        if (newMode)
+        {
+            codecRejectUnknownEnumValueEnabled = newModeValue;
+        }
+        else
+        {
+            codecRejectUnknownEnumValueEnabled = Generator.ENUM_VALUE_PROPERTY;
+        }
+        return codecRejectUnknownEnumValueEnabled;
     }
 
     private static Dictionary parseDictionary(final File xmlFile, final Dictionary parentDictionary) throws Exception

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/CodecGenerationTool.java
@@ -60,18 +60,15 @@ public final class CodecGenerationTool
         final EnumGenerator enumGenerator = new EnumGenerator(dictionary, PARENT_PACKAGE, parentOutput);
         final ConstantGenerator constantGenerator = new ConstantGenerator(dictionary, PARENT_PACKAGE, parentOutput);
 
+        final String codecRejectUnknownEnumValueEnabled = HARD_CODED_REJECT_UNKNOWN_EMUM_VALUES
+            .map(String::valueOf)
+            .orElse(Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
         final FixDictionaryGenerator fixDictionaryGenerator = new FixDictionaryGenerator(
             dictionary,
             parentOutput,
             ENCODER_PACKAGE,
             DECODER_PACKAGE,
             PARENT_PACKAGE);
-
-        final boolean newMode = false;
-        final String newModeValue = "true";
-        final String codecRejectUnknownEnumValueEnabled;
-
-        codecRejectUnknownEnumValueEnabled = fetchRejectionMode(newMode, newModeValue);
 
         final EncoderGenerator encoderGenerator = new EncoderGenerator(
             dictionary,
@@ -126,20 +123,6 @@ public final class CodecGenerationTool
 
             flyweightDecoderGenerator.generate();
         }
-    }
-
-    private static String fetchRejectionMode(final boolean newMode, final String newModeValue)
-    {
-        final String codecRejectUnknownEnumValueEnabled;
-        if (newMode)
-        {
-            codecRejectUnknownEnumValueEnabled = newModeValue;
-        }
-        else
-        {
-            codecRejectUnknownEnumValueEnabled = Generator.ENUM_VALUE_PROPERTY;
-        }
-        return codecRejectUnknownEnumValueEnabled;
     }
 
     private static Dictionary parseDictionary(final File xmlFile, final Dictionary parentDictionary) throws Exception

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -113,10 +113,11 @@ public class DecoderGenerator extends Generator
         final Class<?> validationClass,
         final Class<?> rejectUnknownFieldClass,
         final Class<?> rejectUnknownEnumValueClass,
-        final boolean flyweightsEnabled)
+        final boolean flyweightsEnabled,
+        final String codecRejectUnknownEnumValueEnabled)
     {
         super(dictionary, thisPackage, commonPackage, outputManager, validationClass, rejectUnknownFieldClass,
-            rejectUnknownEnumValueClass, flyweightsEnabled);
+            rejectUnknownEnumValueClass, flyweightsEnabled, codecRejectUnknownEnumValueEnabled);
         this.initialBufferSize = initialBufferSize;
     }
 
@@ -496,7 +497,7 @@ public class DecoderGenerator extends Generator
         final boolean isPrimitive = type.isIntBased() || type == Type.CHAR;
 
         final String enumValidation = String.format(
-            "        if (" + CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED + " && !%1$s.isValid(%2$s%4$s))\n" +
+            "        if (" + codecRejectUnknownEnumValueEnabled + " && !%1$s.isValid(%2$s%4$s))\n" +
             "        {\n" +
             "            invalidTagId = %3$s;\n" +
             "            rejectReason = " + VALUE_IS_INCORRECT + ";\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -169,10 +169,11 @@ public class EncoderGenerator extends Generator
         final OutputManager outputManager,
         final Class<?> validationClass,
         final Class<?> rejectUnknownFieldClass,
-        final Class<?> rejectUnknownEnumValueClass)
+        final Class<?> rejectUnknownEnumValueClass,
+        final String codecRejectUnknownEnumValueEnabled)
     {
         super(dictionary, builderPackage, builderCommonPackage, outputManager, validationClass, rejectUnknownFieldClass,
-            rejectUnknownEnumValueClass, false);
+            rejectUnknownEnumValueClass, false, codecRejectUnknownEnumValueEnabled);
 
         final Component header = dictionary.header();
         validateHasField(header, BEGIN_STRING);

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -17,6 +17,7 @@ package uk.co.real_logic.artio.dictionary.generation;
 
 import org.agrona.Verify;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.Character.isUpperCase;
@@ -30,6 +31,9 @@ public final class GenerationUtil
     public static final String PARENT_PACKAGE =
         System.getProperty("fix.codecs.parent_package", "uk.co.real_logic.artio");
     public static final boolean FLYWEIGHTS_ENABLED = Boolean.getBoolean("fix.codecs.flyweight");
+    public static final Optional<Boolean> HARD_CODED_REJECT_UNKNOWN_EMUM_VALUES =
+        Optional.ofNullable(System.getProperty("reject.unknown.enum.value"))
+        .map(Boolean::parseBoolean);
 
     public static final String ENCODER_PACKAGE = PARENT_PACKAGE + ".builder";
     public static final String DECODER_PACKAGE = PARENT_PACKAGE + ".decoder";

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -56,7 +56,8 @@ public abstract class Generator
     public static final String EXPAND_INDENT = ".toString().replace(\"\\n\", \"\\n  \")";
     public static final String CODEC_VALIDATION_ENABLED = "CODEC_VALIDATION_ENABLED";
     public static final String CODEC_REJECT_UNKNOWN_FIELD_ENABLED = "CODEC_REJECT_UNKNOWN_FIELD_ENABLED";
-    public static final String CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED = "CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED";
+    public static final String ENUM_VALUE_PROPERTY = "CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED";
+    final String codecRejectUnknownEnumValueEnabled;
     public static final String MESSAGE_FIELDS = "messageFields";
 
     protected String commonCompoundImports(final String form, final boolean headerWrapsTrailer,
@@ -102,7 +103,8 @@ public abstract class Generator
         final Class<?> validationClass,
         final Class<?> rejectUnknownFieldClass,
         final Class<?> rejectUnknownEnumValueClass,
-        final boolean flyweightsEnabled)
+        final boolean flyweightsEnabled,
+        final String codecRejectUnknownEnumValueEnabled)
     {
         this.dictionary = dictionary;
         this.builderPackage = thisPackage;
@@ -112,6 +114,7 @@ public abstract class Generator
         this.rejectUnknownFieldClass = rejectUnknownFieldClass;
         this.rejectUnknownEnumValueClass = rejectUnknownEnumValueClass;
         this.flyweightsEnabled = flyweightsEnabled;
+        this.codecRejectUnknownEnumValueEnabled = codecRejectUnknownEnumValueEnabled;
     }
 
     public void generate()
@@ -166,7 +169,7 @@ public abstract class Generator
         out .append(importStaticFor(StandardCharsets.class, "US_ASCII"))
             .append(importStaticFor(validationClass, CODEC_VALIDATION_ENABLED))
             .append(importStaticFor(rejectUnknownFieldClass, CODEC_REJECT_UNKNOWN_FIELD_ENABLED))
-            .append(importStaticFor(rejectUnknownEnumValueClass, CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED));
+            .append(importStaticFor(rejectUnknownEnumValueClass, ENUM_VALUE_PROPERTY));
 
         if (!builderPackage.equals(builderCommonPackage) && !builderCommonPackage.isEmpty())
         {

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -56,7 +56,7 @@ public abstract class Generator
     public static final String EXPAND_INDENT = ".toString().replace(\"\\n\", \"\\n  \")";
     public static final String CODEC_VALIDATION_ENABLED = "CODEC_VALIDATION_ENABLED";
     public static final String CODEC_REJECT_UNKNOWN_FIELD_ENABLED = "CODEC_REJECT_UNKNOWN_FIELD_ENABLED";
-    public static final String ENUM_VALUE_PROPERTY = "CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED";
+    public static final String RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY = "CODEC_REJECT_UNKNOWN_ENUM_VALUE_ENABLED";
     final String codecRejectUnknownEnumValueEnabled;
     public static final String MESSAGE_FIELDS = "messageFields";
 
@@ -169,7 +169,7 @@ public abstract class Generator
         out .append(importStaticFor(StandardCharsets.class, "US_ASCII"))
             .append(importStaticFor(validationClass, CODEC_VALIDATION_ENABLED))
             .append(importStaticFor(rejectUnknownFieldClass, CODEC_REJECT_UNKNOWN_FIELD_ENABLED))
-            .append(importStaticFor(rejectUnknownEnumValueClass, ENUM_VALUE_PROPERTY));
+            .append(importStaticFor(rejectUnknownEnumValueClass, RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY));
 
         if (!builderPackage.equals(builderCommonPackage) && !builderCommonPackage.isEmpty())
         {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractDecoderGeneratorTest
         final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass, rejectUnknownField,
-            rejectUnknownEnumValue, flyweightStringsEnabled, Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
+            rejectUnknownEnumValue, flyweightStringsEnabled, String.valueOf(rejectingUnknownEnumValue));
 
         constantGenerator.generate();
         enumGenerator.generate();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractDecoderGeneratorTest
         final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass, rejectUnknownField,
-            rejectUnknownEnumValue, flyweightStringsEnabled, Generator.ENUM_VALUE_PROPERTY);
+            rejectUnknownEnumValue, flyweightStringsEnabled, Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
 
         constantGenerator.generate();
         enumGenerator.generate();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractDecoderGeneratorTest
         final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass, rejectUnknownField,
-            rejectUnknownEnumValue, flyweightStringsEnabled);
+            rejectUnknownEnumValue, flyweightStringsEnabled, Generator.ENUM_VALUE_PROPERTY);
 
         constantGenerator.generate();
         enumGenerator.generate();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -108,7 +108,7 @@ public abstract class AbstractDecoderGeneratorTest
         }
     }
 
-    static Map<String, CharSequence> generateSources(
+    private static Map<String, CharSequence> generateSources(
         final boolean validation, final boolean rejectingUnknownFields, final boolean rejectingUnknownEnumValue,
         final boolean flyweightStringsEnabled)
     {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
@@ -39,7 +39,8 @@ public class AcceptorGeneratorTest
         new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class,
-        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false, Generator.ENUM_VALUE_PROPERTY);
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false,
+        Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
     private static AcceptorGenerator acceptorGenerator =
         new AcceptorGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> acceptor;

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
@@ -39,7 +39,7 @@ public class AcceptorGeneratorTest
         new EnumGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class,
-        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false);
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false, Generator.ENUM_VALUE_PROPERTY);
     private static AcceptorGenerator acceptorGenerator =
         new AcceptorGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> acceptor;

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -79,7 +79,7 @@ public class EncoderGeneratorTest
         final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final EncoderGenerator encoderGenerator =
             new EncoderGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass,
-            rejectUnknownField, rejectUnknownEnumValue);
+            rejectUnknownField, rejectUnknownEnumValue, Generator.ENUM_VALUE_PROPERTY);
         enumGenerator.generate();
         encoderGenerator.generate();
         return outputManager.getSources();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -79,7 +79,7 @@ public class EncoderGeneratorTest
         final EnumGenerator enumGenerator = new EnumGenerator(MESSAGE_EXAMPLE, TEST_PARENT_PACKAGE, outputManager);
         final EncoderGenerator encoderGenerator =
             new EncoderGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, validationClass,
-            rejectUnknownField, rejectUnknownEnumValue, Generator.ENUM_VALUE_PROPERTY);
+            rejectUnknownField, rejectUnknownEnumValue, Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
         enumGenerator.generate();
         encoderGenerator.generate();
         return outputManager.getSources();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
@@ -39,7 +39,7 @@ public class PrinterGeneratorTest
 
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class,
-        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false);
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false, Generator.ENUM_VALUE_PROPERTY);
     private static PrinterGenerator printerGenerator =
         new PrinterGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> printer;

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
@@ -39,7 +39,8 @@ public class PrinterGeneratorTest
 
     private static DecoderGenerator decoderGenerator =
         new DecoderGenerator(MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, outputManager, ValidationOn.class,
-        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false, Generator.ENUM_VALUE_PROPERTY);
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false,
+        Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
     private static PrinterGenerator printerGenerator =
         new PrinterGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE, outputManager);
     private static Class<?> printer;


### PR DESCRIPTION
after recent discussion on gitter, we modified the code generator to support an alternative to RejectUnknownEnumValue.CODEC_DISABLE_REJECT_UNKNOWN_ENUM_VALUE_PROP ("fix.codecs.disable_reject_unknown_enum_value").  Providing a boolean value to -Dreject.unknown.enum.value when running the code generator will use that value (resulting in an if (true) / if (false) in the generated code rather than if (CODEC_DISABLE_REJECT_UNKNOWN_ENUM_VALUE_PROP). This allows for compile time configuration without deprecating the old configuration style. Happy to apply this to other configuration if you like this approach.

n.b. we had issues running the fix integration tests locally (with and without our changes), but we've integrated the branch with our code at TransFICC and our tests are passing.

Thanks,

Tom / Stef