### PR TITLE
Allow Message Types of up to 5 chars

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/SessionConstants.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/SessionConstants.java
@@ -15,6 +15,8 @@
  */
 package uk.co.real_logic.artio.dictionary;
 
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.packMessageType;
+
 public final class SessionConstants
 {
     public static final byte START_OF_HEADER = 0x01;
@@ -40,17 +42,6 @@ public final class SessionConstants
     public static final int PASSWORD = 554;
     public static final int NEW_PASSWORD = 925;
 
-
-    public static final int LOGON_MESSAGE_TYPE = 65;
-    public static final int HEARTBEAT_MESSAGE_TYPE = 48;
-    public static final int TEST_REQUEST_MESSAGE_TYPE = 49;
-    public static final int RESEND_REQUEST_MESSAGE_TYPE = 50;
-    public static final int REJECT_MESSAGE_TYPE = 51;
-    public static final int SEQUENCE_RESET_MESSAGE_TYPE = 52;
-    public static final int LOGOUT_MESSAGE_TYPE = 53;
-
-    public static final int USER_REQUEST_MESSAGE_TYPE = 17730;
-
     public static final String LOGON_MESSAGE_TYPE_STR = "A";
     public static final String HEARTBEAT_MESSAGE_TYPE_STR = "0";
     public static final String TEST_REQUEST_MESSAGE_TYPE_STR = "1";
@@ -58,6 +49,17 @@ public final class SessionConstants
     public static final String REJECT_MESSAGE_TYPE_STR = "3";
     public static final String SEQUENCE_RESET_TYPE_STR = "4";
     public static final String LOGOUT_MESSAGE_TYPE_STR = "5";
+    public static final String USER_REQUEST_MESSAGE_TYPE_STR = "BE";
+
+    public static final int LOGON_MESSAGE_TYPE = packMessageType(LOGON_MESSAGE_TYPE_STR);
+    public static final int HEARTBEAT_MESSAGE_TYPE = packMessageType(HEARTBEAT_MESSAGE_TYPE_STR);
+    public static final int TEST_REQUEST_MESSAGE_TYPE = packMessageType(TEST_REQUEST_MESSAGE_TYPE_STR);
+    public static final int RESEND_REQUEST_MESSAGE_TYPE = packMessageType(RESEND_REQUEST_MESSAGE_TYPE_STR);
+    public static final int REJECT_MESSAGE_TYPE = packMessageType(REJECT_MESSAGE_TYPE_STR);
+    public static final int SEQUENCE_RESET_MESSAGE_TYPE = packMessageType(SEQUENCE_RESET_TYPE_STR);
+    public static final int LOGOUT_MESSAGE_TYPE = packMessageType(LOGOUT_MESSAGE_TYPE_STR);
+
+    public static final int USER_REQUEST_MESSAGE_TYPE = packMessageType(USER_REQUEST_MESSAGE_TYPE_STR);
 
     public static final char[] LOGON_MESSAGE_TYPE_CHARS = LOGON_MESSAGE_TYPE_STR.toCharArray();
     public static final char[] HEARTBEAT_MESSAGE_TYPE_CHARS = HEARTBEAT_MESSAGE_TYPE_STR.toCharArray();

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/ConstantGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/ConstantGenerator.java
@@ -112,7 +112,9 @@ public class ConstantGenerator
                 final int type = message.packedType();
                 final String constantName = GenerationUtil.constantName(message.name()) + "_MESSAGE";
                 final String stringConstantName = constantName + "_AS_STR";
-                return generateMessageTypeConstant(stringConstantName, type) + generateIntConstant(constantName, type);
+                final String messageTypeConstant = generateMessageTypeConstant(stringConstantName, message.fullType());
+                final String intConstant = generateIntConstant(constantName, type);
+                return messageTypeConstant + intConstant;
             })
             .collect(joining());
     }
@@ -132,22 +134,12 @@ public class ConstantGenerator
             .values();
     }
 
-    private String generateMessageTypeConstant(final String stringConstantName, final int messageType)
+    private String generateMessageTypeConstant(final String stringConstantName, final String messageType)
     {
-        final char[] chars;
-        if (messageType > Byte.MAX_VALUE)
-        {
-            chars = new char[]{ (char)(byte)messageType, (char)(byte)(messageType >>> 8) };
-        }
-        else
-        {
-            chars = new char[]{ (char)(byte)messageType };
-        }
-
         return String.format(
             "    public static final String %1$s = \"%2$s\";\n",
             stringConstantName,
-            new String(chars));
+            messageType);
     }
 
     private String generateIntConstant(final String name, final int number)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -15,10 +15,11 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
-import org.agrona.Verify;
-
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import org.agrona.Verify;
+
 
 import static java.lang.Character.isUpperCase;
 import static java.lang.Character.toUpperCase;
@@ -32,8 +33,7 @@ public final class GenerationUtil
         System.getProperty("fix.codecs.parent_package", "uk.co.real_logic.artio");
     public static final boolean FLYWEIGHTS_ENABLED = Boolean.getBoolean("fix.codecs.flyweight");
     public static final Optional<Boolean> HARD_CODED_REJECT_UNKNOWN_EMUM_VALUES =
-        Optional.ofNullable(System.getProperty("reject.unknown.enum.value"))
-        .map(Boolean::parseBoolean);
+        Optional.ofNullable(System.getProperty("reject.unknown.enum.value")).map(Boolean::parseBoolean);
 
     public static final String ENCODER_PACKAGE = PARENT_PACKAGE + ".builder";
     public static final String DECODER_PACKAGE = PARENT_PACKAGE + ".decoder";
@@ -47,12 +47,12 @@ public final class GenerationUtil
     public static String fileHeader(final String packageName)
     {
         return String.format(
-            "/* Generated Fix Gateway message codec */\n" +
-            "package %s;\n\n",
-            packageName);
+                "/* Generated Fix Gateway message codec */\n" +
+                "package %s;\n\n",
+                packageName);
     }
 
-    public static int packMessageType(final String representation)
+    public static int packMessageType(final CharSequence representation)
     {
         int packed = (byte)representation.charAt(0);
 
@@ -65,15 +65,49 @@ public final class GenerationUtil
         return packed;
     }
 
+    public static int packMessageType2(final CharSequence representation)
+    {
+        if (representation.length() > 8)
+        {
+            throw new IllegalArgumentException("Cannot support message types of size greater than 8");
+        }
+
+        int packed = getIntValue(representation, 0);
+        for (int index = 1; index < representation.length(); index++)
+        {
+            final int second = getIntValue(representation, index);
+            packed |= (second << (6 * index));
+        }
+        return packed;
+    }
+
+    private static int getIntValue(final CharSequence representation, final int i)
+    {
+        final byte originalValue = (byte)representation.charAt(i);
+        byte valueToReturn = originalValue;
+
+        valueToReturn -= 48;
+
+        if (originalValue >= 65)
+        {
+            valueToReturn -= 7;
+        }
+        if (originalValue >= 97)
+        {
+            valueToReturn -= 6;
+        }
+        return valueToReturn;
+    }
+
     public static String constantName(final String name)
     {
         final String replacedName = name.replace("ID", "Id")
             .replace("GroupCounter", "");
         return toUpperCase(replacedName.charAt(0)) + replacedName
-            .substring(1)
-            .chars()
-            .mapToObj((codePoint) -> (isUpperCase(codePoint) ? "_" : "") + (char)toUpperCase(codePoint))
-            .collect(joining());
+             .substring(1)
+             .chars()
+             .mapToObj((codePoint) -> (isUpperCase(codePoint) ? "_" : "") + (char)toUpperCase(codePoint))
+             .collect(joining());
     }
 
     public static class Var
@@ -123,8 +157,8 @@ public final class GenerationUtil
     public static String paramDeclaration(final Var[] parameters)
     {
         return Stream.of(parameters)
-            .map(Var::declaration)
-            .collect(joining(", "));
+                     .map(Var::declaration)
+                     .collect(joining(", "));
     }
 
     public static String importFor(final Class<?> cls)
@@ -152,9 +186,9 @@ public final class GenerationUtil
     public static String optionalStaticInit(final String containing)
     {
         return containing.isEmpty() ? "\n" :
-            "    static\n" +
-            "    {\n" +
-            containing +
-            "    }\n\n";
+               "    static\n" +
+               "    {\n" +
+               containing +
+               "    }\n\n";
     }
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -81,7 +81,7 @@ public final class GenerationUtil
                 packageName);
     }
 
-    public static int packMessageType(final CharSequence representation)
+    public static int packMessageType0(final CharSequence representation)
     {
         int packed = (byte)representation.charAt(0);
 
@@ -94,11 +94,11 @@ public final class GenerationUtil
         return packed;
     }
 
-    public static int packMessageType2(final CharSequence representation)
+    public static int packMessageType(final CharSequence representation)
     {
-        if (representation.length() > 8)
+        if (representation.length() > 5)
         {
-            throw new IllegalArgumentException("Cannot support message types of size greater than 8");
+            throw new IllegalArgumentException("Cannot support message types of size greater than 5");
         }
 
         int packed = getIntValue(representation, 0);

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -178,7 +178,7 @@ public final class GenerationUtil
     private static int[] generatePackingLookUpTable()
     {
         final int[] table = new int[123];
-        int value = 0;
+        int value = 1; //0 fails for message type '00'
         for (int c = 48; c <= 122; c++)
         {
             switch (c)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -38,34 +38,9 @@ public final class GenerationUtil
     public static final String DECODER_PACKAGE = PARENT_PACKAGE + ".decoder";
     public static final String DECODER_FLYWEIGHT_PACKAGE = PARENT_PACKAGE + ".decoder_flyweight";
     public static final String INDENT = "    ";
+    public static final int INVALID_MSG_TYPE = -1;
 
-    private static final int[] PACKING_LOOK_UP_TABLE = new int[123];
-
-    static
-    {
-        int value = 0;
-        for (int c = 48; c <= 122; c++)
-        {
-            switch (c)
-            {
-                case 58:
-                case 59:
-                case 60:
-                case 61:
-                case 62:
-                case 63:
-                case 64:
-                case 91:
-                case 92:
-                case 93:
-                case 94:
-                case 95:
-                case 96:
-                    continue;
-            }
-            PACKING_LOOK_UP_TABLE[c] = value++;
-        }
-    }
+    private static final int[] PACKING_LOOK_UP_TABLE = generatePackingLookUpTable();
 
     private GenerationUtil()
     {
@@ -87,12 +62,18 @@ public final class GenerationUtil
             throw new IllegalArgumentException("Cannot support message types of size greater than 5");
         }
 
-        int packed = getIntValue(representation, 0);
-        for (int index = 1; index < representation.length(); index++)
+        int packed = 0;
+
+        for (int index = 0; index < representation.length(); index++)
         {
+            if (!Character.isLetterOrDigit(representation.charAt(index)))
+            {
+                return INVALID_MSG_TYPE;
+            }
             final int second = getIntValue(representation, index);
             packed |= (second << (6 * index));
         }
+
         return packed;
     }
 
@@ -192,5 +173,33 @@ public final class GenerationUtil
                "    {\n" +
                containing +
                "    }\n\n";
+    }
+
+    private static int[] generatePackingLookUpTable()
+    {
+        final int[] table = new int[123];
+        int value = 0;
+        for (int c = 48; c <= 122; c++)
+        {
+            switch (c)
+            {
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                case 64:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                case 96:
+                    continue;
+            }
+            table[c] = value++;
+        }
+        return table;
     }
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -40,8 +40,37 @@ public final class GenerationUtil
     public static final String DECODER_FLYWEIGHT_PACKAGE = PARENT_PACKAGE + ".decoder_flyweight";
     public static final String INDENT = "    ";
 
+    private static final int[] PACKING_LOOK_UP_TABLE = new int[123];
+
+    static
+    {
+        int value = 0;
+        for (int c = 48; c <= 122; c++)
+        {
+            switch (c)
+            {
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                case 64:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                case 96:
+                    continue;
+            }
+            PACKING_LOOK_UP_TABLE[c] = value++;
+        }
+    }
+
     private GenerationUtil()
     {
+
     }
 
     public static String fileHeader(final String packageName)
@@ -81,22 +110,9 @@ public final class GenerationUtil
         return packed;
     }
 
-    private static int getIntValue(final CharSequence representation, final int i)
+    private static int getIntValue(final CharSequence representation, final int index)
     {
-        final byte originalValue = (byte)representation.charAt(i);
-        byte valueToReturn = originalValue;
-
-        valueToReturn -= 48;
-
-        if (originalValue >= 65)
-        {
-            valueToReturn -= 7;
-        }
-        if (originalValue >= 97)
-        {
-            valueToReturn -= 6;
-        }
-        return valueToReturn;
+        return PACKING_LOOK_UP_TABLE[representation.charAt(index)];
     }
 
     public static String constantName(final String name)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -27,7 +27,6 @@ import static java.util.stream.Collectors.joining;
 
 public final class GenerationUtil
 {
-    private static final int MESSAGE_TYPE_BITSHIFT = 8;
 
     public static final String PARENT_PACKAGE =
         System.getProperty("fix.codecs.parent_package", "uk.co.real_logic.artio");
@@ -79,19 +78,6 @@ public final class GenerationUtil
                 "/* Generated Fix Gateway message codec */\n" +
                 "package %s;\n\n",
                 packageName);
-    }
-
-    public static int packMessageType0(final CharSequence representation)
-    {
-        int packed = (byte)representation.charAt(0);
-
-        if (representation.length() == 2)
-        {
-            final int second = (int)representation.charAt(1);
-            packed |= second << MESSAGE_TYPE_BITSHIFT;
-        }
-
-        return packed;
     }
 
     public static int packMessageType(final CharSequence representation)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -55,23 +55,23 @@ public final class GenerationUtil
                 packageName);
     }
 
-    public static int packMessageType(final CharSequence representation)
+    public static int packMessageType(final CharSequence messageType)
     {
-        if (representation.length() > 5)
+        if (messageType.length() > 5)
         {
             throw new IllegalArgumentException("Cannot support message types of size greater than 5");
         }
 
         int packed = 0;
 
-        for (int index = 0; index < representation.length(); index++)
+        for (int index = 0; index < messageType.length(); index++)
         {
-            if (!Character.isLetterOrDigit(representation.charAt(index)))
+            if (!Character.isLetterOrDigit(messageType.charAt(index)))
             {
                 return INVALID_MSG_TYPE;
             }
-            final int second = getIntValue(representation, index);
-            packed |= (second << (6 * index));
+            final int intRepresentationOfChar = getIntValue(messageType, index);
+            packed |= (intRepresentationOfChar << (6 * index));
         }
 
         return packed;

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
@@ -38,6 +38,8 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
     private static final byte[] MIN_INTEGER_VALUE = String.valueOf(Integer.MIN_VALUE).getBytes(US_ASCII);
     private static final byte[] MIN_LONG_VALUE = String.valueOf(Long.MIN_VALUE).getBytes(US_ASCII);
 
+    private final StringBuilder messageTypeBuffer = new StringBuilder();
+
     public MutableAsciiBuffer()
     {
         super(0, 0);
@@ -159,8 +161,9 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
 
     public int getMessageType(final int offset, final int length)
     {
-        final String messageType = this.getStringWithoutLengthAscii(offset, length);
-        return GenerationUtil.packMessageType(messageType);
+        messageTypeBuffer.setLength(0);
+        this.getStringWithoutLengthAscii(offset, length, messageTypeBuffer);
+        return GenerationUtil.packMessageType(messageTypeBuffer);
     }
 
     @SuppressWarnings("FinalParameters")

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
@@ -17,6 +17,9 @@ package uk.co.real_logic.artio.util;
 
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+
+
+import uk.co.real_logic.artio.dictionary.generation.GenerationUtil;
 import uk.co.real_logic.artio.fields.*;
 
 import java.nio.ByteBuffer;
@@ -156,15 +159,8 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
 
     public int getMessageType(final int offset, final int length)
     {
-        // message types can only be 1 or 2 bytes in size
-        if (length == 1)
-        {
-            return getByte(offset);
-        }
-        else
-        {
-            return getShort(offset);
-        }
+        final String messageType = this.getStringWithoutLengthAscii(offset, length);
+        return GenerationUtil.packMessageType(messageType);
     }
 
     @SuppressWarnings("FinalParameters")

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/DictionaryParserTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/DictionaryParserTest.java
@@ -15,17 +15,37 @@
  */
 package uk.co.real_logic.artio.dictionary;
 
+import java.util.List;
+
 import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import uk.co.real_logic.artio.dictionary.ir.*;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.typeCompatibleWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+import uk.co.real_logic.artio.dictionary.ir.Component;
+import uk.co.real_logic.artio.dictionary.ir.Dictionary;
+import uk.co.real_logic.artio.dictionary.ir.Entry;
+import uk.co.real_logic.artio.dictionary.ir.Field;
 import uk.co.real_logic.artio.dictionary.ir.Field.Type;
 import uk.co.real_logic.artio.dictionary.ir.Field.Value;
+import uk.co.real_logic.artio.dictionary.ir.Group;
+import uk.co.real_logic.artio.dictionary.ir.Message;
 
-import java.util.List;
-
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static uk.co.real_logic.artio.dictionary.ir.Category.ADMIN;
 import static uk.co.real_logic.artio.dictionary.ir.Field.Type.INT;
 import static uk.co.real_logic.artio.dictionary.ir.Field.Type.STRING;
@@ -154,7 +174,7 @@ public class DictionaryParserTest
         final Message heartbeat = dictionary.messages().get(0);
 
         assertEquals("Heartbeat", heartbeat.name());
-        assertEquals('0', heartbeat.packedType());
+        assertEquals(ExampleDictionary.PACKED_HEARTBEAT_TYPE, heartbeat.packedType());
         assertEquals(ADMIN, heartbeat.category());
 
         final Entry entry = heartbeat.entries().get(0);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -104,7 +104,8 @@ public final class ExampleDictionary
     public static final String MSG_TYPE = "msgType";
     public static final String BODY_LENGTH = "bodyLength";
 
-    public static final int HEARTBEAT_TYPE = '0';
+    public static final char HEARTBEAT_TYPE = '0';
+    public static final int PACKED_HEARTBEAT_TYPE = GenerationUtil.packMessageType(String.valueOf(HEARTBEAT_TYPE));
 
     public static final Dictionary FIELD_EXAMPLE;
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/IntDictionaryTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/IntDictionaryTest.java
@@ -15,21 +15,24 @@
  */
 package uk.co.real_logic.artio.dictionary;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.agrona.collections.IntHashSet;
 import org.junit.Before;
 import org.junit.Test;
-import uk.co.real_logic.artio.dictionary.ir.Dictionary;
-import uk.co.real_logic.artio.dictionary.ir.Field;
-import uk.co.real_logic.artio.dictionary.ir.Field.Type;
-import uk.co.real_logic.artio.dictionary.ir.Message;
-
-import java.util.Arrays;
-import java.util.List;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+
+import uk.co.real_logic.artio.dictionary.ir.Dictionary;
+import uk.co.real_logic.artio.dictionary.ir.Field;
+import uk.co.real_logic.artio.dictionary.ir.Field.Type;
+import uk.co.real_logic.artio.dictionary.ir.Message;
+
 import static uk.co.real_logic.artio.dictionary.ir.Category.ADMIN;
 
 public class IntDictionaryTest
@@ -51,24 +54,26 @@ public class IntDictionaryTest
     public void buildsValidationDictionaryForRequiredFields()
     {
         final IntDictionary intDictionary = IntDictionary.requiredFields(data);
-        final IntHashSet heartbeat = intDictionary.values('0');
+        final int heartBeatRepresentation = ExampleDictionary.PACKED_HEARTBEAT_TYPE;
+        final IntHashSet heartbeat = intDictionary.values(heartBeatRepresentation);
 
         assertThat(heartbeat, hasItem(115));
         assertThat(heartbeat, hasSize(1));
-        assertTrue(intDictionary.contains('0', 115));
+        assertTrue(intDictionary.contains(heartBeatRepresentation, 115));
     }
 
     @Test
     public void buildsValidationDictionaryForAllFields()
     {
         final IntDictionary intDictionary = IntDictionary.allFields(data);
-        final IntHashSet heartbeat = intDictionary.values('0');
+        final int heartBeatRepresentation = ExampleDictionary.PACKED_HEARTBEAT_TYPE;
+        final IntHashSet heartbeat = intDictionary.values(heartBeatRepresentation);
 
         assertThat(heartbeat, hasItem(115));
         assertThat(heartbeat, hasItem(112));
         assertThat(heartbeat, hasSize(2));
 
-        assertTrue(intDictionary.contains('0', 115));
-        assertTrue(intDictionary.contains('0', 112));
+        assertTrue(intDictionary.contains(heartBeatRepresentation, 115));
+        assertTrue(intDictionary.contains(heartBeatRepresentation, 112));
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -357,7 +357,7 @@ public abstract class AbstractDecoderGeneratorTest
     {
         final int messageType = (int)getStatic(heartbeat, "MESSAGE_TYPE");
 
-        assertEquals(HEARTBEAT_TYPE, messageType);
+        assertEquals(ExampleDictionary.PACKED_HEARTBEAT_TYPE, messageType);
     }
 
     @Test

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
@@ -18,6 +18,9 @@ package uk.co.real_logic.artio.dictionary.generation;
 import org.agrona.generation.StringWriterOutputManager;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+
+import uk.co.real_logic.artio.dictionary.ExampleDictionary;
 import uk.co.real_logic.artio.util.AsciiBuffer;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 
@@ -115,7 +118,7 @@ public class AcceptorGeneratorTest
     {
         buffer.putAscii(1, ENCODED_MESSAGE);
         decoder.getMethod(ON_MESSAGE, AsciiBuffer.class, int.class, int.class, int.class)
-               .invoke(inst, buffer, 1, ENCODED_MESSAGE.length(), '0');
+               .invoke(inst, buffer, 1, ENCODED_MESSAGE.length(), ExampleDictionary.PACKED_HEARTBEAT_TYPE);
     }
 
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/ConstantGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/ConstantGeneratorTest.java
@@ -19,6 +19,9 @@ import org.agrona.collections.IntHashSet;
 import org.agrona.generation.StringWriterOutputManager;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+
+import uk.co.real_logic.artio.dictionary.ExampleDictionary;
 import uk.co.real_logic.artio.util.Reflection;
 
 import java.util.Map;
@@ -64,13 +67,13 @@ public class ConstantGeneratorTest
     @Test
     public void shouldContainNumericConstantsForMessageTypes() throws Exception
     {
-        assertEquals(HEARTBEAT_TYPE, getField(constants, "HEARTBEAT_MESSAGE"));
+        assertEquals(ExampleDictionary.PACKED_HEARTBEAT_TYPE, getField(constants, "HEARTBEAT_MESSAGE"));
     }
 
     @Test
     public void shouldContainStringConstantsForMessageTypes() throws Exception
     {
-        final String heartbeatString = String.valueOf((char)HEARTBEAT_TYPE);
+        final String heartbeatString = String.valueOf(HEARTBEAT_TYPE);
         assertEquals(heartbeatString, getField(constants, "HEARTBEAT_MESSAGE_AS_STR"));
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -48,6 +48,34 @@ public class GenerationUtilTest
         permutations(new StringBuilder(), 5, 0, seen);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void failsToGeneratePackedIfFor6Characters()
+    {
+        packMessageType("AAAAAA");
+    }
+
+    private static void sawOrNot(final StringBuilder permutation, final BitSet seen, final int packed)
+    {
+        final boolean alreadySaw = seen.get(packed);
+        if (alreadySaw)
+        {
+            Assert.assertFalse(permutation.toString(), alreadySaw);
+        }
+        seen.set(packed);
+    }
+
+    @Test
+    public void shouldReplaceIDWithIdInConstantName()
+    {
+        assertEquals("DEFAULT_APPL_VER_ID", constantName("DefaultApplVerID"));
+    }
+
+    @Test
+    public void shouldDropGroupCounterForNumberOfElementsInReaptingGroupConstant()
+    {
+        assertEquals("NO_MSG_TYPES", constantName("NoMsgTypesGroupCounter"));
+    }
+
     private static void permutations(
         final StringBuilder permutation, final int maxDepth,
         final int curDepth, final BitSet seen)
@@ -81,27 +109,5 @@ public class GenerationUtilTest
             permutations(permutation, maxDepth, curDepth + 1, seen);
             permutation.setLength(permutation.length() - 1);
         }
-    }
-
-    private static void sawOrNot(final StringBuilder permutation, final BitSet seen, final int packed)
-    {
-        final boolean alreadySaw = seen.get(packed);
-        if (alreadySaw)
-        {
-            Assert.assertFalse(permutation.toString(), alreadySaw);
-        }
-        seen.set(packed);
-    }
-
-    @Test
-    public void shouldReplaceIDWithIdInConstantName()
-    {
-        assertEquals("DEFAULT_APPL_VER_ID", constantName("DefaultApplVerID"));
-    }
-
-    @Test
-    public void shouldDropGroupCounterForNumberOfElementsInReaptingGroupConstant()
-    {
-        assertEquals("NO_MSG_TYPES", constantName("NoMsgTypesGroupCounter"));
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -54,16 +54,6 @@ public class GenerationUtilTest
         packMessageType("AAAAAA");
     }
 
-    private static void sawOrNot(final StringBuilder permutation, final BitSet seen, final int packed)
-    {
-        final boolean alreadySaw = seen.get(packed);
-        if (alreadySaw)
-        {
-            Assert.assertFalse(permutation.toString(), alreadySaw);
-        }
-        seen.set(packed);
-    }
-
     @Test
     public void shouldReplaceIDWithIdInConstantName()
     {
@@ -109,5 +99,15 @@ public class GenerationUtilTest
             permutations(permutation, maxDepth, curDepth + 1, seen);
             permutation.setLength(permutation.length() - 1);
         }
+    }
+
+    private static void sawOrNot(final StringBuilder permutation, final BitSet seen, final int packed)
+    {
+        final boolean alreadySaw = seen.get(packed);
+        if (alreadySaw)
+        {
+            Assert.assertFalse(permutation.toString(), alreadySaw);
+        }
+        seen.set(packed);
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -45,26 +45,18 @@ public class GenerationUtilTest
     @Test
     public void generatesUniquePackedIds()
     {
-        final BitSet positive = new BitSet();
-        final BitSet negative = new BitSet();
-        permutations(new StringBuilder(), 5, 0, positive, negative);
+        final BitSet seen = new BitSet();
+        permutations(new StringBuilder(), 5, 0, seen);
     }
 
-    private static void permutations(final StringBuilder permutation, final int maxDepth,
-        final int curDepth, final BitSet positive, final BitSet negative)
+    private static void permutations(
+        final StringBuilder permutation, final int maxDepth,
+        final int curDepth, final BitSet seen)
     {
         if (curDepth == maxDepth)
         {
             final int packed = packMessageType2(permutation);
-            if (packed > 0)
-            {
-                sawOrNot(permutation, positive, packed);
-            }
-            else
-            {
-                sawOrNot(permutation, negative, packed);
-            }
-
+            sawOrNot(permutation, seen, packed);
             return;
         }
         for (int c = 48; c <= 122; c++)
@@ -87,7 +79,7 @@ public class GenerationUtilTest
                     continue;
             }
             permutation.append((char)c);
-            permutations(permutation, maxDepth, curDepth + 1, positive, negative);
+            permutations(permutation, maxDepth, curDepth + 1, seen);
             permutation.setLength(permutation.length() - 1);
         }
     }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertNotEquals;
 
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.constantName;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.packMessageType;
-import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.packMessageType2;
 
 public class GenerationUtilTest
 {
@@ -55,7 +54,7 @@ public class GenerationUtilTest
     {
         if (curDepth == maxDepth)
         {
-            final int packed = packMessageType2(permutation);
+            final int packed = packMessageType(permutation);
             sawOrNot(permutation, seen, packed);
             return;
         }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -15,12 +15,18 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
+import java.util.BitSet;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+
+
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.constantName;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.packMessageType;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.packMessageType2;
 
 public class GenerationUtilTest
 {
@@ -34,6 +40,63 @@ public class GenerationUtilTest
         assertNotEquals(packMessageType("BC"), packMessageType("BB"));
         assertNotEquals(packMessageType("BD"), packMessageType("BE"));
         assertNotEquals(packMessageType("BG"), packMessageType("BF"));
+    }
+
+    @Test
+    public void generatesUniquePackedIds()
+    {
+        final BitSet positive = new BitSet();
+        final BitSet negative = new BitSet();
+        permutations(new StringBuilder(), 5, 0, positive, negative);
+    }
+
+    private static void permutations(final StringBuilder permutation, final int maxDepth,
+        final int curDepth, final BitSet positive, final BitSet negative)
+    {
+        if (curDepth == maxDepth)
+        {
+            final int packed = packMessageType2(permutation);
+            if (packed > 0)
+            {
+                sawOrNot(permutation, positive, packed);
+            }
+            else
+            {
+                sawOrNot(permutation, negative, packed);
+            }
+
+            return;
+        }
+        for (int c = 48; c <= 122; c++)
+        {
+            switch (c)
+            {
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                case 64:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                case 96:
+                    continue;
+            }
+            permutation.append((char)c);
+            permutations(permutation, maxDepth, curDepth + 1, positive, negative);
+            permutation.setLength(permutation.length() - 1);
+        }
+    }
+
+    private static void sawOrNot(final StringBuilder permutation, final BitSet seen, final int packed)
+    {
+        final boolean alreadySaw = seen.get(packed);
+        Assert.assertFalse(permutation + " results in a duplicate ", alreadySaw);
+        seen.set(packed);
     }
 
     @Test

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -55,7 +55,7 @@ public class GenerationUtilTest
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void failsToGeneratePackedIfFor6Characters()
+    public void failsToPackMessageTypeFor6Characters()
     {
         packMessageType("AAAAAA");
     }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -95,7 +95,10 @@ public class GenerationUtilTest
     private static void sawOrNot(final StringBuilder permutation, final BitSet seen, final int packed)
     {
         final boolean alreadySaw = seen.get(packed);
-        Assert.assertFalse(permutation + " results in a duplicate ", alreadySaw);
+        if (alreadySaw)
+        {
+            Assert.assertFalse(permutation.toString(), alreadySaw);
+        }
         seen.set(packed);
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -42,6 +42,12 @@ public class GenerationUtilTest
     }
 
     @Test
+    public void shouldReturnSentinelValueForInvalidMsgType()
+    {
+        assertEquals(GenerationUtil.INVALID_MSG_TYPE, packMessageType("*"));
+    }
+
+    @Test
     public void generatesUniquePackedIds()
     {
         final BitSet seen = new BitSet();

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -21,7 +21,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.constantName;
@@ -29,17 +28,6 @@ import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.packMe
 
 public class GenerationUtilTest
 {
-
-    @Test
-    public void shouldGenerateDifferentMessageTypeIdentifiers()
-    {
-        assertNotEquals(packMessageType("AL"), packMessageType("AM"));
-        assertNotEquals(packMessageType("AL"), packMessageType("AN"));
-        assertNotEquals(packMessageType("AR"), packMessageType("AQ"));
-        assertNotEquals(packMessageType("BC"), packMessageType("BB"));
-        assertNotEquals(packMessageType("BD"), packMessageType("BE"));
-        assertNotEquals(packMessageType("BG"), packMessageType("BF"));
-    }
 
     @Test
     public void shouldReturnSentinelValueForInvalidMsgType()
@@ -76,7 +64,7 @@ public class GenerationUtilTest
         final StringBuilder permutation, final int maxDepth,
         final int curDepth, final BitSet seen)
     {
-        if (permutation.length() > 0)
+        if (curDepth > 0)
         {
             final int packed = packMessageType(permutation);
             sawOrNot(permutation, seen, packed);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtilTest.java
@@ -76,10 +76,14 @@ public class GenerationUtilTest
         final StringBuilder permutation, final int maxDepth,
         final int curDepth, final BitSet seen)
     {
-        if (curDepth == maxDepth)
+        if (permutation.length() > 0)
         {
             final int packed = packMessageType(permutation);
             sawOrNot(permutation, seen, packed);
+        }
+
+        if (curDepth == maxDepth)
+        {
             return;
         }
         for (int c = 48; c <= 122; c++)
@@ -102,6 +106,7 @@ public class GenerationUtilTest
                     continue;
             }
             permutation.append((char)c);
+
             permutations(permutation, maxDepth, curDepth + 1, seen);
             permutation.setLength(permutation.length() - 1);
         }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
@@ -19,6 +19,7 @@ import org.agrona.generation.StringWriterOutputManager;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import uk.co.real_logic.artio.builder.Printer;
+import uk.co.real_logic.artio.dictionary.ExampleDictionary;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 
 import java.lang.reflect.InvocationTargetException;
@@ -68,7 +69,8 @@ public class PrinterGeneratorTest
         final Printer printer = printer();
         buffer.putAscii(1, ENCODED_MESSAGE);
 
-        final String string = printer.toString(buffer, 1, ENCODED_MESSAGE.length(), HEARTBEAT_TYPE);
+        final int messageType = ExampleDictionary.PACKED_HEARTBEAT_TYPE;
+        final String string = printer.toString(buffer, 1, ENCODED_MESSAGE.length(), messageType);
 
         assertThat(string, containsString(STRING_ENCODED_MESSAGE_EXAMPLE));
     }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/otf/OtfParserTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/otf/OtfParserTest.java
@@ -23,6 +23,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import uk.co.real_logic.artio.dictionary.IntDictionary;
+import uk.co.real_logic.artio.dictionary.generation.GenerationUtil;
 import uk.co.real_logic.artio.fields.AsciiFieldFlyweight;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 
@@ -134,7 +135,8 @@ public class OtfParserTest
 
         parser.onMessage(buffer, offset, INVALID_CHECKSUM_LEN);
 
-        verify(mockAcceptor).onError(eq(INVALID_CHECKSUM), eq((int)'D'), eq(10), any(AsciiFieldFlyweight.class));
+        verify(mockAcceptor).onError(eq(INVALID_CHECKSUM),
+            eq(GenerationUtil.packMessageType("D")), eq(10), any(AsciiFieldFlyweight.class));
     }
 
     @Theory
@@ -144,7 +146,8 @@ public class OtfParserTest
 
         parser.onMessage(buffer, offset, INVALID_LEN);
 
-        verify(mockAcceptor).onError(eq(PARSE_ERROR), eq((int)'D'), eq(11), any(AsciiFieldFlyweight.class));
+        verify(mockAcceptor).onError(eq(PARSE_ERROR),
+            eq(GenerationUtil.packMessageType("D")), eq(11), any(AsciiFieldFlyweight.class));
     }
 
     @Theory

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/otf/OtfValidatorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/otf/OtfValidatorTest.java
@@ -17,6 +17,7 @@ package uk.co.real_logic.artio.otf;
 
 import org.junit.Test;
 import uk.co.real_logic.artio.dictionary.IntDictionary;
+import uk.co.real_logic.artio.dictionary.generation.GenerationUtil;
 import uk.co.real_logic.artio.fields.AsciiFieldFlyweight;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 
@@ -26,6 +27,7 @@ import static uk.co.real_logic.artio.dictionary.SessionConstants.MESSAGE_TYPE;
 
 public class OtfValidatorTest
 {
+    private static final int PACKED_HEARTBEAT = GenerationUtil.packMessageType("0");
     private OtfMessageAcceptor acceptor = mock(OtfMessageAcceptor.class);
 
     private IntDictionary requiredFields = new IntDictionary();
@@ -136,19 +138,19 @@ public class OtfValidatorTest
 
     private void testReqIdIsARequiredHeartBeatField()
     {
-        requiredFields.put('0', 112);
+        requiredFields.put(PACKED_HEARTBEAT, 112);
     }
 
     private void heartbeatsHaveATestReqId()
     {
         heartBeatsAreKnownMessages();
-        allFields.put('0', 112);
+        allFields.put(PACKED_HEARTBEAT, 112);
     }
 
     private void heartBeatsAreKnownMessages()
     {
-        requiredFields.put('0', MESSAGE_TYPE);
-        allFields.put('0', MESSAGE_TYPE);
+        requiredFields.put(PACKED_HEARTBEAT, MESSAGE_TYPE);
+        allFields.put(PACKED_HEARTBEAT, MESSAGE_TYPE);
     }
 
     private void messageIsAHeartBeat()
@@ -173,17 +175,20 @@ public class OtfValidatorTest
 
     private void verifyUnknownMessage()
     {
-        verify(acceptor).onError(eq(UNKNOWN_MESSAGE_TYPE), eq((int)'0'), anyInt(), any(AsciiFieldFlyweight.class));
+        verify(acceptor).onError(eq(UNKNOWN_MESSAGE_TYPE),
+            eq(PACKED_HEARTBEAT), anyInt(), any(AsciiFieldFlyweight.class));
     }
 
     private void verifyUnknownField()
     {
-        verify(acceptor).onError(eq(UNKNOWN_FIELD), eq((int)'0'), eq(112), any(AsciiFieldFlyweight.class));
+        verify(acceptor).onError(eq(UNKNOWN_FIELD), eq(PACKED_HEARTBEAT),
+            eq(112), any(AsciiFieldFlyweight.class));
     }
 
     private void verifyMissingRequiredField()
     {
-        verify(acceptor).onError(eq(MISSING_REQUIRED_FIELD), eq((int)'0'), eq(112), any(AsciiFieldFlyweight.class));
+        verify(acceptor).onError(eq(MISSING_REQUIRED_FIELD),
+            eq(PACKED_HEARTBEAT), eq(112), any(AsciiFieldFlyweight.class));
     }
 
     private void validateTestReqId()

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/AsciiBufferTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/AsciiBufferTest.java
@@ -21,6 +21,10 @@ import org.junit.Test;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+
+
+import uk.co.real_logic.artio.dictionary.generation.GenerationUtil;
+
 import static uk.co.real_logic.artio.util.AsciiBuffer.UNKNOWN_INDEX;
 
 public class AsciiBufferTest
@@ -93,7 +97,7 @@ public class AsciiBufferTest
 
         value = buffer.getMessageType(0, 1);
 
-        assertEquals('0', value);
+        assertEquals(GenerationUtil.packMessageType("0"), value);
     }
 
     @Test
@@ -103,7 +107,7 @@ public class AsciiBufferTest
 
         value = buffer.getMessageType(0, 1);
 
-        assertEquals('D', value);
+        assertEquals(GenerationUtil.packMessageType("D"), value);
     }
 
     @Test
@@ -113,7 +117,7 @@ public class AsciiBufferTest
 
         value = buffer.getMessageType(0, 2);
 
-        assertEquals(20289, value);
+        assertEquals(GenerationUtil.packMessageType("AO"), value);
     }
 
     @Test

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/ReceiverEndPointTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/ReceiverEndPointTest.java
@@ -27,6 +27,7 @@ import org.mockito.verification.VerificationMode;
 import uk.co.real_logic.artio.Clock;
 import uk.co.real_logic.artio.decoder.LogonDecoder;
 import uk.co.real_logic.artio.dictionary.FixDictionary;
+import uk.co.real_logic.artio.dictionary.generation.GenerationUtil;
 import uk.co.real_logic.artio.engine.FixEngine;
 import uk.co.real_logic.artio.messages.DisconnectReason;
 import uk.co.real_logic.artio.messages.MessageStatus;
@@ -53,7 +54,7 @@ import static uk.co.real_logic.artio.util.TestMessages.*;
 
 public class ReceiverEndPointTest
 {
-    private static final int MESSAGE_TYPE = 'D';
+    private static final int MESSAGE_TYPE = GenerationUtil.packMessageType("D");
     private static final long CONNECTION_ID = 20L;
     private static final long SESSION_ID = 4L;
     private static final int LIBRARY_ID = FixEngine.ENGINE_LIBRARY_ID;


### PR DESCRIPTION
* The problem:
We came across a major venue that uses custom messages with a message type of 5 characters. While artio can read the characters off the wire without a problem, the message type is converted into an integer by packing the first two characters in the lower 16 bits of the 32 bit int. As it happens, our custom messages both started with the same two letters, resulting in a duplicated value in a generated switch statement. It's worth pointing out that there's nothing in the fix spec that we can find, that says that message types have a maximum size of 2.

* The solution:
We changed the way converting a message type into an int works, by using 6 bits to represent any alphanumeric character in the message types. We use 6 bits rather than the ASCII 7 so that we can pack 5 characters (6 * 5 = 30 bits) rather than 4 (4 * 7 = 28 bits) and we do this by not using the ASCII numberical value for each character but a custom charset that excludes symbols etc.

* Side effects:
  * Hardcoded ints in the codebase, such as '0' no longer work, as '0' no longer maps to ASCII 48. Our generator needs to be used. This also means that switching using the constants as case values doesn't work, as the compiler can't resolve them at compile time, so an if statement has to be used.
  * If those numbers are serialised to disk, then the mapping will no longer work between versions because we have changed it. New mapping is, however, stable and two way.
  * We've introduced an exhaustive test that checks all possible alphanumerical permutations of strings sized 1-5 to make sure that our algorithm works. We found this useful as it took a few attempts to get right. The test does take 1.5 mins on our work station though.

This is a significant change, but as long as the ints are used we struggle to see how larger message types could be supported. We could support up to 4 by using the ASCII encoding but we have a concrete example that uses 5.