### PR TITLE
Avoid allocation in the Indexer

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
@@ -155,8 +155,9 @@ public class Indexer implements Agent, ControlledFragmentHandler
             streamId,
             aeronSessionId);
 
-        for (final Index index : indices)
+        for (int i = 0, size = indices.size(); i < size; i++)
         {
+            final Index index = indices.get(i);
             index.onFragment(buffer, offset, length, header);
         }
 

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/Indexer.java
@@ -95,7 +95,7 @@ public class Indexer implements Agent, ControlledFragmentHandler
                     {
                         DebugLogger.log(
                             LogTag.INDEX,
-                            "Catchup [%s]: recordingId = %d, recordingStopped @ %d, indexStopped @ %d",
+                            "Catchup [%s]: recordingId = %d, recordingStopped @ %d, indexStopped @ %d%n",
                             index.getName(),
                             recordingId,
                             recordingStoppedPosition,


### PR DESCRIPTION
This showed up as the main source of garbage in our perf tests.