### PR TITLE
add the option to defer binding to the network when starting up

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
@@ -227,7 +227,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     private FixDictionary acceptorfixDictionary;
     private boolean deleteLogFileDirOnStart = false;
     private long authenticationTimeoutInMs = DEFAULT_AUTHENTICATION_TIMEOUT_IN_MS;
-    private boolean deferBinding;
+    private boolean bindAtStartup = true;
 
     /**
      * Sets the local address to bind to when the Gateway is used to accept connections.
@@ -247,14 +247,15 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     }
 
     /**
-     * Defers binding to the local address provided to {@link #bindTo(String, int)} until {@link FixEngine#bind()} is invoked.
+     * Controls whether the engine should eagerly bind the network interface at startup when {@link #bindTo(String, int)} is used, or
+     * whether it is delayed delayed until {@link FixEngine#bind()} is invoked.
      *
-     * @param deferBinding true to defer binding.
+     * @param bindAtStartup false to delay binding until {@link FixEngine#bind()} is invoked.
      * @return this
      */
-    public EngineConfiguration deferBinding(final boolean deferBinding)
+    public EngineConfiguration bindAtStartup(final boolean bindAtStartup)
     {
-        this.deferBinding = deferBinding;
+        this.bindAtStartup = bindAtStartup;
         return this;
     }
 
@@ -700,9 +701,9 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
         return new InetSocketAddress(host, port);
     }
 
-    public boolean deferBinding()
+    public boolean bindAtStartup()
     {
-        return this.deferBinding;
+        return this.bindAtStartup;
     }
 
     public String logFileDir()

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
@@ -227,6 +227,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     private FixDictionary acceptorfixDictionary;
     private boolean deleteLogFileDirOnStart = false;
     private long authenticationTimeoutInMs = DEFAULT_AUTHENTICATION_TIMEOUT_IN_MS;
+    private boolean deferBinding;
 
     /**
      * Sets the local address to bind to when the Gateway is used to accept connections.
@@ -242,6 +243,18 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
         Objects.requireNonNull(host, "host");
         this.host = host;
         this.port = port;
+        return this;
+    }
+
+    /**
+     * Defers binding to the local address provided to {@link #bindTo(String, int)} until {@link FixEngine#bind()} is invoked.
+     *
+     * @param deferBinding true to defer binding.
+     * @return this
+     */
+    public EngineConfiguration deferBinding(final boolean deferBinding)
+    {
+        this.deferBinding = deferBinding;
         return this;
     }
 
@@ -687,6 +700,11 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
         return new InetSocketAddress(host, port);
     }
 
+    public boolean deferBinding()
+    {
+        return this.deferBinding;
+    }
+
     public String logFileDir()
     {
         return logFileDir;
@@ -1059,4 +1077,5 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
         CloseHelper.close(receivedSequenceNumberIndex);
         CloseHelper.close(sessionIdBuffer);
     }
+
 }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
@@ -33,7 +33,7 @@ public class DefaultTcpChannelSupplier extends TcpChannelSupplier
         try
         {
             selector = Selector.open();
-            if (!configuration.bindAtStartup())
+            if (configuration.bindAtStartup())
             {
                 bind();
             }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
@@ -33,7 +33,10 @@ public class DefaultTcpChannelSupplier extends TcpChannelSupplier
         try
         {
             selector = Selector.open();
-            bind();
+            if (!configuration.deferBinding())
+            {
+                bind();
+            }
         }
         catch (final IOException ex)
         {

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
@@ -33,7 +33,7 @@ public class DefaultTcpChannelSupplier extends TcpChannelSupplier
         try
         {
             selector = Selector.open();
-            if (!configuration.deferBinding())
+            if (!configuration.bindAtStartup())
             {
                 bind();
             }

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
@@ -234,6 +234,13 @@ public class MessageBasedAcceptorSystemTest
         }
     }
 
+    @Test
+    public void bindingCanBeDeferred() throws IOException
+    {
+        setup(true, false);
+        cannotConnect();
+    }
+
     private void completeBind()
     {
         final Reply<?> bindReply = engine.bind();
@@ -294,11 +301,10 @@ public class MessageBasedAcceptorSystemTest
             .monitoringFile(acceptorMonitoringFile("engineCounters"))
             .logFileDir(ACCEPTOR_LOGS)
             .sessionPersistenceStrategy(logon ->
-            sequenceNumberReset ? TRANSIENT_SEQUENCE_NUMBERS : PERSISTENT_SEQUENCE_NUMBERS);
-        if (shouldBind)
-        {
-            config.bindTo("localhost", port);
-        }
+            sequenceNumberReset ? TRANSIENT_SEQUENCE_NUMBERS : PERSISTENT_SEQUENCE_NUMBERS)
+            .bindTo("localhost", port)
+            .deferBinding(!shouldBind);
+
         config.printErrorMessages(false);
         engine = FixEngine.launch(config);
     }

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
@@ -212,7 +212,7 @@ public class MessageBasedAcceptorSystemTest
     @Test
     public void shouldReturnErrorWhenBindingWithoutAddress()
     {
-        setup(true, false);
+        setup(true, false, false);
 
         final Reply<?> reply = engine.bind();
         SystemTestUtil.awaitReply(reply);
@@ -293,6 +293,11 @@ public class MessageBasedAcceptorSystemTest
 
     private void setup(final boolean sequenceNumberReset, final boolean shouldBind)
     {
+        setup(sequenceNumberReset, shouldBind, true);
+    }
+
+    private void setup(final boolean sequenceNumberReset, final boolean shouldBind, final boolean provideBindingAddress)
+    {
         mediaDriver = launchMediaDriver();
 
         delete(ACCEPTOR_LOGS);
@@ -302,8 +307,12 @@ public class MessageBasedAcceptorSystemTest
             .logFileDir(ACCEPTOR_LOGS)
             .sessionPersistenceStrategy(logon ->
             sequenceNumberReset ? TRANSIENT_SEQUENCE_NUMBERS : PERSISTENT_SEQUENCE_NUMBERS)
-            .bindTo("localhost", port)
-            .bindAtStartup(!shouldBind);
+            .bindAtStartup(shouldBind);
+
+        if (provideBindingAddress)
+        {
+            config.bindTo("localhost", port);
+        }
 
         config.printErrorMessages(false);
         engine = FixEngine.launch(config);

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
@@ -303,7 +303,7 @@ public class MessageBasedAcceptorSystemTest
             .sessionPersistenceStrategy(logon ->
             sequenceNumberReset ? TRANSIENT_SEQUENCE_NUMBERS : PERSISTENT_SEQUENCE_NUMBERS)
             .bindTo("localhost", port)
-            .deferBinding(!shouldBind);
+            .bindAtStartup(!shouldBind);
 
         config.printErrorMessages(false);
         engine = FixEngine.launch(config);


### PR DESCRIPTION
On top of the bind/unbind API recently added, this allows users to spin up the engine in an unbound state. Currently we have to start the engine bound to the interface then unbind.