### PR TITLE
[Tom/Richard] Fix required enum char encoding.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -1027,7 +1027,8 @@ public class EncoderGenerator extends Generator
     protected boolean hasFlag(final Entry entry, final Field field)
     {
         final Type type = field.type();
-        return (!entry.required() && !type.hasLengthField(false)) || type.isFloatBased() || type.isIntBased();
+        return (!entry.required() && !type.hasLengthField(false)) ||
+            type.isFloatBased() || type.isIntBased() || type.isCharBased();
     }
 
     protected String resetTemporalValue(final String name)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Field.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/ir/Field.java
@@ -111,65 +111,68 @@ public final class Field implements Element
     public enum Type
     {
         // int types
-        INT(false, true, false, false),
-        LENGTH(false, true, false, false),
-        SEQNUM(false, true, false, false),
-        NUMINGROUP(false, true, false, false),
-        DAYOFMONTH(false, true, false, false),
+        INT(false, true, false, false, false),
+        LENGTH(false, true, false, false, false),
+        SEQNUM(false, true, false, false, false),
+        NUMINGROUP(false, true, false, false, false),
+        DAYOFMONTH(false, true, false, false, false),
 
         // float types
-        FLOAT(false, false, true, false),
-        PRICE(false, false, true, false),
-        PRICEOFFSET(false, false, true, false),
-        QTY(false, false, true, false),
-        PERCENTAGE(false, false, true, false), // Percentage represented as a float
-        AMT(false, false, true, false), // Float amount, not to be confused with boolean Y/N AMT
+        FLOAT(false, false, true, false, false),
+        PRICE(false, false, true, false, false),
+        PRICEOFFSET(false, false, true, false, false),
+        QTY(false, false, true, false, false),
+        PERCENTAGE(false, false, true, false, false), // Percentage represented as a float
+        AMT(false, false, true, false, false), // Float amount, not to be confused with boolean Y/N AMT
 
-        CHAR(false, false, false, false),
+        CHAR(false, false, false, false, true),
 
-        MULTIPLECHARVALUE(true, false, false, true),
-        STRING(true, false, false, false),
-        MULTIPLEVALUESTRING(true, false, false, true),
-        MULTIPLESTRINGVALUE(true, false, false, true),
+        MULTIPLECHARVALUE(true, false, false, true, false),
+        STRING(true, false, false, false, false),
+        MULTIPLEVALUESTRING(true, false, false, true, false),
+        MULTIPLESTRINGVALUE(true, false, false, true, false),
 
-        CURRENCY(true, false, false, false), // String using ISO 4217 (3 chars)
-        EXCHANGE(true, false, false, false), // String using ISO 10383 (2 chars)
-        COUNTRY(true, false, false, false), // String using ISO 3166
-        LANGUAGE(true, false, false, false), // String using ISO 639-1 standard
+        CURRENCY(true, false, false, false, false), // String using ISO 4217 (3 chars)
+        EXCHANGE(true, false, false, false, false), // String using ISO 10383 (2 chars)
+        COUNTRY(true, false, false, false, false), // String using ISO 3166
+        LANGUAGE(true, false, false, false, false), // String using ISO 639-1 standard
 
         // NB: data doesn't have a length field because in specified
         // XML files it often comes along with a length field.
-        DATA(false, false, false, false),
+        DATA(false, false, false, false, false),
         // Only used in 5.0sp1 or later.
-        XMLDATA(false, false, false, false),
+        XMLDATA(false, false, false, false, false),
 
         // Boolean types
-        BOOLEAN(false, false, false, false),
+        BOOLEAN(false, false, false, false, false),
 
-        UTCTIMESTAMP(true, false, false, false), // YYYYMMDD-HH:MM:SS or YYYYMMDD-HH:MM:SS.sss
-        UTCTIMEONLY(true, false, false, false), // HH:MM:SS or HH:MM:SS.sss
-        UTCDATEONLY(true, false, false, false), // YYYYMMDD
-        LOCALMKTDATE(true, false, false, false), // YYYYMMDD
-        MONTHYEAR(true, false, false, false), // YYYYMM or YYYYMMDD or YYYYMMWW
-        TZTIMEONLY(true, false, false, false), // HH:MM[:SS][Z [ + - hh[:mm]]]
-        TZTIMESTAMP(true, false, false, false); // YYYYMMDD-HH:MM:SS.sss*[Z [ + - hh[:mm]]]
+        UTCTIMESTAMP(true, false, false, false, false), // YYYYMMDD-HH:MM:SS or YYYYMMDD-HH:MM:SS.sss
+        UTCTIMEONLY(true, false, false, false, false), // HH:MM:SS or HH:MM:SS.sss
+        UTCDATEONLY(true, false, false, false, false), // YYYYMMDD
+        LOCALMKTDATE(true, false, false, false, false), // YYYYMMDD
+        MONTHYEAR(true, false, false, false, false), // YYYYMM or YYYYMMDD or YYYYMMWW
+        TZTIMEONLY(true, false, false, false, false), // HH:MM[:SS][Z [ + - hh[:mm]]]
+        TZTIMESTAMP(true, false, false, false, false); // YYYYMMDD-HH:MM:SS.sss*[Z [ + - hh[:mm]]]
 
         private final boolean isStringBased;
         private final boolean isIntBased;
         private final boolean isFloatBased;
         private final boolean isMultiValue;
+        private final boolean isCharBased;
 
         Type(
             final boolean isStringBased,
             final boolean isIntBased,
             final boolean isFloatBased,
-            final boolean isMultiValue
+            final boolean isMultiValue,
+            final boolean isCharBased
         )
         {
             this.isStringBased = isStringBased;
             this.isIntBased = isIntBased;
             this.isFloatBased = isFloatBased;
             this.isMultiValue = isMultiValue;
+            this.isCharBased = isCharBased;
         }
 
         public boolean isStringBased()
@@ -185,6 +188,11 @@ public final class Field implements Element
         public boolean isFloatBased()
         {
             return isFloatBased;
+        }
+
+        public boolean isCharBased()
+        {
+            return isCharBased;
         }
 
         public boolean isDataBased()

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -67,6 +67,7 @@ public final class ExampleDictionary
     public static final String OTHER_MESSAGE_DECODER = TEST_PACKAGE + ".OtherMessageDecoder";
     public static final String OTHER_MESSAGE_ENCODER = TEST_PACKAGE + ".OtherMessageEncoder";
     public static final String ENUM_TEST_MESSAGE_DECODER = TEST_PACKAGE + ".EnumTestMessageDecoder";
+    public static final String ENUM_TEST_MESSAGE_ENCODER = TEST_PACKAGE + ".EnumTestMessageEncoder";
 
     public static final String PRINTER = TEST_PACKAGE + ".PrinterImpl";
 
@@ -95,6 +96,10 @@ public final class ExampleDictionary
     public static final String STRING_ENUM_RF = "StringEnumRF";
     public static final String INT_ENUM_RF = "IntEnumRF";
     public static final String CHAR_ENUM_RF = "CharEnumRF";
+
+    public static final String STRING_ENUM_REQ = "stringEnumReq";
+    public static final String INT_ENUM_REQ = "intEnumReq";
+    public static final String CHAR_ENUM_REQ = "charEnumReq";
 
     public static final String HAS_TEST_REQ_ID = "hasTestReqID";
     public static final String HAS_BOOLEAN_FIELD = "hasBooleanField";

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -61,9 +61,6 @@ public abstract class AbstractDecoderGeneratorTest
     private static final String CHAR_ENUM_OPT = "charEnumOpt";
     private static final String INT_ENUM_OPT = "intEnumOpt";
     private static final String STRING_ENUM_OPT = "stringEnumOpt";
-    private static final String CHAR_ENUM_REQ = "charEnumReq";
-    private static final String INT_ENUM_REQ = "intEnumReq";
-    private static final String STRING_ENUM_REQ = "stringEnumReq";
 
     private static Class<?> heartbeatWithoutValidation;
     private static Class<?> heartbeatWithoutEnumValueValidation;

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -45,6 +45,7 @@ public class EncoderGeneratorTest
 {
     private static Map<String, CharSequence> sources;
     private static Class<?> heartbeat;
+    private static Class<?> enumTestMessage;
     private static Class<?> otherMessage;
     private static Class<?> heartbeatWithoutValidation;
 
@@ -60,6 +61,11 @@ public class EncoderGeneratorTest
         }
         heartbeat = compileInMemory(HEARTBEAT_ENCODER, sources);
         if (heartbeat == null && !AbstractDecoderGeneratorTest.CODEC_LOGGING)
+        {
+            System.out.println(sources);
+        }
+        enumTestMessage = compileInMemory(ENUM_TEST_MESSAGE_ENCODER, sources);
+        if (enumTestMessage == null && !AbstractDecoderGeneratorTest.CODEC_LOGGING)
         {
             System.out.println(sources);
         }
@@ -697,6 +703,60 @@ public class EncoderGeneratorTest
         encoder.encode(buffer, 1);
     }
 
+    @Test(expected = EncodingException.class)
+    public void shouldValidateMissingRequiredCharEnumFields() throws Exception
+    {
+        final Encoder encoder = newEnumTestMessage();
+
+        setEnumByRepresentation(
+            encoder,
+            INT_ENUM_REQ,
+            PARENT_PACKAGE + ".IntEnumReq",
+            30);
+        setEnumByRepresentation(
+            encoder,
+            STRING_ENUM_REQ,
+            PARENT_PACKAGE + ".StringEnumReq",
+            "gamma");
+        encoder.encode(buffer, 1);
+    }
+
+    @Test(expected = EncodingException.class)
+    public void shouldValidateMissingRequiredIntEnumFields() throws Exception
+    {
+        final Encoder encoder = newEnumTestMessage();
+
+        setEnumByRepresentation(
+            encoder,
+            CHAR_ENUM_REQ,
+            PARENT_PACKAGE + ".CharEnumReq",
+            'c');
+        setEnumByRepresentation(
+            encoder,
+            STRING_ENUM_REQ,
+            PARENT_PACKAGE + ".StringEnumReq",
+            "gamma");
+        encoder.encode(buffer, 1);
+    }
+
+    @Test(expected = EncodingException.class)
+    public void shouldValidateMissingRequiredStringEnumFields() throws Exception
+    {
+        final Encoder encoder = newEnumTestMessage();
+
+        setEnumByRepresentation(
+            encoder,
+            CHAR_ENUM_REQ,
+            PARENT_PACKAGE + ".CharEnumReq",
+            'c');
+        setEnumByRepresentation(
+            encoder,
+            INT_ENUM_REQ,
+            PARENT_PACKAGE + ".IntEnumReq",
+            30);
+        encoder.encode(buffer, 1);
+    }
+
     @Test
     public void canDisableRequiredStringFieldValidation() throws Exception
     {
@@ -990,6 +1050,11 @@ public class EncoderGeneratorTest
     private Encoder newHeartbeat() throws Exception
     {
         return (Encoder)heartbeat.getConstructor().newInstance();
+    }
+
+    private Encoder newEnumTestMessage() throws Exception
+    {
+        return (Encoder)enumTestMessage.getConstructor().newInstance();
     }
 
     private void assertTestReqIdLength(final int expectedLength, final Object encoder) throws Exception

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
@@ -40,12 +40,6 @@ public final class Reflection
         set(object, setter, int.class, value);
     }
 
-    public static void setEnum(final Object object, final String setter, final Object value)
-        throws Exception
-    {
-        set(object, setter, value.getClass(), value);
-    }
-
     public static void setEnumByRepresentation(
         final Object object,
         final String setter,


### PR DESCRIPTION
We found that for all enum types, except for char-based ones, throw an exception if they do not have a value set when encoding and they are a required field.

This change introduces the same behaviour for char-based enums, where if we write the default value we end up with a corrupted FIX message