### PR TITLE
Changed AsciiBuffer::scan to use exclusive end index.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/AsciiBuffer.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/AsciiBuffer.java
@@ -81,9 +81,9 @@ public interface AsciiBuffer extends DirectBuffer
 
     int scanBack(int startInclusive, int endExclusive, byte terminator);
 
-    int scan(int startInclusive, int endInclusive, char terminatingCharacter);
+    int scan(int startInclusive, int endExclusive, char terminatingCharacter);
 
-    int scan(int startInclusive, int endInclusive, byte terminator);
+    int scan(int startInclusive, int endExclusive, byte terminator);
 
-    int computeChecksum(int offset, int end);
+    int computeChecksum(int startInclusive, int endExclusive);
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
@@ -199,7 +199,7 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
 
     public int scanBack(final int startInclusive, final int endExclusive, final byte terminator)
     {
-        for (int index = startInclusive; index >= endExclusive; index--)
+        for (int index = startInclusive; index > endExclusive; index--)
         {
             final byte value = getByte(index);
             if (value == terminator)
@@ -211,15 +211,15 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
         return UNKNOWN_INDEX;
     }
 
-    public int scan(final int startInclusive, final int endInclusive, final char terminatingCharacter)
+    public int scan(final int startInclusive, final int endExclusive, final char terminatingCharacter)
     {
-        return scan(startInclusive, endInclusive, (byte)terminatingCharacter);
+        return scan(startInclusive, endExclusive, (byte)terminatingCharacter);
     }
 
-    public int scan(final int startInclusive, final int endInclusive, final byte terminator)
+    public int scan(final int startInclusive, final int endExclusive, final byte terminator)
     {
         int indexValue = UNKNOWN_INDEX;
-        for (int i = startInclusive; i <= endInclusive; i++)
+        for (int i = startInclusive; i < endExclusive; i++)
         {
             final byte value = getByte(i);
             if (value == terminator)
@@ -232,10 +232,10 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
         return indexValue;
     }
 
-    public int computeChecksum(final int offset, final int end)
+    public int computeChecksum(final int startInclusive, final int endExclusive)
     {
         int total = 0;
-        for (int index = offset; index < end; index++)
+        for (int index = startInclusive; index < endExclusive; index++)
         {
             total += getByte(index);
         }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -1326,7 +1326,7 @@ public abstract class AbstractDecoderGeneratorTest
         assertThat(decoder4.validate(), is(false));
 
         assertRejectReason(decoder1, RejectReason.VALUE_IS_INCORRECT);
-        assertRejectReason(decoder2, RejectReason.VALUE_IS_INCORRECT);
+        assertRejectReason(decoder2, RejectReason.REQUIRED_TAG_MISSING);
         assertRejectReason(decoder3, RejectReason.VALUE_IS_INCORRECT);
         assertRejectReason(decoder4, RejectReason.REQUIRED_TAG_MISSING);
     }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixReceiverEndPoint.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixReceiverEndPoint.java
@@ -371,7 +371,7 @@ class FixReceiverEndPoint extends ReceiverEndPoint
 
     private int scanEndOfMessage(final int startOfChecksumValue)
     {
-        return buffer.scan(startOfChecksumValue, usedBufferData - 1, START_OF_HEADER);
+        return buffer.scan(startOfChecksumValue, usedBufferData, START_OF_HEADER);
     }
 
     private int scanForBodyLength(final int offset, final long readTimestamp)
@@ -401,12 +401,12 @@ class FixReceiverEndPoint extends ReceiverEndPoint
 
     private int scanEndOfBodyLength(final int startOfBodyLength)
     {
-        return buffer.scan(startOfBodyLength + 1, usedBufferData - 1, START_OF_HEADER);
+        return buffer.scan(startOfBodyLength + 1, usedBufferData, START_OF_HEADER);
     }
 
     private int scanNextField(final int startScan)
     {
-        return buffer.scan(startScan + 1, usedBufferData - 1, START_OF_HEADER);
+        return buffer.scan(startScan + 1, usedBufferData, START_OF_HEADER);
     }
 
     private void startAuthenticationFlow(final int offset, final int length, final long messageType)

--- a/artio-system-tests/src/perf/java/uk/co/real_logic/artio/system_benchmarks/AbstractBenchmarkClient.java
+++ b/artio-system-tests/src/perf/java/uk/co/real_logic/artio/system_benchmarks/AbstractBenchmarkClient.java
@@ -159,7 +159,7 @@ public abstract class AbstractBenchmarkClient
 
             while (index < length)
             {
-                index = readFlyweight.scan(index, length - 1, NINE);
+                index = readFlyweight.scan(index, length, NINE);
 
                 if (index == UNKNOWN_INDEX)
                 {


### PR DESCRIPTION
There was confusion around that, when some callers passed inclusive index while others (including generated decoders) exclusive. This commit settles on using exclusive index, which is more consistent with other commonly used java APIs.