### PR TITLE
Fix wrong filePosition of session context after reload. 

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContexts.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContexts.java
@@ -199,7 +199,8 @@ public class SessionContexts
                 final FixDictionary thisDictionary = (dictionary == null) ?
                     FixDictionary.of(FixDictionary.find(lastFixDictionary)) : dictionary;
                 final SessionContext sessionContext = new SessionContext(compositeKey,
-                    sessionId, sequenceIndex, lastLogonTime, lastSequenceResetTime, this, filePosition,
+                    sessionId, sequenceIndex, lastLogonTime, lastSequenceResetTime, this,
+                    sessionIdDecoder.initialOffset(),
                     initialSequenceIndex, thisDictionary);
                 compositeToContext.put(compositeKey, sessionContext);
 

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionContextsTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionContextsTest.java
@@ -116,6 +116,19 @@ public class SessionContextsTest
     }
 
     @Test
+    public void sessionPersistedCorrectlyAfterARestart()
+    {
+        sessionContexts.onLogon(aSession, fixDictionary);
+        final SessionContexts sessionContextsAfterRestart = newSessionContexts(buffer);
+        final SessionContext reloadedAContext = sessionContextsAfterRestart.onLogon(aSession, fixDictionary);
+        reloadedAContext.onSequenceReset(time + 1);
+
+        final SessionContexts sessionContextsAfterSecondRestart = newSessionContexts(buffer);
+        final SessionContext reloadedAgainContext = sessionContextsAfterSecondRestart.onLogon(aSession, fixDictionary);
+        assertEquals(time + 1, reloadedAgainContext.lastSequenceResetTime());
+    }
+
+    @Test
     public void continuesIncrementingSessionContextsAfterRestart()
     {
         final SessionContext bContext = sessionContexts.onLogon(bSession, fixDictionary);


### PR DESCRIPTION
Everything works fine till next restart when composite key usually can not be load, because last state where persisted to composite key offset. Test case added (fails with OutOfBoundsException without changes)