### PR TITLE
fix sequence reset to apply sequence numbers after restart

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/SequenceNumberIndexWriter.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/SequenceNumberIndexWriter.java
@@ -285,7 +285,7 @@ public class SequenceNumberIndexWriter implements Index
                 case ResetSequenceNumberDecoder.TEMPLATE_ID:
                 {
                     resetSequenceNumber.wrap(buffer, offset, actingBlockLength, version);
-                    saveRecord(0, resetSequenceNumber.session(), endPosition, NO_REQUIRED_POSITION);
+                    resetSequenceNumber(resetSequenceNumber.session(), endPosition);
                     break;
                 }
 
@@ -515,6 +515,11 @@ public class SequenceNumberIndexWriter implements Index
         return framerContext.offer(response);
     }
 
+    void resetSequenceNumber(final long session, final long endPosition)
+    {
+        saveRecord(0, session, endPosition, NO_REQUIRED_POSITION);
+    }
+
     void resetSequenceNumbers()
     {
         inMemoryBuffer.setMemory(0, indexedPositionsOffset, (byte)0);
@@ -692,7 +697,7 @@ public class SequenceNumberIndexWriter implements Index
                 }
 
                 lastKnownDecoder.wrap(inMemoryBuffer, position, RECORD_SIZE, SCHEMA_VERSION);
-                if (lastKnownDecoder.sequenceNumber() == 0)
+                if (lastKnownDecoder.sequenceNumber() == 0 && newSequenceNumber != 0)
                 {
                     // Don't redact if there's nothing to redact
                     if (requiredPosition == NO_REQUIRED_POSITION)
@@ -704,6 +709,7 @@ public class SequenceNumberIndexWriter implements Index
                 }
                 else if (lastKnownDecoder.sessionId() == sessionId)
                 {
+                    recordOffsets.put(sessionId, position);
                     updateSequenceNumber(newSequenceNumber, position, messagePosition, requiredPosition);
                     return position;
                 }


### PR DESCRIPTION
In case several sessions are reset (we do it after restart based on settings) it appears they all set the same position to 0, and some of them are not effectively reset in fact. reproduction case looks tricky, but it happens with the scenario