### PR TITLE
make replay position buffer size configurable

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
@@ -136,6 +136,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     public static final int DEFAULT_SEQUENCE_NUMBER_INDEX_SIZE = 8 * 1024 * 1024;
     public static final int DEFAULT_SESSION_ID_BUFFER_SIZE = 4 * 1024 * 1024;
     public static final int DEFAULT_SENDER_MAX_BYTES_IN_BUFFER = 4 * 1024 * 1024;
+    public static final int DEFAULT_REPLAY_POSITION_BUFFER_SIZE = 4 * 1024;
     public static final int DEFAULT_NO_LOGON_DISCONNECT_TIMEOUT = (int)SECONDS.toMillis(5);
     public static final String DEFAULT_SESSION_ID_FILE = "session_id_buffer";
     public static final String DEFAULT_ILINK3_ID_FILE = "ilink3_id_buffer";
@@ -238,6 +239,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     private int initialSequenceIndex = DEFAULT_INITIAL_SEQUENCE_INDEX;
     private MessageTimingHandler messageTimingHandler = null;
     private int maxConcurrentSessionReplays = DEFAULT_MAX_CONCURRENT_SESSION_REPLAYS;
+    private int replayPositionBufferSize = DEFAULT_REPLAY_POSITION_BUFFER_SIZE;
 
     /**
      * Sets the local address to bind to when the Gateway is used to accept connections.
@@ -771,6 +773,12 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
         return this;
     }
 
+    public EngineConfiguration replayPositionBufferSize(final int replayPositionBufferSize)
+    {
+        this.replayPositionBufferSize = replayPositionBufferSize;
+        return this;
+    }
+
     public int receiverBufferSize()
     {
         return receiverBufferSize;
@@ -983,6 +991,11 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     public int maxConcurrentSessionReplays()
     {
         return maxConcurrentSessionReplays;
+    }
+
+    public int replayPositionBufferSize()
+    {
+        return replayPositionBufferSize;
     }
 
     /**

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineContext.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineContext.java
@@ -174,7 +174,7 @@ public class EngineContext implements AutoCloseable
             cacheNumSets,
             cacheSetSize,
             LoggerUtil::map,
-            ReplayIndexDescriptor.replayPositionBuffer(logFileDir, streamId),
+            ReplayIndexDescriptor.replayPositionBuffer(logFileDir, streamId, configuration.replayPositionBufferSize()),
             errorHandler,
             recordingIdLookup,
             connectionIdToILinkUuid);

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayIndexDescriptor.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayIndexDescriptor.java
@@ -27,8 +27,6 @@ import java.util.Objects;
 
 public final class ReplayIndexDescriptor
 {
-    static final int REPLAY_POSITION_BUFFER_SIZE = 4 * 1024;
-
     private static final int BEGIN_CHANGE_OFFSET = MessageHeaderEncoder.ENCODED_LENGTH;
     private static final int END_CHANGE_OFFSET = BEGIN_CHANGE_OFFSET + BitUtil.SIZE_OF_LONG;
 
@@ -71,10 +69,10 @@ public final class ReplayIndexDescriptor
         return sessionIds;
     }
 
-    public static UnsafeBuffer replayPositionBuffer(final String logFileDir, final int streamId)
+    public static UnsafeBuffer replayPositionBuffer(final String logFileDir, final int streamId, final int bufferSize)
     {
         final String pathname = replayPositionPath(logFileDir, streamId);
-        return new UnsafeBuffer(LoggerUtil.map(new File(pathname), REPLAY_POSITION_BUFFER_SIZE));
+        return new UnsafeBuffer(LoggerUtil.map(new File(pathname), bufferSize));
     }
 
     static String replayPositionPath(final String logFileDir, final int streamId)

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayIndexTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayIndexTest.java
@@ -39,6 +39,7 @@ import uk.co.real_logic.artio.Clock;
 import uk.co.real_logic.artio.CommonConfiguration;
 import uk.co.real_logic.artio.TestFixtures;
 import uk.co.real_logic.artio.dictionary.generation.Exceptions;
+import uk.co.real_logic.artio.engine.EngineConfiguration;
 import uk.co.real_logic.artio.messages.MessageHeaderEncoder;
 import uk.co.real_logic.artio.protocol.GatewayPublication;
 import uk.co.real_logic.artio.session.Session;
@@ -59,7 +60,6 @@ import static uk.co.real_logic.artio.TestFixtures.cleanupMediaDriver;
 import static uk.co.real_logic.artio.TestFixtures.largeTestReqId;
 import static uk.co.real_logic.artio.engine.EngineConfiguration.*;
 import static uk.co.real_logic.artio.engine.logger.ReplayIndexDescriptor.RECORD_LENGTH;
-import static uk.co.real_logic.artio.engine.logger.ReplayIndexDescriptor.REPLAY_POSITION_BUFFER_SIZE;
 import static uk.co.real_logic.artio.engine.logger.Replayer.MOST_RECENT_MESSAGE;
 
 public class ReplayIndexTest extends AbstractLogTest
@@ -83,7 +83,8 @@ public class ReplayIndexTest extends AbstractLogTest
 
     private ReplayIndex replayIndex;
 
-    private final UnsafeBuffer replayPositionBuffer = new UnsafeBuffer(new byte[REPLAY_POSITION_BUFFER_SIZE]);
+    private final UnsafeBuffer replayPositionBuffer =
+        new UnsafeBuffer(new byte[EngineConfiguration.DEFAULT_REPLAY_POSITION_BUFFER_SIZE]);
     private final IndexedPositionConsumer positionConsumer = mock(IndexedPositionConsumer.class);
     private final IndexedPositionReader positionReader = new IndexedPositionReader(replayPositionBuffer);
 


### PR DESCRIPTION
Add an option to configure replay position buffer.

It seems the ReplayIndexDescriptor.REPLAY_POSITION_BUFFER_SIZE value is too small. 
It allow to keep only 4096/24 records.

artio freeze during startup at:
uk.co.real_logic.artio.engine.logger.IndexedPositionWriter.indexedUpTo(IndexedPositionWriter.java:132)
        at uk.co.real_logic.artio.engine.logger.ReplayIndex.onFragment(ReplayIndex.java:199)
        at uk.co.real_logic.artio.engine.logger.ReplayIndex.onFragment(ReplayIndex.java:128)
        at uk.co.real_logic.artio.engine.logger.Indexer.onFragment(Indexer.java:181)

