### PR TITLE
allow more tolerant time-parsing

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/UtcTimestampDecoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/UtcTimestampDecoder.java
@@ -27,10 +27,10 @@ import static uk.co.real_logic.artio.fields.UtcDateOnlyDecoder.LENGTH;
  * Equivalent to a Java format string of "yyyyMMdd-HH:mm:ss[.SSS]". The builtin parsers could cope with
  * this situation, but allocate and perform poorly.
  * <p>
- * If the final fraction of the second is expected to be in 3 characters and only supports up to
- * millisecond precision then you can use the normal {@link UtcTimestampDecoder#decode(AsciiBuffer, int, int)} method.
+ * If the final fraction of the second is expected to be in 3 characters and only supports up to millisecond precision
+ * then you can use the normal {@link UtcTimestampDecoder#decode(AsciiBuffer, int, int, boolean)} method.
  * Support for microsecond precision, eg: "yyyyMMdd-HH:mm:ss[.SSSSSS]" is provided through the
- * {@link UtcTimestampDecoder#decodeMicros(AsciiBuffer, int, int)} method.
+ * {@link UtcTimestampDecoder#decodeMicros(AsciiBuffer, int, int, boolean)} method.
  */
 public final class UtcTimestampDecoder
 {
@@ -49,11 +49,20 @@ public final class UtcTimestampDecoder
     private static final int TIME_OFFSET = LENGTH + 1;
 
     private final AsciiBuffer buffer = new MutableAsciiBuffer();
+    private final boolean strict;
+
+    /**
+     * @param strict if length of FIX encoded value has to be checked to match FIX specification
+     */
+    public UtcTimestampDecoder(final boolean strict)
+    {
+        this.strict = strict;
+    }
 
     public long decode(final byte[] bytes, final int length)
     {
         buffer.wrap(bytes);
-        return decode(buffer, 0, length);
+        return decode(buffer, 0, length, strict);
     }
 
     public long decode(final byte[] bytes)
@@ -64,7 +73,7 @@ public final class UtcTimestampDecoder
     public long decodeMicros(final byte[] bytes, final int length)
     {
         buffer.wrap(bytes);
-        return decodeMicros(buffer, 0, length);
+        return decodeMicros(buffer, 0, length, strict);
     }
 
     public long decodeMicros(final byte[] bytes)
@@ -75,7 +84,7 @@ public final class UtcTimestampDecoder
     public long decodeNanos(final byte[] bytes, final int length)
     {
         buffer.wrap(bytes);
-        return decodeNanos(buffer, 0, length);
+        return decodeNanos(buffer, 0, length, strict);
     }
 
     public long decodeNanos(final byte[] bytes)
@@ -87,13 +96,14 @@ public final class UtcTimestampDecoder
      * @param timestamp a buffer containing the FIX encoded value of the timestamp in ASCII
      * @param offset the offset within the timestamp buffer where the value starts
      * @param length the length of the FIX encoded value in bytes / ASCII characters
+     * @param strict if length of FIX encoded value has to be checked to match FIX specification
      * @return the number of milliseconds since the Unix Epoch that represents this timestamp
      */
-    public static long decode(final AsciiBuffer timestamp, final int offset, final int length)
+    public static long decode(final AsciiBuffer timestamp, final int offset, final int length, final boolean strict)
     {
         final long epochDay = UtcDateOnlyDecoder.decode(timestamp, offset);
         final long millisecondOfDay = UtcTimeOnlyDecoder.decode(
-            timestamp, offset + TIME_OFFSET, length - TIME_OFFSET);
+            timestamp, offset + TIME_OFFSET, length - TIME_OFFSET, strict);
         return epochDay * MILLIS_IN_DAY + millisecondOfDay;
     }
 
@@ -101,13 +111,15 @@ public final class UtcTimestampDecoder
      * @param timestamp a buffer containing the FIX encoded value of the timestamp in ASCII
      * @param offset the offset within the timestamp buffer where the value starts
      * @param length the length of the FIX encoded value in bytes / ASCII characters
+     * @param strict if length of FIX encoded value has to be checked to match FIX specification
      * @return the number of microseconds since the Unix Epoch that represents this timestamp
      */
-    public static long decodeMicros(final AsciiBuffer timestamp, final int offset, final int length)
+    public static long decodeMicros(final AsciiBuffer timestamp, final int offset, final int length,
+        final boolean strict)
     {
         final long epochDay = UtcDateOnlyDecoder.decode(timestamp, offset);
         final long microsOfDay = UtcTimeOnlyDecoder.decodeMicros(
-            timestamp, offset + TIME_OFFSET, length - TIME_OFFSET);
+            timestamp, offset + TIME_OFFSET, length - TIME_OFFSET, strict);
         return epochDay * MICROS_IN_DAY + microsOfDay;
     }
 
@@ -115,13 +127,15 @@ public final class UtcTimestampDecoder
      * @param timestamp a buffer containing the FIX encoded value of the timestamp in ASCII
      * @param offset the offset within the timestamp buffer where the value starts
      * @param length the length of the FIX encoded value in bytes / ASCII characters
+     * @param strict if length of FIX encoded value has to be checked to match FIX specification
      * @return the number of nanoseconds since the Unix Epoch that represents this timestamp
      */
-    public static long decodeNanos(final AsciiBuffer timestamp, final int offset, final int length)
+    public static long decodeNanos(final AsciiBuffer timestamp, final int offset, final int length,
+        final boolean strict)
     {
         final long epochDay = UtcDateOnlyDecoder.decode(timestamp, offset);
         final long nanosOfDay = UtcTimeOnlyDecoder.decodeNanos(
-            timestamp, offset + TIME_OFFSET, length - TIME_OFFSET);
+            timestamp, offset + TIME_OFFSET, length - TIME_OFFSET, strict);
         return epochDay * NANOS_IN_DAY + nanosOfDay;
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
@@ -180,12 +180,12 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
 
     public long getUtcTimestamp(final int offset, final int length)
     {
-        return UtcTimestampDecoder.decode(this, offset, length);
+        return UtcTimestampDecoder.decode(this, offset, length, true);
     }
 
     public long getUtcTimeOnly(final int offset, final int length)
     {
-        return UtcTimeOnlyDecoder.decode(this, offset, length);
+        return UtcTimeOnlyDecoder.decode(this, offset, length, true);
     }
 
     public int getUtcDateOnly(final int offset)

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -1026,7 +1026,7 @@ public abstract class AbstractDecoderGeneratorTest
         final Decoder decoder = decodeHeartbeat(SHORT_TIMESTAMP_MESSAGE);
 
         final byte[] someTime = getSomeTimeField(decoder);
-        final UtcTimestampDecoder someTimeDecoder = new UtcTimestampDecoder();
+        final UtcTimestampDecoder someTimeDecoder = new UtcTimestampDecoder(true);
         final long someTimeValue = someTimeDecoder.decode(someTime, someTime.length);
         assertEquals(0, someTimeValue);
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampCodecsTrailingZerosTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampCodecsTrailingZerosTest.java
@@ -63,15 +63,15 @@ public class UtcTimestampCodecsTrailingZerosTest
         buffer.putBytes(1, bytes);
 
         // Normal
-        long result = UtcTimestampDecoder.decodeNanos(buffer, 1, LENGTH_WITH_NANOSECONDS);
+        long result = UtcTimestampDecoder.decodeNanos(buffer, 1, LENGTH_WITH_NANOSECONDS, true);
         assertEquals(EPOCH_NANOS, result);
 
         // Short
-        result = UtcTimestampDecoder.decodeNanos(buffer, 1, LENGTH_WITH_MICROSECONDS);
+        result = UtcTimestampDecoder.decodeNanos(buffer, 1, LENGTH_WITH_MICROSECONDS, true);
         assertEquals(EPOCH_NANOS, result);
 
         // Long
-        result = UtcTimestampDecoder.decode(buffer, 1, LENGTH_WITH_NANOSECONDS);
+        result = UtcTimestampDecoder.decode(buffer, 1, LENGTH_WITH_NANOSECONDS, true);
         assertEquals(EPOCH_MILLIS, result);
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderInvalidCasesTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderInvalidCasesTest.java
@@ -52,12 +52,12 @@ public class UtcTimestampDecoderInvalidCasesTest
     @Test(expected = IllegalArgumentException.class)
     public void cannotParseTimestamp()
     {
-        new UtcTimestampDecoder().decode(timestamp.getBytes(US_ASCII));
+        new UtcTimestampDecoder(true).decode(timestamp.getBytes(US_ASCII));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void cannotParseTimestampMicros()
     {
-        new UtcTimestampDecoder().decodeMicros(timestamp.getBytes(US_ASCII));
+        new UtcTimestampDecoder(true).decodeMicros(timestamp.getBytes(US_ASCII));
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderNonStrictCasesTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderNonStrictCasesTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.fields;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import uk.co.real_logic.artio.util.MutableAsciiBuffer;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.time.temporal.ChronoField.MICRO_OF_SECOND;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static uk.co.real_logic.artio.fields.UtcTimestampDecoder.LENGTH_WITH_NANOSECONDS;
+
+@RunWith(Parameterized.class)
+public class UtcTimestampDecoderNonStrictCasesTest
+{
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+        .appendPattern("yyyyMMdd-HH:mm:ss")
+        .appendFraction(NANO_OF_SECOND, 0, 9, true)
+        .toFormatter();
+
+    public static long toEpochMillis(final String timestamp)
+    {
+        final LocalDateTime parsedDate = LocalDateTime.parse(timestamp, FORMATTER);
+        final ZonedDateTime utc = ZonedDateTime.of(parsedDate, ZoneId.of("UTC"));
+        return SECONDS.toMillis(utc.toEpochSecond()) + utc.getLong(MILLI_OF_SECOND);
+    }
+
+    public static long toEpochMicros(final String timestamp)
+    {
+        final LocalDateTime parsedDate = LocalDateTime.parse(timestamp, FORMATTER);
+        final ZonedDateTime utc = ZonedDateTime.of(parsedDate, ZoneId.of("UTC"));
+        return SECONDS.toMicros(utc.toEpochSecond()) + utc.getLong(MICRO_OF_SECOND);
+    }
+
+    public static long toEpochNanos(final String timestamp)
+    {
+        final LocalDateTime parsedDate = LocalDateTime.parse(timestamp, FORMATTER);
+        final ZonedDateTime utc = ZonedDateTime.of(parsedDate, ZoneId.of("UTC"));
+        return SECONDS.toNanos(utc.toEpochSecond()) + utc.getLong(NANO_OF_SECOND);
+    }
+
+    private final int length;
+    private final long expectedEpochMillis;
+    private final long expectedEpochMicros;
+    private final long expectedEpochNanos;
+    private final MutableAsciiBuffer buffer;
+    private final String timestamp;
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList(
+            new Object[] {"20150225-17:51:32"},
+            new Object[] {"20150225-17:51:32.1"},
+            new Object[] {"20600225-17:51:32.123"},
+            new Object[] {"20600225-17:51:32.1234"},
+            new Object[] {"20600225-17:51:32.12345"},
+            new Object[] {"20600225-17:51:32.123456"},
+            new Object[] {"20600225-17:51:32.1234567"},
+            new Object[] {"20600225-17:51:32.12345678"},
+            new Object[] {"20600225-17:51:32.123456789"}
+        );
+    }
+
+    public UtcTimestampDecoderNonStrictCasesTest(final String timestamp)
+    {
+        this.timestamp = timestamp;
+        this.length = timestamp.length();
+
+        expectedEpochMillis = toEpochMillis(timestamp);
+        expectedEpochMicros = toEpochMicros(timestamp);
+        expectedEpochNanos = toEpochNanos(timestamp);
+
+        final byte[] bytes = timestamp.getBytes(US_ASCII);
+        buffer = new MutableAsciiBuffer(new byte[LENGTH_WITH_NANOSECONDS + 2]);
+        buffer.putBytes(1, bytes);
+    }
+
+    @Test
+    public void shouldParseTimestampMillis()
+    {
+        final long epochMillis = UtcTimestampDecoder.decode(buffer, 1, length, false);
+        assertEquals("Failed Millis testcase for: " + timestamp, expectedEpochMillis, epochMillis);
+    }
+
+    @Test
+    public void shouldParseTimestampMicros()
+    {
+        final long epochMicros = UtcTimestampDecoder.decodeMicros(buffer, 1, length, false);
+        assertEquals("Failed Micros testcase for: " + buffer.getAscii(1, length),
+            expectedEpochMicros, epochMicros);
+    }
+
+    @Test
+    public void shouldParseTimestampNanos()
+    {
+        final long epochNanos = UtcTimestampDecoder.decodeNanos(buffer, 1, length, false);
+        assertEquals("Failed Nanos testcase for: " + timestamp, expectedEpochNanos, epochNanos);
+    }
+}

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderValidCasesTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderValidCasesTest.java
@@ -100,7 +100,7 @@ public class UtcTimestampDecoderValidCasesTest
 
     private void assertDecodeMillis(final int lengthWithMicroseconds)
     {
-        final long epochMillis = UtcTimestampDecoder.decode(buffer, 1, lengthWithMicroseconds);
+        final long epochMillis = UtcTimestampDecoder.decode(buffer, 1, lengthWithMicroseconds, true);
         assertEquals("Failed Millis testcase for: " + timestamp, expectedEpochMillis, epochMillis);
     }
 
@@ -129,7 +129,7 @@ public class UtcTimestampDecoderValidCasesTest
 
     private void assertDecodesMicros(final int length)
     {
-        final long epochMicros = UtcTimestampDecoder.decodeMicros(buffer, 1, length);
+        final long epochMicros = UtcTimestampDecoder.decodeMicros(buffer, 1, length, true);
         assertEquals("Failed Micros testcase for: " + buffer.getAscii(1, length),
             expectedEpochMicros, epochMicros);
     }
@@ -162,7 +162,7 @@ public class UtcTimestampDecoderValidCasesTest
 
     private void assertDecodesNanos(final int length)
     {
-        final long epochNanos = UtcTimestampDecoder.decodeNanos(buffer, 1, length);
+        final long epochNanos = UtcTimestampDecoder.decodeNanos(buffer, 1, length, true);
         assertEquals("Failed Nanos testcase for: " + timestamp, expectedEpochNanos, epochNanos);
     }
 

--- a/artio-core/src/main/java/uk/co/real_logic/artio/CommonConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/CommonConfiguration.java
@@ -249,6 +249,7 @@ public class CommonConfiguration
     private int outboundLibraryStream = DEFAULT_OUTBOUND_LIBRARY_STREAM;
     private boolean gracefulShutdown = true;
     private boolean validateCompIdsOnEveryMessage = true;
+    private boolean validateTimeStrictly = true;
     private EpochFractionFormat sessionEpochFractionFormat = EpochFractionFormat.MILLISECONDS;
 
     private final AtomicBoolean isConcluded = new AtomicBoolean(false);
@@ -562,6 +563,19 @@ public class CommonConfiguration
     }
 
     /**
+     * Set to true in order to validate that time from sender corresponds to FIX time format.
+     * See http://fixwiki.org/fixwiki/UTCTimestampDataType for details.
+     *
+     * @param validateTimeStrictly true to validate time matches format
+     * @return this
+     */
+    public CommonConfiguration validateTimeStrictly(final boolean validateTimeStrictly)
+    {
+        this.validateTimeStrictly = validateTimeStrictly;
+        return this;
+    }
+
+    /**
      * Sets the time precision that the the session logic uses to encode time stamps.
      *
      * @param sessionEpochFractionFormat the format to use.
@@ -677,6 +691,11 @@ public class CommonConfiguration
     public boolean validateCompIdsOnEveryMessage()
     {
         return validateCompIdsOnEveryMessage;
+    }
+
+    public boolean validateTimeStrictly()
+    {
+        return validateTimeStrictly;
     }
 
     public EpochFractionFormat sessionEpochFractionFormat()

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/GatewaySessions.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/GatewaySessions.java
@@ -79,6 +79,7 @@ class GatewaySessions
     private final long reasonableTransmissionTimeInMs;
     private final boolean logAllMessages;
     private final boolean validateCompIdsOnEveryMessage;
+    private final boolean validateTimeStrictly;
     private final SessionContexts sessionContexts;
     private final SessionPersistenceStrategy sessionPersistenceStrategy;
     private final SequenceNumberIndexReader sentSequenceNumberIndex;
@@ -122,6 +123,7 @@ class GatewaySessions
         this.reasonableTransmissionTimeInMs = configuration.reasonableTransmissionTimeInMs();
         this.logAllMessages = configuration.logAllMessages();
         this.validateCompIdsOnEveryMessage = configuration.validateCompIdsOnEveryMessage();
+        this.validateTimeStrictly = configuration.validateTimeStrictly();
         this.clock = configuration.clock();
         this.errorHandler = errorHandler;
         this.sessionContexts = sessionContexts;
@@ -210,6 +212,7 @@ class GatewaySessions
             validationStrategy,
             errorHandler,
             validateCompIdsOnEveryMessage,
+            validateTimeStrictly,
             messageInfo,
             sessionIdStrategy);
 

--- a/artio-core/src/main/java/uk/co/real_logic/artio/library/LibraryPoller.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/library/LibraryPoller.java
@@ -1720,7 +1720,8 @@ final class LibraryPoller implements LibraryEndPointHandler, ProtocolHandler, Au
         final MessageValidationStrategy validationStrategy = configuration.messageValidationStrategy();
         final SessionParser parser = new SessionParser(
             session, validationStrategy,
-            THROW_ERRORS, configuration.validateCompIdsOnEveryMessage(), messageInfo, sessionIdStrategy);
+            THROW_ERRORS, configuration.validateCompIdsOnEveryMessage(), configuration.validateTimeStrictly(),
+            messageInfo, sessionIdStrategy);
         parser.sessionKey(compositeKey);
         parser.fixDictionary(fixDictionary);
         final SessionSubscriber subscriber = new SessionSubscriber(

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionParser.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionParser.java
@@ -45,7 +45,7 @@ import static uk.co.real_logic.artio.session.Session.UNKNOWN;
 public class SessionParser
 {
     private final AsciiBuffer asciiBuffer = new MutableAsciiBuffer();
-    private final UtcTimestampDecoder timestampDecoder = new UtcTimestampDecoder();
+    private final UtcTimestampDecoder timestampDecoder;
 
     private AbstractLogonDecoder logon;
     private AbstractLogoutDecoder logout;
@@ -70,6 +70,7 @@ public class SessionParser
         final MessageValidationStrategy validationStrategy,
         final ErrorHandler errorHandler,
         final boolean validateCompIdsOnEveryMessage,
+        final boolean validateTimeStrictly,
         final OnMessageInfo messageInfo,
         final SessionIdStrategy sessionIdStrategy)
     {
@@ -79,6 +80,7 @@ public class SessionParser
         this.validateCompIdsOnEveryMessage = validateCompIdsOnEveryMessage;
         this.messageInfo = messageInfo;
         this.sessionIdStrategy = sessionIdStrategy;
+        this.timestampDecoder = new UtcTimestampDecoder(validateTimeStrictly);
     }
 
     public void fixDictionary(final FixDictionary fixDictionary)

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/AbstractLogTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/AbstractLogTest.java
@@ -42,7 +42,7 @@ public class AbstractLogTest
 {
     protected static final String ORIGINAL_SENDING_TIME = "19700101-00:00:00";
     protected static final long ORIGINAL_SENDING_EPOCH_MS =
-        new UtcTimestampDecoder().decode(ORIGINAL_SENDING_TIME.getBytes(US_ASCII));
+        new UtcTimestampDecoder(true).decode(ORIGINAL_SENDING_TIME.getBytes(US_ASCII));
 
     protected static final long SESSION_ID = 1;
     protected static final long SESSION_ID_2 = 2;

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayerTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayerTest.java
@@ -73,7 +73,7 @@ public class ReplayerTest extends AbstractLogTest
 {
     private static final String DATE_TIME_STR = "19840521-15:00:00.000";
     private static final long DATE_TIME_EPOCH_MS =
-        new UtcTimestampDecoder().decode(DATE_TIME_STR.getBytes(US_ASCII));
+        new UtcTimestampDecoder(true).decode(DATE_TIME_STR.getBytes(US_ASCII));
 
     public static final byte[] MESSAGE_REQUIRING_LONGER_BODY_LENGTH =
         ("8=FIX.4.4\0019=99\00135=1\00134=1\00149=LEH_LZJ02\00152=" + ORIGINAL_SENDING_TIME + "\00156=CCG\001" +

--- a/artio-core/src/test/java/uk/co/real_logic/artio/session/SessionParserTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/session/SessionParserTest.java
@@ -42,7 +42,7 @@ public class SessionParserTest
 
     private final SessionParser parser = new SessionParser(
         mockSession, validationStrategy, LangUtil::rethrowUnchecked,
-        false, messageInfo, null);
+        false, true, messageInfo, null);
 
     @Before
     public void setUp()


### PR DESCRIPTION
we have some parthers, who remove trailing zeroes in time fields. while that's non-compliant with FIX spec, it still can be parsed anyway. Added a configuration parameter to turn this on/off