### PR TITLE
accept exceeding gap range in resend

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
@@ -1650,6 +1650,8 @@ public class Session
                     lastResentMsgSeqNo = 0;
                     lastResendChunkMsgSeqNum = 0;
                     endOfResendRequestRange = 0;
+                    // if new sequence is beyond original sequence
+                    // accept it so that new messages will not cause resend request
                     if (lastReceivedMsgSeqNum < newSeqNo)
                     {
                         lastReceivedMsgSeqNum(newSeqNo - 1);

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
@@ -1650,6 +1650,10 @@ public class Session
                     lastResentMsgSeqNo = 0;
                     lastResendChunkMsgSeqNum = 0;
                     endOfResendRequestRange = 0;
+                    if (lastReceivedMsgSeqNum < newSeqNo)
+                    {
+                        lastReceivedMsgSeqNum(newSeqNo - 1);
+                    }
                 }
                 else
                 {

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FixConnection.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FixConnection.java
@@ -418,6 +418,18 @@ final class FixConnection implements AutoCloseable
         return readMessage(new LogoutDecoder());
     }
 
+    public void sendGapFill(final int msgSeqNum, final int newMsgSeqNum)
+    {
+        final SequenceResetEncoder sequenceResetEncoder = new SequenceResetEncoder();
+        final HeaderEncoder headerEncoder = sequenceResetEncoder.header();
+
+        setupHeader(headerEncoder, msgSeqNum, false);
+        sequenceResetEncoder.newSeqNo(newMsgSeqNum)
+            .gapFillFlag(true);
+
+        send(sequenceResetEncoder);
+    }
+
     public void sendExecutionReport(final int msgSeqNum, final boolean possDupFlag)
     {
         final ExecutionReportEncoder executionReportEncoder = new ExecutionReportEncoder();

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FixConnection.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FixConnection.java
@@ -423,7 +423,7 @@ final class FixConnection implements AutoCloseable
         final SequenceResetEncoder sequenceResetEncoder = new SequenceResetEncoder();
         final HeaderEncoder headerEncoder = sequenceResetEncoder.header();
 
-        setupHeader(headerEncoder, msgSeqNum, false);
+        setupHeader(headerEncoder, msgSeqNum, true);
         sequenceResetEncoder.newSeqNo(newMsgSeqNum)
             .gapFillFlag(true);
 

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedInitiatorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedInitiatorSystemTest.java
@@ -19,7 +19,11 @@ import io.aeron.archive.ArchivingMediaDriver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import uk.co.real_logic.artio.*;
+import uk.co.real_logic.artio.Constants;
+import uk.co.real_logic.artio.OrdStatus;
+import uk.co.real_logic.artio.Reply;
+import uk.co.real_logic.artio.Side;
+import uk.co.real_logic.artio.Timing;
 import uk.co.real_logic.artio.builder.ExecutionReportEncoder;
 import uk.co.real_logic.artio.builder.HeaderEncoder;
 import uk.co.real_logic.artio.decoder.ExecutionReportDecoder;
@@ -35,13 +39,21 @@ import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static uk.co.real_logic.artio.Constants.EXECUTION_REPORT_MESSAGE_AS_STR;
 import static uk.co.real_logic.artio.Reply.State.COMPLETED;
-import static uk.co.real_logic.artio.TestFixtures.*;
+import static uk.co.real_logic.artio.TestFixtures.cleanupMediaDriver;
+import static uk.co.real_logic.artio.TestFixtures.launchMediaDriver;
+import static uk.co.real_logic.artio.TestFixtures.unusedPort;
 import static uk.co.real_logic.artio.Timing.assertEventuallyTrue;
 import static uk.co.real_logic.artio.messages.SessionState.ACTIVE;
-import static uk.co.real_logic.artio.system_tests.SystemTestUtil.*;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.ACCEPTOR_ID;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.INITIATOR_ID;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.LIBRARY_LIMIT;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.initiatingLibraryConfig;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.launchInitiatingEngine;
 
 // For reproducing error scenarios when initiating a connection
 public class MessageBasedInitiatorSystemTest
@@ -195,6 +207,43 @@ public class MessageBasedInitiatorSystemTest
             connection.readHeartbeat(testReqID);
         }
     }
+
+    @Test
+    public void shouldAcceptExtendedFillGap() throws IOException
+    {
+        final String testReqID = "thisIsATest";
+
+        try (FixConnection connection = acceptConnection())
+        {
+            sendLogonToAcceptor(connection);
+
+            connection.msgSeqNum(4).logon(false);
+
+            final Session session = lookupSession();
+            assertTrue(session.awaitingResend());
+
+            // Receive resend request for missing messages.
+            final ResendRequestDecoder resendRequestDecoder = connection.readMessage(new ResendRequestDecoder());
+            assertEquals(1, resendRequestDecoder.beginSeqNo());
+            assertEquals(0, resendRequestDecoder.endSeqNo());
+
+            // Fill the gap
+            connection.sendGapFill(1, 6);
+            connection.msgSeqNum(6).sendTestRequest(testReqID);
+
+            Timing.assertEventuallyTrue("Session has caught up", () ->
+            {
+                testSystem.poll();
+
+                return !session.awaitingResend();
+            });
+
+            testSystem.poll();
+
+            connection.readHeartbeat(testReqID);
+        }
+    }
+
 
     @Test
     public void shouldBeNotifiedOnDisconnect() throws IOException

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedInitiatorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedInitiatorSystemTest.java
@@ -199,10 +199,8 @@ public class MessageBasedInitiatorSystemTest
             {
                 testSystem.poll();
 
-                return !session.awaitingResend();
+                return !session.awaitingResend() && session.lastReceivedMsgSeqNum() == 5;
             });
-
-            testSystem.poll();
 
             connection.readHeartbeat(testReqID);
         }
@@ -235,10 +233,8 @@ public class MessageBasedInitiatorSystemTest
             {
                 testSystem.poll();
 
-                return !session.awaitingResend();
+                return !session.awaitingResend() && session.lastReceivedMsgSeqNum() == 6;
             });
-
-            testSystem.poll();
 
             connection.readHeartbeat(testReqID);
         }


### PR DESCRIPTION
Some partners exceed the range we expect with new sequence. Generally it can be seen artio does not reject this, and stops awaiting a resend, however in this case seq num stays where it was at the resend request.