### PR TITLE
add reftag id to malformed message rejects

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/MalformedTagFormatException.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/MalformedTagFormatException.java
@@ -1,0 +1,17 @@
+package uk.co.real_logic.artio.session;
+
+public class MalformedTagFormatException extends RuntimeException
+{
+    private final int refTagId;
+
+    public MalformedTagFormatException(final int refTagId, final Throwable cause)
+    {
+        super(cause);
+        this.refTagId = refTagId;
+    }
+
+    public int refTagId()
+    {
+        return refTagId;
+    }
+}

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
@@ -17,6 +17,7 @@ package uk.co.real_logic.artio.system_tests;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import uk.co.real_logic.artio.Constants;
 import uk.co.real_logic.artio.Timing;
 import uk.co.real_logic.artio.builder.*;
 import uk.co.real_logic.artio.decoder.LogonDecoder;
@@ -103,6 +104,7 @@ public class MessageBasedAcceptorSystemTest extends AbstractMessageBasedAcceptor
 
             final RejectDecoder reject = connection.readMessage(new RejectDecoder());
             assertEquals(1, reject.refSeqNum());
+            assertEquals(Constants.SENDING_TIME, reject.refTagID());
             assertEquals(LogonDecoder.MESSAGE_TYPE_AS_STRING, reject.refMsgTypeAsString());
 
             connection.logoutAndAwaitReply();
@@ -122,6 +124,7 @@ public class MessageBasedAcceptorSystemTest extends AbstractMessageBasedAcceptor
 
             final RejectDecoder reject = connection.readMessage(new RejectDecoder());
             assertEquals(2, reject.refSeqNum());
+            assertEquals(Constants.SENDING_TIME, reject.refTagID());
 
             connection.logoutAndAwaitReply();
         }


### PR DESCRIPTION
Added ref tag id to malformed message rejects where possible. A small step towards https://github.com/real-logic/artio/issues/301 
Also a small defect fixed where original sending time couldn't be parsed if it had different length with sending time (could be somehow). 
