### PR TITLE
send logout after rejected logon message

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionParser.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionParser.java
@@ -201,6 +201,7 @@ public class SessionParser
             {
                 session.logoutAndDisconnect();
             }
+            return action;
         }
         else if (messageType == LOGOUT_MESSAGE_TYPE)
         {

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionParser.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionParser.java
@@ -32,6 +32,7 @@ import uk.co.real_logic.artio.util.AsciiBuffer;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 import uk.co.real_logic.artio.validation.MessageValidationStrategy;
 
+import static io.aeron.logbuffer.ControlledFragmentHandler.Action.ABORT;
 import static io.aeron.logbuffer.ControlledFragmentHandler.Action.CONTINUE;
 import static uk.co.real_logic.artio.builder.Validation.CODEC_VALIDATION_ENABLED;
 import static uk.co.real_logic.artio.builder.Validation.isValidMsgType;
@@ -195,7 +196,11 @@ public class SessionParser
     {
         if (messageType == LOGON_MESSAGE_TYPE)
         {
-            return onExceptionalMessage(logon.header(), refTagId, position);
+            final Action action = onExceptionalMessage(logon.header(), refTagId, position);
+            if (action != ABORT)
+            {
+                session.logoutAndDisconnect();
+            }
         }
         else if (messageType == LOGOUT_MESSAGE_TYPE)
         {

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
@@ -94,7 +94,7 @@ public class MessageBasedAcceptorSystemTest extends AbstractMessageBasedAcceptor
     }
 
     @Test
-    public void shouldRejectExceptionalLogonMessage() throws IOException
+    public void shouldRejectExceptionalLogonMessageAndLogout() throws IOException
     {
         setup(true, true);
 
@@ -107,7 +107,7 @@ public class MessageBasedAcceptorSystemTest extends AbstractMessageBasedAcceptor
             assertEquals(Constants.SENDING_TIME, reject.refTagID());
             assertEquals(LogonDecoder.MESSAGE_TYPE_AS_STRING, reject.refMsgTypeAsString());
 
-            connection.logoutAndAwaitReply();
+            connection.readLogout();
         }
     }
 


### PR DESCRIPTION
Per FIX specification correct handling of invalid logon is (Optional) Reject message referencing Logon, sending Logout message and disconnecting