### PR TITLE
Ensure FixEngine.close() can be executed once even if exception is th…

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/FixEngine.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/FixEngine.java
@@ -380,9 +380,14 @@ public final class FixEngine extends GatewayProcess
 
                 framerContext.startClose();
 
-                closeAll(scheduler, engineContext, configuration, super::close);
-
-                isClosed = true;
+                try
+                {
+                    closeAll(scheduler, engineContext, configuration, super::close);
+                }
+                finally
+                {
+                    isClosed = true;
+                }
             }
         }
     }


### PR DESCRIPTION
…rown.