### PR TITLE
Fix archive version property in JAR manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,7 +209,7 @@ subprojects {
     jar {
         manifest.attributes(
             'Implementation-Title': 'Artio',
-            'Implementation-Version': "${archiveVersion}",
+            'Implementation-Version': archiveVersion,
             'Implementation-Vendor': 'Real Logic Limited'
         )
     }


### PR DESCRIPTION
The string interpolation syntax in build.gradle was causing an incorrect version string to be recorded in the JAR manifest files:

```
❯ unzip -p artio-core/build/libs/artio-core-0.72-SNAPSHOT.jar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Implementation-Title: Artio
Implementation-Version: task ':artio-core:jar' property 'archiveVersio
 n'
Implementation-Vendor: Real Logic Limited
```

After this change:

```
❯ unzip -p artio-core/build/libs/artio-core-0.72-SNAPSHOT.jar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Implementation-Title: Artio
Implementation-Version: 0.72-SNAPSHOT
Implementation-Vendor: Real Logic Limited
```

This version string is shown in stack traces (and probably elsewhere).