### PR TITLE
Fix edge-case in UtcTimestampEncoder date-roll logic

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/UtcTimestampEncoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/UtcTimestampEncoder.java
@@ -204,7 +204,7 @@ public final class UtcTimestampEncoder
      */
     public int update(final long epochFraction)
     {
-        if (epochFraction > startOfNextDayInFraction || epochFraction < beginningOfDayInFraction)
+        if (epochFraction >= startOfNextDayInFraction || epochFraction < beginningOfDayInFraction)
         {
             return initialise(epochFraction);
         }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderValidCasesTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampDecoderValidCasesTest.java
@@ -62,6 +62,7 @@ public class UtcTimestampDecoderValidCasesTest
             new Object[] {"20150225-17:51:32.000", true},
             new Object[] {"20150225-17:51:32.123", true},
             new Object[] {"20600225-17:51:32.123", true},
+            new Object[] {"19700101-00:00:00.000", true},
             new Object[] {"00010101-00:00:00.000", false},
             new Object[] {"00010101-00:00:00.001", false},
             new Object[] {"99991231-23:59:59.999", false}

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampEncoderDateRollTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampEncoderDateRollTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.fields;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static uk.co.real_logic.artio.fields.UtcTimestampDecoderValidCasesTest.toEpochMillis;
+
+public class UtcTimestampEncoderDateRollTest
+{
+
+    @Test
+    public void shouldHandleDateRoll()
+    {
+        final UtcTimestampEncoder encoder = new UtcTimestampEncoder();
+        encoder.initialise(toEpochMillis("20150914-12:34:56.789"));
+
+        final String newTimestamp = "20150915-00:01:23.456";
+        final int length = encoder.update(toEpochMillis(newTimestamp));
+
+        assertEquals("encoded wrong length", newTimestamp.length(), length);
+        assertEquals(newTimestamp, new String(encoder.buffer(), 0, length, US_ASCII));
+    }
+
+    @Test
+    public void shouldHandleDateRollOnMidnight()
+    {
+        final UtcTimestampEncoder encoder = new UtcTimestampEncoder();
+        encoder.initialise(toEpochMillis("20150914-12:34:56.789"));
+
+        final String newTimestamp = "20150915-00:00:00.000";
+        final int length = encoder.update(toEpochMillis(newTimestamp));
+
+        assertEquals("encoded wrong length", newTimestamp.length(), length);
+        assertEquals(newTimestamp, new String(encoder.buffer(), 0, length, US_ASCII));
+    }
+
+}

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampEncoderUpdateValidCasesTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/UtcTimestampEncoderUpdateValidCasesTest.java
@@ -95,10 +95,32 @@ public class UtcTimestampEncoderUpdateValidCasesTest
     }
 
     @Test
+    public void canUpdateTimestampWithoutInitialize()
+    {
+        final UtcTimestampEncoder encoder = new UtcTimestampEncoder();
+
+        final int length = encoder.update(epochMillis);
+
+        assertEquals("encoded wrong length", expectedLength, length);
+        assertEquals(expectedTimestamp, new String(encoder.buffer(), 0, length, US_ASCII));
+    }
+
+    @Test
     public void canUpdateTimestampMicros()
     {
         final UtcTimestampEncoder encoder = new UtcTimestampEncoder(MICROSECONDS);
         encoder.initialise(otherEpochMicros);
+
+        final int length = encoder.update(epochMicros);
+
+        assertEquals("encoded wrong length", expectedLengthMicros, length);
+        assertEquals(expectedTimestampMicros, new String(encoder.buffer(), 0, length, US_ASCII));
+    }
+
+    @Test
+    public void canUpdateTimestampMicrosWithoutInitialise()
+    {
+        final UtcTimestampEncoder encoder = new UtcTimestampEncoder(MICROSECONDS);
 
         final int length = encoder.update(epochMicros);
 
@@ -113,6 +135,20 @@ public class UtcTimestampEncoderUpdateValidCasesTest
         {
             final UtcTimestampEncoder encoder = new UtcTimestampEncoder(NANOSECONDS);
             encoder.initialise(otherEpochNanos);
+
+            final int length = encoder.update(epochNanos);
+
+            assertEquals("encoded wrong length", expectedLengthNanos, length);
+            assertEquals(expectedTimestampNanos, new String(encoder.buffer(), 0, length, US_ASCII));
+        }
+    }
+
+    @Test
+    public void canUpdateTimestampNanosWithoutInitialise()
+    {
+        if (validNanoSecondTestCase)
+        {
+            final UtcTimestampEncoder encoder = new UtcTimestampEncoder(NANOSECONDS);
 
             final int length = encoder.update(epochNanos);
 


### PR DESCRIPTION
Because current time was compared with start of next day using `>` rather than `>=`, date-roll executed exactly on midnight (highly unlikely event) was still encoding previous day.

As a side effect, initialize() is now completely optional - date-roll logic would kick in and encode the right date in all cases; which I think is a slight improvement in usability. Please note that for almost all timestamps that was the case already, the only exception was start of epoch which happens to be handled now.
I guess initialise() still can be used as a kind of optimisation to encode the date part during startup.