### PR TITLE
Use the right counter type for the sent sequence when refreshing the counters

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
@@ -2156,7 +2156,7 @@ public class Session
     {
         closeCounters();
         receivedMsgSeqNo = counters.receivedMsgSeqNo(connectionId);
-        sentMsgSeqNo = counters.receivedMsgSeqNo(connectionId);
+        sentMsgSeqNo = counters.sentMsgSeqNo(connectionId);
     }
 
     /**


### PR DESCRIPTION
That would explain the double `Last Received MsgSeqNo` counter issue.