### PR TITLE
Use the same variable for the constructor as used in the classname so they match

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -269,7 +269,7 @@ class EncoderGenerator extends Generator
             interfaces = emptyList();
         }
         out.append(classDeclaration(className, interfaces, type == GROUP));
-        out.append(constructor(aggregate, type, dictionary));
+        out.append(constructor(className, aggregate, type, dictionary));
         if (isMessage)
         {
             out.append(commonCompoundImports("Encoder", false, ""));
@@ -336,7 +336,8 @@ class EncoderGenerator extends Generator
         );
     }
 
-    private String constructor(final Aggregate aggregate, final AggregateType type, final Dictionary dictionary)
+    private String constructor(
+        final String className, final Aggregate aggregate, final AggregateType type, final Dictionary dictionary)
     {
         if (type == AggregateType.MESSAGE)
         {
@@ -352,22 +353,22 @@ class EncoderGenerator extends Generator
                 "    {\n" +
                 "        return %sL;\n" +
                 "    }\n\n" +
-                "    public %sEncoder()\n" +
+                "    public %s()\n" +
                 "    {\n" +
                 "%s" +
                 "    }\n\n",
                 packedType,
-                aggregate.name(),
+                className,
                 msgType);
         }
         else if (type == AggregateType.HEADER)
         {
             return String.format(
-                "    public %sEncoder()\n" +
+                "    public %s()\n" +
                 "    {\n" +
                 "        beginString(DEFAULT_BEGIN_STRING);\n" +
                 "    }\n\n",
-                aggregate.name());
+                className);
         }
         else
         {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -44,6 +44,7 @@ public final class ExampleDictionary
     public static final String EG_COMPONENT = "EgComponent";
     public static final String EG_NESTED_COMPONENT = "EgNestedComponent";
     public static final String FIELDS_MESSAGE = "FieldsMessage";
+    public static final String LOWERCASE_MESSAGE = "lowerCaseMessage";
 
     public static final String EG_ENUM = DEFAULT_PARENT_PACKAGE + "." + "EgEnum";
     public static final String OTHER_ENUM = DEFAULT_PARENT_PACKAGE + "." + "OtherEnum";
@@ -612,6 +613,9 @@ public final class ExampleDictionary
         fieldsMessage.optionalEntry(groupForAdmin);
         fieldsMessage.optionalEntry(nestedComponent);
 
+        final Message lowerCaseMessage = new Message(LOWERCASE_MESSAGE, "LC", ADMIN);
+        lowerCaseMessage.requiredEntry(registerField(messageEgFields, 1001, "CurrencyField", CURRENCY));
+
         final Message enumTestMessage = new Message(ENUM_TEST_MESSAGE, ENUM_TEST_MESSAGE_TYPE, APP);
         enumTestMessage.optionalEntry(registerField(messageEgFields, 501, "CharEnumOpt", CHAR)
             .addValue("a", "A")
@@ -647,8 +651,8 @@ public final class ExampleDictionary
         allReqFieldTypesMessage.requiredEntry(registerField(messageEgFields, 707, CURRENCY_ENUM_RF, CURRENCY)
             .addValue("USD", "US_Dollar").addValue("GBP", "Pound"));
 
-        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage, allReqFieldTypesMessage,
-            enumTestMessage);
+        final List<Message> messages = asList(heartbeat, otherMessage, fieldsMessage, lowerCaseMessage,
+            allReqFieldTypesMessage, enumTestMessage);
 
         final Map<String, Component> components = new HashMap<>();
         components.put(EG_COMPONENT, egComponent);


### PR DESCRIPTION
We've received FIX data dictionaries where all the message names are in lower case. Whilst the generation of the java classes handled this without a problem, the constructor names were being derived from a different source and were all in lower case (resulting in compiler errors)