### PR TITLE
Fix DefaultTcpChannelSupplier.open()

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
@@ -147,9 +147,24 @@ public class DefaultTcpChannelSupplier extends TcpChannelSupplier
     {
         final SocketChannel channel = SocketChannel.open();
         channel.configureBlocking(false);
-        channel.register(selector, OP_CONNECT, channelHandler);
         configure(channel);
-        channel.connect(address);
+        try
+        {
+            channel.connect(address);
+        }
+        catch (final Exception e)
+        {
+            try
+            {
+                channel.close();
+            }
+            catch (final IOException ce)
+            {
+                e.addSuppressed(ce);
+            }
+            throw e;
+        }
+        channel.register(selector, OP_CONNECT, channelHandler);
         openingSocketChannels.add(channel);
     }
 

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
@@ -1067,9 +1067,9 @@ class Framer implements Agent, EngineEndPointHandler, ProtocolHandler
     {
         final String msg =
             "You need to enable the logging of inbound and outbound messages on your EngineConfiguration" +
-            "in order to initiate a connection with persistent sequence numbers. " +
-            "logInboundMessages = " + logInboundMessages +
-            "logOutboundMessages = " + logOutboundMessages;
+            " in order to initiate a connection with persistent sequence numbers." +
+            " logInboundMessages = " + logInboundMessages +
+            " logOutboundMessages = " + logOutboundMessages;
 
         saveError(INVALID_CONFIGURATION, libraryId, correlationId, msg);
 


### PR DESCRIPTION
`SocketChannel.connect()` might throw `UnresolvedAddressException`. This leaves the channel incorrectly registered with the selector for `OP_CONNECT`. The next selection operation will try to `finishConnect()` and fail with `NoConnectionPendingException`:
```
java.nio.channels.NoConnectionPendingException
        at java.base/sun.nio.ch.SocketChannelImpl.beginFinishConnect(SocketChannelImpl.java:728)
        at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:772)
        at uk.co.real_logic.artio.engine.framer.DefaultTcpChannelSupplier.pollSelector(DefaultTcpChannelSupplier.java:82)
        at uk.co.real_logic.artio.engine.framer.Framer.pollNewConnections(Framer.java:597)
        at uk.co.real_logic.artio.engine.framer.Framer.doWork(Framer.java:374)
        at org.agrona.concurrent.AgentRunner.doDutyCycle(AgentRunner.java:291)
        at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:164)
        at java.base/java.lang.Thread.run(Thread.java:834)
```
Framer might get stuck doing that in a tight loop.

This change makes any exceptions from `connect()` close the channel to make sure all resources are cleaned up. It also moves the registration after connect, otherwise the underlying socket won't be cleaned up until the next selection operation, and the framer might not do that in a timely manner.

BTW, is `ex.printStackTrace()` needed in `Framer.java:961`? It is passed to the error handler later.