### PR TITLE
FIX ResendRequest may cause infinite loop when BeginSeqNo>lastMsgSeqNo

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayQuery.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayQuery.java
@@ -205,7 +205,7 @@ public class ReplayQuery implements AutoCloseable
             long stopIteratingPosition = iteratorPosition + capacity;
 
             int lastSequenceNumber = -1;
-            while (iteratorPosition != stopIteratingPosition)
+            while (iteratorPosition < stopIteratingPosition)
             {
                 final long changePosition = endChangeVolatile(buffer);
 


### PR DESCRIPTION
It seems like an infinite loop might occur in the ReplayQuery#query.
Client send ResendRequest(beginSeqNo,endSeqNo)  with beginSeqNo > when maximum session seqNo.
The cycle in the SessionQuery#query:
while (iteratorPosition != stopIteratingPosition) {..}
will not stop because
offset(iteratorPosition, capacity) 
always point to the some existing record in the index file.