### PR TITLE
wait for slow image when handing session over

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
@@ -180,6 +180,7 @@ class Framer implements Agent, EngineEndPointHandler, ProtocolHandler
     private final AcceptorFixDictionaryLookup acceptorFixDictionaryLookup;
     private final LongHashSet requestAllSessionSeenSessions = new LongHashSet();
     private final Image outboundEngineImage;
+    private final Image outboundEngineSlowImage;
     private final boolean acceptsFixP;
 
     private ILink3Contexts iLink3Contexts;
@@ -367,6 +368,7 @@ class Framer implements Agent, EngineEndPointHandler, ProtocolHandler
         channelSupplier = configuration.channelSupplier();
         shouldBind = configuration.bindAtStartup();
         outboundEngineImage = librarySubscription.imageBySessionId(outboundPublication.sessionId());
+        outboundEngineSlowImage = slowSubscription.imageBySessionId(outboundPublication.sessionId());
     }
 
     private LibrarySlowPeeker getOutboundSlowPeeker(final GatewayPublication outboundPublication)
@@ -2156,7 +2158,8 @@ class Framer implements Agent, EngineEndPointHandler, ProtocolHandler
         {
             // If there's still a message that was sent by the session when it was managed by the FixEngine
             // then wait for it to be sent.
-            if (outboundEngineImage.position() < gatewaySession.lastSentPosition())
+            if (outboundEngineImage.position() < gatewaySession.lastSentPosition() ||
+                outboundEngineSlowImage.position() < gatewaySession.lastSentPosition())
             {
                 return BACK_PRESSURED;
             }


### PR DESCRIPTION
if engine session falls back to slow (e. g. fragmented message), then remaining part can be lost, since outbound tracker is switched to other image.