### PR TITLE
extend disconnect notification with reason

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixGatewaySessions.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixGatewaySessions.java
@@ -248,7 +248,8 @@ public class FixGatewaySessions extends GatewaySessions
     {
         authenticationStrategy.onDisconnect(
             sessionId,
-            connectionId);
+            connectionId,
+            reason);
     }
 
     protected void setLastSequenceResetTime(final GatewaySession session)

--- a/artio-core/src/main/java/uk/co/real_logic/artio/validation/AbstractAuthenticationProxy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/validation/AbstractAuthenticationProxy.java
@@ -15,6 +15,8 @@
  */
 package uk.co.real_logic.artio.validation;
 
+import uk.co.real_logic.artio.messages.DisconnectReason;
+
 /**
  * Interface to notify the gateway whether a session should be authenticated or not. Either invoker accept or reject.
  *
@@ -50,7 +52,7 @@ public interface AbstractAuthenticationProxy
     /**
      * Gets the connection id that uniquely identifies this individual connection. This can be used to correlate
      * logon operations with disconnect callbacks to
-     * {@link AuthenticationStrategy#onDisconnect(long, long)}.
+     * {@link AuthenticationStrategy#onDisconnect(long, long, DisconnectReason)}.
      *
      * @return the connection id.
      */

--- a/artio-core/src/main/java/uk/co/real_logic/artio/validation/AuthenticationStrategy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/validation/AuthenticationStrategy.java
@@ -18,6 +18,7 @@ package uk.co.real_logic.artio.validation;
 
 import uk.co.real_logic.artio.decoder.AbstractLogonDecoder;
 import uk.co.real_logic.artio.decoder.AbstractUserRequestDecoder;
+import uk.co.real_logic.artio.messages.DisconnectReason;
 
 /**
  * Implement this interface in order to add customisable checks to logon messages.
@@ -105,10 +106,12 @@ public interface AuthenticationStrategy
      *
      * @param sessionId the session id of the session that has disconnected
      * @param connectionId the connection id of the session that has disconnected.
+     * @param reason the reason of the session disconnect
      */
     default void onDisconnect(
         final long sessionId,
-        final long connectionId)
+        final long connectionId,
+        final DisconnectReason reason)
     {
         // Deliberately blank for backwards compatibility
     }

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AsyncAuthenticatorTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AsyncAuthenticatorTest.java
@@ -26,6 +26,7 @@ import uk.co.real_logic.artio.decoder.AbstractLogonDecoder;
 import uk.co.real_logic.artio.engine.EngineConfiguration;
 import uk.co.real_logic.artio.engine.FixEngine;
 import uk.co.real_logic.artio.library.LibraryConfiguration;
+import uk.co.real_logic.artio.messages.DisconnectReason;
 import uk.co.real_logic.artio.session.Session;
 import uk.co.real_logic.artio.validation.AuthenticationProxy;
 import uk.co.real_logic.artio.validation.AuthenticationStrategy;
@@ -230,28 +231,30 @@ public class AsyncAuthenticatorTest extends AbstractGatewayToGatewaySystemTest
     @Test
     public void shouldNotifyAuthStrategyUponAcceptorLogoff()
     {
-        notifyAuthStrategyUpon(this::logoutAcceptingSession);
+        notifyAuthStrategyUpon(this::logoutAcceptingSession, DisconnectReason.REMOTE_DISCONNECT);
     }
 
     @Test
     public void shouldNotifyAuthStrategyUponInitiatorLogoff()
     {
-        notifyAuthStrategyUpon(this::logoutInitiatingSession);
+        notifyAuthStrategyUpon(this::logoutInitiatingSession, DisconnectReason.LOGOUT);
     }
 
     @Test
     public void shouldNotifyAuthStrategyUponAcceptorDisconnect()
     {
-        notifyAuthStrategyUpon(() -> testSystem.awaitRequestDisconnect(acceptingSession));
+        notifyAuthStrategyUpon(
+            () -> testSystem.awaitRequestDisconnect(acceptingSession), DisconnectReason.APPLICATION_DISCONNECT);
     }
 
     @Test
     public void shouldNotifyAuthStrategyUponInitiatorDisconnect()
     {
-        notifyAuthStrategyUpon(() -> testSystem.awaitRequestDisconnect(initiatingSession));
+        notifyAuthStrategyUpon(
+            () -> testSystem.awaitRequestDisconnect(initiatingSession), DisconnectReason.REMOTE_DISCONNECT);
     }
 
-    private void notifyAuthStrategyUpon(final Runnable disconnector)
+    private void notifyAuthStrategyUpon(final Runnable disconnector, final DisconnectReason reason)
     {
         shouldConnectedAcceptedAuthentications();
         acquireAcceptingSession();
@@ -264,6 +267,7 @@ public class AsyncAuthenticatorTest extends AbstractGatewayToGatewaySystemTest
         assertEquals(acceptingSession.id(), auth.disconnectSessionId);
         assertEquals(connectionId, auth.disconnectConnectionId);
         assertEquals(connectionId, auth.authConnectionId);
+        assertEquals(reason, auth.disconnectReason);
     }
 
     private RejectEncoder newRejectEncoder()
@@ -306,6 +310,7 @@ public class AsyncAuthenticatorTest extends AbstractGatewayToGatewaySystemTest
         private long authConnectionId;
         private long disconnectSessionId;
         private long disconnectConnectionId;
+        private DisconnectReason disconnectReason;
         private volatile boolean hasDisconnected;
 
         public void authenticateAsync(final AbstractLogonDecoder logon, final AuthenticationProxy authProxy)
@@ -360,10 +365,12 @@ public class AsyncAuthenticatorTest extends AbstractGatewayToGatewaySystemTest
 
         public void onDisconnect(
             final long sessionId,
-            final long connectionId)
+            final long connectionId,
+            final DisconnectReason reason)
         {
             this.disconnectSessionId = sessionId;
             this.disconnectConnectionId = connectionId;
+            this.disconnectReason = reason;
             hasDisconnected = true;
         }
     }

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AsyncAuthenticatorTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AsyncAuthenticatorTest.java
@@ -231,7 +231,8 @@ public class AsyncAuthenticatorTest extends AbstractGatewayToGatewaySystemTest
     @Test
     public void shouldNotifyAuthStrategyUponAcceptorLogoff()
     {
-        notifyAuthStrategyUpon(this::logoutAcceptingSession, DisconnectReason.REMOTE_DISCONNECT);
+        // can be either logout or remote disconnect
+        notifyAuthStrategyUpon(this::logoutAcceptingSession, null);
     }
 
     @Test
@@ -267,7 +268,10 @@ public class AsyncAuthenticatorTest extends AbstractGatewayToGatewaySystemTest
         assertEquals(acceptingSession.id(), auth.disconnectSessionId);
         assertEquals(connectionId, auth.disconnectConnectionId);
         assertEquals(connectionId, auth.authConnectionId);
-        assertEquals(reason, auth.disconnectReason);
+        if (reason != null)
+        {
+            assertEquals(reason, auth.disconnectReason);
+        }
     }
 
     private RejectEncoder newRejectEncoder()


### PR DESCRIPTION
this can be useful for monitoring invalid logons (such as duplicate sessions, no logon, or authentication timeouts).