### PR TITLE
respond to resend request with a too high seq number

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/library/OnMessageInfo.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/library/OnMessageInfo.java
@@ -20,7 +20,8 @@ import uk.co.real_logic.artio.messages.MessageStatus;
 public class OnMessageInfo
 {
     private MessageStatus status;
-    private boolean isValid;
+    private boolean valid;
+    private boolean outOfSequence;
 
     public OnMessageInfo status(final MessageStatus status)
     {
@@ -30,7 +31,13 @@ public class OnMessageInfo
 
     public OnMessageInfo isValid(final boolean valid)
     {
-        isValid = valid;
+        this.valid = valid;
+        return this;
+    }
+
+    public OnMessageInfo isOutOfSequence(final boolean isOutOfSequence)
+    {
+        this.outOfSequence = isOutOfSequence;
         return this;
     }
 
@@ -41,6 +48,11 @@ public class OnMessageInfo
 
     public boolean isValid()
     {
-        return isValid;
+        return valid;
+    }
+
+    public boolean isOutOfSequence()
+    {
+        return outOfSequence;
     }
 }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
@@ -1250,7 +1250,7 @@ public class Session
             }
             else if (msgSeqNum > endOfResendRequestRange)
             {
-                messageInfo.isValid(false);
+                messageInfo.isOutOfSequence(false);
                 if (sendRedundantResendRequests)
                 {
                     return Pressure.apply(trySendResendRequest(endOfResendRequestRange + 1, msgSeqNum));
@@ -1309,7 +1309,7 @@ public class Session
         final long position = trySendResendRequest(expectedSeqNo, receivedMsgSeqNo);
         if (position >= 0)
         {
-            messageInfo.isValid(false);
+            messageInfo.isOutOfSequence(false);
             awaitingResend = true;
             lastResentMsgSeqNo = expectedSeqNo - 1;
             lastReceivedMsgSeqNum = receivedMsgSeqNo;

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FakeHandler.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FakeHandler.java
@@ -113,6 +113,7 @@ public class FakeHandler
         parsedMessage.sequenceIndex(sequenceIndex);
         parsedMessage.status(messageInfo.status());
         parsedMessage.isValid(messageInfo.isValid());
+        parsedMessage.isOutOfSequence(messageInfo.isOutOfSequence());
         acceptor.forSession(session);
 
         if (copyMessages)

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FixMessage.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/FixMessage.java
@@ -35,6 +35,7 @@ public class FixMessage extends Int2ObjectHashMap<String>
     private int sequenceIndex;
     private MessageStatus status;
     private boolean valid;
+    private boolean outOfSequence;
 
     public FixMessage()
     {
@@ -118,6 +119,16 @@ public class FixMessage extends Int2ObjectHashMap<String>
     public boolean isValid()
     {
         return valid;
+    }
+
+    public void isOutOfSequence(final boolean outOfSequence)
+    {
+        this.outOfSequence = outOfSequence;
+    }
+
+    public boolean isOutOfSequence()
+    {
+        return outOfSequence;
     }
 
     public int cancelOnDisconnectType()

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/GatewayToGatewaySystemTest.java
@@ -197,6 +197,40 @@ public class GatewayToGatewaySystemTest extends AbstractGatewayToGatewaySystemTe
     }
 
     @Test(timeout = TEST_TIMEOUT_IN_MS)
+    public void shouldAnswerToResendRequestWithHighSeqNum()
+    {
+        final String testReqID = "AAA";
+
+        acquireAcceptingSession();
+
+        exchangeExampleMessageFromInitiatorToAcceptor(testReqID);
+        assertTestRequestSentAndReceived(initiatingSession, testSystem, acceptingOtfAcceptor);
+
+        acceptorSendsResendRequest(1, 3);
+        acceptorSendsResendRequest(1, 3);
+
+        assertThat(acceptingOtfAcceptor.messages(), hasSize(0));
+        assertEventuallyTrue("Failed to receive the reply",
+            () ->
+            {
+                testSystem.poll();
+
+                assertEquals(2, acceptingOtfAcceptor
+                    .receivedMessage(EXAMPLE_MESSAGE_MESSAGE_AS_STR)
+                    .filter(msg -> "Y".equals(msg.possDup()))
+                    .filter(msg -> 2 == msg.messageSequenceNumber())
+                    .filter(msg -> testReqID.equals(msg.testReqId()))
+                    .count());
+
+                assertNull("Detected Error", acceptingOtfAcceptor.lastError());
+                assertTrue("Failed to complete parsing", acceptingOtfAcceptor.isCompleted());
+            });
+
+        assertSequenceIndicesAre(0);
+    }
+
+
+    @Test(timeout = TEST_TIMEOUT_IN_MS)
     public void gatewayProcessesResendRequestsOfFragmentedMessages()
     {
         final String testReqID = largeTestReqId();

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedAcceptorSystemTest.java
@@ -492,6 +492,34 @@ public class MessageBasedAcceptorSystemTest extends AbstractMessageBasedAcceptor
     }
 
     @Test(timeout = TEST_TIMEOUT_IN_MS)
+    public void shouldAnswerResendRequestWithHighSeqNum() throws IOException
+    {
+        setup(true, true);
+        setupLibrary();
+
+        try (FixConnection connection = FixConnection.initiate(port))
+        {
+            logon(connection);
+            testSystem.poll();
+
+            final HeartbeatDecoder abc = connection.exchangeTestRequestHeartbeat("ABC");
+            assertEquals(2, abc.header().msgSeqNum());
+
+            // shift msg seq num
+            connection.msgSeqNum(connection.msgSeqNum() + 3);
+            connection.sendResendRequest(1, 2);
+            // answers with resend
+            connection.readResendRequest(3, 0);
+            connection.sendGapFill(3, connection.msgSeqNum() + 1);
+            // answers the resend as well
+            final SequenceResetDecoder sequenceResetDecoder = connection.readMessage(new SequenceResetDecoder());
+            assertEquals(sequenceResetDecoder.header().msgSeqNum(), 1);
+            assertEquals(sequenceResetDecoder.newSeqNo(), 3);
+        }
+    }
+
+
+    @Test(timeout = TEST_TIMEOUT_IN_MS)
     public void shouldSupportLogonBasedSequenceNumberResetWithImmediateMessageSend() throws IOException
     {
         shouldSupportLogonBasedSequenceNumberReset(ENGINE, (connection, reportFactory) ->

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedInitiatorSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/MessageBasedInitiatorSystemTest.java
@@ -461,13 +461,13 @@ public class MessageBasedInitiatorSystemTest
         final FixMessage logon = messages.get(0);
         assertEquals(logon.toString(), 4, logon.messageSequenceNumber());
         assertEquals(logon.toString(), LOGON_MESSAGE_AS_STR, logon.msgType());
-        assertFalse(logon.toString(), logon.isValid());
+        assertFalse(logon.toString(), logon.isOutOfSequence());
 
         final FixMessage invalidReport5 = messages.get(1);
         assertEquals(invalidReport5.toString(), 5, invalidReport5.messageSequenceNumber());
         assertEquals(invalidReport5.toString(), EXECUTION_REPORT_MESSAGE_AS_STR, invalidReport5.msgType());
         assertNull(invalidReport5.toString(), invalidReport5.possDup());
-        assertFalse(invalidReport5.toString(), invalidReport5.isValid());
+        assertFalse(invalidReport5.toString(), invalidReport5.isOutOfSequence());
 
         final FixMessage report3 = messages.get(2);
         assertEquals(report3.toString(), 3, report3.messageSequenceNumber());


### PR DESCRIPTION
a resend request with sequence number too high is not answered immeditely as invalid. since it's an admin message it will not be resent from counterparty (a gap fill will be sent instead) - therefore it is never answered

additionally, out-of-sequence, but valid responses are now distinguished from invalid ones (probably could fix without this, but probably still a good idea).