### PR TITLE
optimize-put-float-ascii-method

### DIFF
--- a/artio-system-tests/src/perf/java/uk/co/real_logic/artio/DecimalFloatEncoderBenchmark.java
+++ b/artio-system-tests/src/perf/java/uk/co/real_logic/artio/DecimalFloatEncoderBenchmark.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio;
+
+import org.openjdk.jmh.annotations.*;
+import uk.co.real_logic.artio.util.MutableAsciiBuffer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark for the {@link uk.co.real_logic.artio.util.MutableAsciiBuffer#putFloatAscii(int, long, int)} method.
+ */
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@State(Scope.Benchmark)
+public class DecimalFloatEncoderBenchmark
+{
+    @Param({ "0", "-9182", "27085146", "-123456789", "2147483647" })
+    private int value;
+    @Param({ "0", "2", "5", "10" })
+    private int scale;
+
+    private final MutableAsciiBuffer buffer = new MutableAsciiBuffer(new byte[64]);
+
+    /**
+     * Benchmark  {@link uk.co.real_logic.artio.util.MutableAsciiBuffer#putFloatAscii(int, long, int)}  method
+     *
+     * @return length in bytes of the written value.
+     */
+    @Benchmark
+    public int benchmark()
+    {
+        return buffer.putFloatAscii(0, value, scale);
+    }
+}


### PR DESCRIPTION
Couldn't resist after seeing https://github.com/real-logic/agrona/pull/236

JMH results:

before:
```
Benchmark                               (scale)     (value)  Mode  Cnt   Score   Error  Units
DecimalFloatEncoderBenchmark.benchmark        0           0  avgt   10   5.580 ± 0.036  ns/op
DecimalFloatEncoderBenchmark.benchmark        0       -9182  avgt   10  18.150 ± 0.788  ns/op
DecimalFloatEncoderBenchmark.benchmark        0    27085146  avgt   10  23.314 ± 0.304  ns/op
DecimalFloatEncoderBenchmark.benchmark        0  -123456789  avgt   10  25.021 ± 0.891  ns/op
DecimalFloatEncoderBenchmark.benchmark        0  2147483647  avgt   10  26.734 ± 0.489  ns/op
DecimalFloatEncoderBenchmark.benchmark        2           0  avgt   10   6.634 ± 0.107  ns/op
DecimalFloatEncoderBenchmark.benchmark        2       -9182  avgt   10  23.149 ± 0.670  ns/op
DecimalFloatEncoderBenchmark.benchmark        2    27085146  avgt   10  29.421 ± 0.576  ns/op
DecimalFloatEncoderBenchmark.benchmark        2  -123456789  avgt   10  30.981 ± 0.302  ns/op
DecimalFloatEncoderBenchmark.benchmark        2  2147483647  avgt   10  33.554 ± 0.408  ns/op
DecimalFloatEncoderBenchmark.benchmark        5           0  avgt   10   8.259 ± 0.059  ns/op
DecimalFloatEncoderBenchmark.benchmark        5       -9182  avgt   10  21.445 ± 0.244  ns/op
DecimalFloatEncoderBenchmark.benchmark        5    27085146  avgt   10  29.417 ± 0.354  ns/op
DecimalFloatEncoderBenchmark.benchmark        5  -123456789  avgt   10  30.683 ± 0.508  ns/op
DecimalFloatEncoderBenchmark.benchmark        5  2147483647  avgt   10  32.964 ± 1.373  ns/op
DecimalFloatEncoderBenchmark.benchmark       10           0  avgt   10  10.326 ± 0.214  ns/op
DecimalFloatEncoderBenchmark.benchmark       10       -9182  avgt   10  24.439 ± 0.522  ns/op
DecimalFloatEncoderBenchmark.benchmark       10    27085146  avgt   10  27.796 ± 0.287  ns/op
DecimalFloatEncoderBenchmark.benchmark       10  -123456789  avgt   10  28.720 ± 0.470  ns/op
DecimalFloatEncoderBenchmark.benchmark       10  2147483647  avgt   10  27.498 ± 0.276  ns/op
```
After:
```
Benchmark                               (scale)     (value)  Mode  Cnt   Score   Error  Units
DecimalFloatEncoderBenchmark.benchmark        0           0  avgt   10   5.648 ± 0.094  ns/op
DecimalFloatEncoderBenchmark.benchmark        0       -9182  avgt   10  11.098 ± 0.337  ns/op
DecimalFloatEncoderBenchmark.benchmark        0    27085146  avgt   10  21.633 ± 3.651  ns/op
DecimalFloatEncoderBenchmark.benchmark        0  -123456789  avgt   10  21.042 ± 1.978  ns/op
DecimalFloatEncoderBenchmark.benchmark        0  2147483647  avgt   10  22.567 ± 0.383  ns/op
DecimalFloatEncoderBenchmark.benchmark        2           0  avgt   10   6.678 ± 0.167  ns/op
DecimalFloatEncoderBenchmark.benchmark        2       -9182  avgt   10  12.556 ± 0.130  ns/op
DecimalFloatEncoderBenchmark.benchmark        2    27085146  avgt   10  20.104 ± 0.321  ns/op
DecimalFloatEncoderBenchmark.benchmark        2  -123456789  avgt   10  23.031 ± 0.405  ns/op
DecimalFloatEncoderBenchmark.benchmark        2  2147483647  avgt   10  24.224 ± 0.371  ns/op
DecimalFloatEncoderBenchmark.benchmark        5           0  avgt   10   8.235 ± 0.227  ns/op
DecimalFloatEncoderBenchmark.benchmark        5       -9182  avgt   10  17.408 ± 2.067  ns/op
DecimalFloatEncoderBenchmark.benchmark        5    27085146  avgt   10  20.123 ± 0.446  ns/op
DecimalFloatEncoderBenchmark.benchmark        5  -123456789  avgt   10  22.941 ± 0.402  ns/op
DecimalFloatEncoderBenchmark.benchmark        5  2147483647  avgt   10  23.994 ± 0.359  ns/op
DecimalFloatEncoderBenchmark.benchmark       10           0  avgt   10  10.722 ± 0.586  ns/op
DecimalFloatEncoderBenchmark.benchmark       10       -9182  avgt   10  19.275 ± 0.472  ns/op
DecimalFloatEncoderBenchmark.benchmark       10    27085146  avgt   10  23.273 ± 0.307  ns/op
DecimalFloatEncoderBenchmark.benchmark       10  -123456789  avgt   10  25.455 ± 1.006  ns/op
DecimalFloatEncoderBenchmark.benchmark       10  2147483647  avgt   10  22.641 ± 0.464  ns/op
```
A side note:  I could not run the benchmark from IDEA directly and had changed gradle build locally to do that (by adding new project artio-benchmarks). If it isn't only my problem I can create a separate pull req.