### PR TITLE
reset session index after sending a logon with seq reset requested

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
@@ -1456,6 +1456,12 @@ public class Session
                     return ABORT;
                 }
 
+                if (proxy.seqNumResetRequested())
+                {
+                    lastReceivedMsgSeqNum = 0;
+                    nextSequenceIndex(logonTimeInNs);
+                }
+
                 // Don't configure this session as active until successful outbound publication
                 setupCompleteLogonState(logonTimeInNs, heartbeatIntervalInS, username, password, timeInNs());
                 // If this is the first logon message this session has received, even if sequence
@@ -1481,9 +1487,9 @@ public class Session
                 final boolean requestSeqNumReset = proxy.seqNumResetRequested();
                 if (requestSeqNumReset) // if we requested sequence number reset then do not await for replay
                 {
-                    lastReceivedMsgSeqNum = 0; // TODO: should this not be msgSeqNum?
+                    lastReceivedMsgSeqNum = 0;
                     setupCompleteLogonStateReset(logonTimeInNs, heartbeatIntervalInS, username, password, timeInNs());
-
+                    nextSequenceIndex(logonTimeInNs); // reset asked so reset
                     return CONTINUE;
                 }
                 else

--- a/artio-core/src/test/java/uk/co/real_logic/artio/session/AcceptorSessionTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/session/AcceptorSessionTest.java
@@ -84,6 +84,7 @@ public class AcceptorSessionTest extends AbstractSessionTest
         onLogon(1);
 
         verifyLogon();
+        verify(sessionProxy).seqNumResetRequested();
         verifyNoFurtherMessages();
         assertState(ACTIVE);
     }

--- a/artio-core/src/test/java/uk/co/real_logic/artio/session/InitiatorSessionTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/session/InitiatorSessionTest.java
@@ -74,6 +74,7 @@ public class InitiatorSessionTest extends AbstractSessionTest
         assertEquals(CONTINUE, onLogon(1));
 
         assertState(ACTIVE);
+        verify(sessionProxy).seqNumResetRequested();
         verifyNoFurtherMessages();
         verifyNotifiesLoginListener();
         assertHasLogonTime();


### PR DESCRIPTION
If decorator adds a seq reset flag to logon answer - the sequence index is not requested.
this may cause messages from counterparty to be ignored during catchup replay (replay from from logon sequence is requested - and nothing is sent back if sequence index stayed the same).