### PR TITLE
reset sequence numbers hangs in sole library mode

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/ResetSequenceNumberCommand.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/ResetSequenceNumberCommand.java
@@ -158,14 +158,15 @@ class ResetSequenceNumberCommand implements Reply<Void>, AdminCommand
                 }
 
                 final GatewaySession gatewaySession = gatewaySessions.sessionById(sessionId);
-                // Engine Managed
-                if (gatewaySession != null)
+                if (gatewaySession instanceof FixGatewaySession)
                 {
-                    if (gatewaySession instanceof FixGatewaySession)
-                    {
-                        session = ((FixGatewaySession)gatewaySession).session();
-                        step = Step.RESET_ENGINE_SESSION;
-                    }
+                    session = ((FixGatewaySession)gatewaySession).session();
+                }
+
+                // Engine Managed
+                if (session != null)
+                {
+                    step = Step.RESET_ENGINE_SESSION;
                 }
                 // Library Managed
                 else if (isAuthenticated())


### PR DESCRIPTION
in sole library mode there's still a gateway session, no session inside. the command then hangs in npe