### PR TITLE
sole library handover may hang

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/IndexedPositionWriter.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/IndexedPositionWriter.java
@@ -223,6 +223,7 @@ class IndexedPositionWriter
                 // May not have setup the recording id when these messages come in.
                 case LibraryConnectDecoder.TEMPLATE_ID:
                 case ApplicationHeartbeatDecoder.TEMPLATE_ID:
+                case ConnectDecoder.TEMPLATE_ID: // handover new connection awaits it to be indexed, can't ignore
                     trackPosition(aeronSessionId, endPosition);
                     return;
 
@@ -232,7 +233,6 @@ class IndexedPositionWriter
                 case ControlNotificationDecoder.TEMPLATE_ID:
                 case EndOfDayDecoder.TEMPLATE_ID:
                 case DisconnectDecoder.TEMPLATE_ID:
-                case ConnectDecoder.TEMPLATE_ID:
                     return;
             }
             recordingId = recordingIdLookup.getRecordingId(aeronSessionId);


### PR DESCRIPTION
in sole library mode the unit of work waits for "connect" message being indexed from inbound publication. so we can't ignore such messages on unknown recording and should either block for recording or track such messages.