### PR TITLE
Fixed "Found Replay Message" logs

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixMessageTracker.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixMessageTracker.java
@@ -75,7 +75,7 @@ public class FixMessageTracker extends MessageTracker
             {
                 messageDecoder.skipMetaData();
                 final int bodyLength = messageDecoder.bodyLength();
-                final int bodyOffset = messageDecoder.limit();
+                final int bodyOffset = messageDecoder.limit() + FixMessageDecoder.bodyHeaderLength();
                 final CharFormatter formatter = FOUND_REPLAY_MESSAGE.get();
                 formatter.clear();
                 DebugLogger.log(logTag, formatter, buffer, bodyOffset, bodyLength);

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/MessageTracker.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/MessageTracker.java
@@ -23,7 +23,7 @@ import uk.co.real_logic.artio.util.CharFormatter;
 public abstract class MessageTracker implements ControlledFragmentHandler
 {
     static final ThreadLocal<CharFormatter> FOUND_REPLAY_MESSAGE =
-        ThreadLocal.withInitial(() -> new CharFormatter("Found Replay Message [%s]%n"));
+        ThreadLocal.withInitial(() -> new CharFormatter("Found Replay Message [%s]"));
 
     final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
     final LogTag logTag;

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderTargetAndSubSessionIdStrategy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderTargetAndSubSessionIdStrategy.java
@@ -219,7 +219,7 @@ class SenderTargetAndSubSessionIdStrategy implements SessionIdStrategy
         {
             return "CompositeKey{" +
                 "localCompId=" + localCompId() +
-                "localSubId=" + localSubId() +
+                ", localSubId=" + localSubId() +
                 ", remoteCompId=" + remoteCompId() +
                 '}';
         }


### PR DESCRIPTION
The message below has binary data in front, it doesn't contain the checksum, and has an extra new line:
```
[REPLAY]Found Replay Message [Z   8=FIX.4.49=6835=B49=initiator56=acceptor34=252=20210628-18:27:26.130112=AAA10=]
```

Also fixed key toString format in `SenderTargetAndSubSessionIdStrategy`.