### PR TITLE
Upgrade to Aeron 1.36.0, Agrona 1.13.0 and SBE 1.25.0

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/CharFormatter.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/CharFormatter.java
@@ -18,7 +18,7 @@ package uk.co.real_logic.artio.util;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
-import static org.agrona.AsciiEncoding.endOffset;
+import static org.agrona.AsciiEncoding.digitCount;
 import static uk.co.real_logic.artio.util.AsciiBuffer.LONGEST_INT_LENGTH;
 import static uk.co.real_logic.artio.util.AsciiBuffer.LONGEST_LONG_LENGTH;
 
@@ -175,7 +175,7 @@ public class CharFormatter
             quotient = -quotient;
         }
 
-        int i = endOffset(quotient);
+        int i = digitCount(quotient) - 1;
         length += i;
 
         while (i >= 0)
@@ -215,7 +215,7 @@ public class CharFormatter
             quotient = -quotient;
         }
 
-        int i = endOffset(quotient);
+        int i = digitCount(quotient) - 1;
         length += i;
 
         while (i >= 0)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
@@ -309,7 +309,7 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
         final int start = offset + minusAdj;
 
         final int length = remainder == Long.MIN_VALUE ? AsciiEncoding.MIN_LONG_VALUE.length - 1 :
-            AsciiEncoding.endOffset(-remainder) + 1;
+            AsciiEncoding.digitCount(-remainder);
 
         if (length <= scale)
         {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorFlyweightTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorFlyweightTest.java
@@ -37,7 +37,7 @@ public class DecoderGeneratorFlyweightTest extends AbstractDecoderGeneratorTest
         final Decoder decoder = decodeHeartbeat(INVALID_INT_VALUE_MESSAGE);
 
         assertTargetThrows(() -> getIntField(decoder), NumberFormatException.class,
-            "'A' is not a valid digit @ 33 tag=116");
+            "error parsing int: A tag=116");
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,9 @@ def mockitoVersion = '4.0.0'
 def hdrHistogramVersion = '2.1.12'
 def jmhVersion = '1.33'
 
-def aeronVersion = '1.35.1'
-def agronaVersion = '1.12.0'
-def sbeVersion = '1.24.0'
+def aeronVersion = '1.36.0'
+def agronaVersion = '1.13.0'
+def sbeVersion = '1.25.0'
 def artioJavaVersion = JavaVersion.VERSION_1_8
 def artioGroup = 'uk.co.real-logic'
 def iLink3Enabled = false


### PR DESCRIPTION
The PR upgrades the dependencies and fixes code due to the Agrona changes, i.e. one test needed a fix due to error message change and usage of the deprecated `endOffset` method was replaced with the `digitCount`.