### PR TITLE
[Java] Fix position in the destination array at which putIntAscii/putLongAscii encode number.

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/CharFormatter.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/CharFormatter.java
@@ -32,6 +32,7 @@ public class CharFormatter
     private static final Pattern PATTERN = Pattern.compile("%s");
     private static final Pattern NEWLINE = Pattern.compile("%n");
     private static final char[] MIN_INTEGER_VALUE = String.valueOf(Integer.MIN_VALUE).toCharArray();
+    private static final char[] MIN_LONG_VALUE = String.valueOf(Long.MIN_VALUE).toCharArray();
 
     private final String formatString;
     private final char[][] segments;
@@ -153,14 +154,14 @@ public class CharFormatter
     {
         if (value == 0)
         {
-            buffer[0] = '0';
+            buffer[index] = '0';
             return 1;
         }
 
         if (value == Integer.MIN_VALUE)
         {
             final int length = MIN_INTEGER_VALUE.length;
-            System.arraycopy(MIN_INTEGER_VALUE, 0, buffer, 0, length);
+            System.arraycopy(MIN_INTEGER_VALUE, 0, buffer, index, length);
             return length;
         }
 
@@ -193,14 +194,14 @@ public class CharFormatter
     {
         if (value == 0)
         {
-            buffer[0] = '0';
+            buffer[index] = '0';
             return 1;
         }
 
         if (value == Long.MIN_VALUE)
         {
-            final int length = MIN_INTEGER_VALUE.length;
-            System.arraycopy(MIN_INTEGER_VALUE, 0, buffer, 0, length);
+            final int length = MIN_LONG_VALUE.length;
+            System.arraycopy(MIN_LONG_VALUE, 0, buffer, index, length);
             return length;
         }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/CharFormatterTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/CharFormatterTest.java
@@ -17,6 +17,8 @@ package uk.co.real_logic.artio.util;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.Assert.assertEquals;
 
@@ -109,11 +111,55 @@ public class CharFormatterTest
         assertFormatsTo("MsgSeqNum too low, expecting 0 but received 1", formatter);
     }
 
+    @Test
+    public void shouldEncodeIntToAscii()
+    {
+        final CharFormatter formatter = new CharFormatter("%s");
+
+        assertPutIntAscii(formatter, 2, 0, "0");
+        assertPutIntAscii(formatter, 1, 1, "1");
+        assertPutIntAscii(formatter, 8, -21, "-21");
+        assertPutIntAscii(formatter, 0, 12345678, "12345678");
+        assertPutIntAscii(formatter, 3, Integer.MAX_VALUE, String.valueOf(Integer.MAX_VALUE));
+        assertPutIntAscii(formatter, 4, Integer.MIN_VALUE, String.valueOf(Integer.MIN_VALUE));
+    }
+
+    @Test
+    public void shouldEncodeLongToAscii()
+    {
+        final CharFormatter formatter = new CharFormatter("%s");
+
+        assertPutLongAscii(formatter, 10, 0, "0");
+        assertPutLongAscii(formatter, 0, -42, "-42");
+        assertPutLongAscii(formatter, 3, 123, "123");
+        assertPutLongAscii(formatter, 5, 999_999_999_999L, "999999999999");
+        assertPutLongAscii(formatter, 3, Long.MAX_VALUE, String.valueOf(Long.MAX_VALUE));
+        assertPutLongAscii(formatter, 4, Long.MIN_VALUE, String.valueOf(Long.MIN_VALUE));
+    }
+
     private void assertFormatsTo(final String format, final CharFormatter formatter)
     {
         final StringBuilder builder = new StringBuilder();
         formatter.appendTo(builder);
 
         assertEquals(format, builder.toString());
+    }
+
+    private static void assertPutIntAscii(
+        final CharFormatter formatter, final int index, final int value, final String encodedValue)
+    {
+        final char[] buffer = new char[16];
+        final int length = formatter.putIntAscii(buffer, index, value);
+        assertEquals(encodedValue.length(), length);
+        assertEquals(encodedValue, new String(Arrays.copyOfRange(buffer, index, index + length)));
+    }
+
+    private static void assertPutLongAscii(
+        final CharFormatter formatter, final int index, final long value, final String encodedValue)
+    {
+        final char[] buffer = new char[32];
+        final int length = formatter.putLongAscii(buffer, index, value);
+        assertEquals(encodedValue.length(), length);
+        assertEquals(encodedValue, new String(Arrays.copyOfRange(buffer, index, index + length)));
     }
 }


### PR DESCRIPTION
Fixes #450.

As a bonus it also fixes encoding of the `Long.MIN_VALUE`. ;)