### PR TITLE
Issue452/prevent modifying decimal float constants

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
@@ -15,10 +15,12 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
-import org.agrona.MutableDirectBuffer;
-import uk.co.real_logic.artio.fields.DecimalFloat;
-
 import java.util.Arrays;
+
+import org.agrona.MutableDirectBuffer;
+
+
+import uk.co.real_logic.artio.fields.ReadOnlyDecimalFloat;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
@@ -261,7 +263,7 @@ public final class CodecUtil
         }
     }
 
-    public static void appendFloat(final StringBuilder builder, final DecimalFloat price)
+    public static void appendFloat(final StringBuilder builder, final ReadOnlyDecimalFloat price)
     {
         final long value = price.value();
         final int scale = price.scale();

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -873,7 +873,7 @@ class EncoderGenerator extends Generator
         return String.format(
             "    %6$s final DecimalFloat %1$s = new DecimalFloat();\n\n" +
             "%2$s" +
-            "    public %3$s %1$s(DecimalFloat value)\n" +
+            "    public %3$s %1$s(ReadOnlyDecimalFloat value)\n" +
             "    {\n" +
             "        %1$s.set(value);\n" +
             "%4$s" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -28,6 +28,7 @@ import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.Entry.Element;
 import uk.co.real_logic.artio.fields.DecimalFloat;
 import uk.co.real_logic.artio.fields.LocalMktDateEncoder;
+import uk.co.real_logic.artio.fields.ReadOnlyDecimalFloat;
 import uk.co.real_logic.artio.fields.UtcTimestampEncoder;
 import uk.co.real_logic.artio.util.AsciiBuffer;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
@@ -154,6 +155,7 @@ public abstract class Generator
         }
 
         out .append(type == MESSAGE ? String.format(COMMON_COMPOUND_IMPORTS, thisPackage, compoundSuffix) : "")
+            .append(importFor(ReadOnlyDecimalFloat.class))
             .append(importFor(DecimalFloat.class))
             .append(importFor(MutableAsciiBuffer.class))
             .append(importFor(AsciiBuffer.class))

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/ReadOnlyDecimalFloat.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/ReadOnlyDecimalFloat.java
@@ -133,7 +133,6 @@ public class ReadOnlyDecimalFloat implements Comparable<ReadOnlyDecimalFloat>
         CodecUtil.appendFloat(builder, this);
     }
 
-    @Override
     public String toString()
     {
         final StringBuilder builder = new StringBuilder();
@@ -141,7 +140,6 @@ public class ReadOnlyDecimalFloat implements Comparable<ReadOnlyDecimalFloat>
         return builder.toString();
     }
 
-    @Override
     public final int compareTo(final ReadOnlyDecimalFloat other)
     {
         final long value = this.value;
@@ -193,9 +191,7 @@ public class ReadOnlyDecimalFloat implements Comparable<ReadOnlyDecimalFloat>
      * Transitive : if x.equals(y) return true and y.equals(z) return true, x.equals(z) return true
      * Consistent : invocations of x.equals(y) return the same value
      * For any x != null, x.equals(null) returns false
-     * <p>
-     * Any class other than DecimalFloat inheriting ReadOnlyDecimalFloat should overwrite this equal method.
-     * <p>
+     *
      * Support for DecimalFloat was done to provide a backward compatibility when some constants such as ZERO or NAN
      * were made read only to avoid subtle bugs. By making DecimalFloats equal the corresponding ReadOnlyDecimalFloat
      * any code that used the predefined constants when they were mutable should still yield the same results,

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/ReadOnlyDecimalFloat.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/ReadOnlyDecimalFloat.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2015-2022 Real Logic Limited., Adaptive Financial Consulting Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.fields;
+
+import uk.co.real_logic.artio.dictionary.generation.CodecUtil;
+import uk.co.real_logic.artio.util.PowerOf10;
+
+import static uk.co.real_logic.artio.util.PowerOf10.HIGHEST_POWER_OF_TEN;
+import static uk.co.real_logic.artio.util.PowerOf10.POWERS_OF_TEN;
+
+/**
+ * The main purpose of this class is to prevent accidental mutation of predefined constant values such as ZERO.
+ * An additional benefit is that it can be used to specify an argument of a function that promises not to
+ * modify the input value.
+ *
+ * The class is prefixed with ReadOnly, not with Immutable. It can still reference a mutable DecimalFloat subclass.
+ * This should be sufficient, as the ReadOnlyDecimalFloat type guarantees the following:
+ *
+ * - holders of the reference to the ReadOnlyDecimalFloat type do not modify its value
+ *   even if the underlying implementation is mutable
+ *
+ * - immutability, when using a predefined constants or when obtained using {@link DecimalFloat#immutableCopy()}
+ *
+ */
+public class ReadOnlyDecimalFloat implements Comparable<ReadOnlyDecimalFloat>
+{
+    private static final int SCALE_NAN_VALUE = -128;
+    private static final long VALUE_NAN_VALUE = Long.MIN_VALUE;
+    private static final double DOUBLE_NAN_VALUE = Double.NaN;
+
+    private static final long VALUE_MAX_VAL = 999_999_999_999_999_999L;
+    private static final long VALUE_MIN_VAL = -VALUE_MAX_VAL;
+    private static final int SCALE_MAX_VAL = 127;
+    private static final int SCALE_MIN_VAL = 0;
+
+    public static final ReadOnlyDecimalFloat MIN_VALUE = new ReadOnlyDecimalFloat(VALUE_MIN_VAL, 0);
+    public static final ReadOnlyDecimalFloat MAX_VALUE = new ReadOnlyDecimalFloat(VALUE_MAX_VAL, 0);
+    public static final ReadOnlyDecimalFloat ZERO = new ReadOnlyDecimalFloat(0, 0);
+    public static final ReadOnlyDecimalFloat NAN = newReadOnlyNanValue();
+    public static final ReadOnlyDecimalFloat MISSING_FLOAT = NAN;
+
+    protected long value;
+    protected int scale;
+
+    /**
+     * Used for values created internally that would not pass the normalization, such as NaN.
+     */
+    private ReadOnlyDecimalFloat()
+    {
+
+    }
+
+    /**
+     * Standard way of constructing decimal float.
+     *
+     * Making this constructor package-private prevents from subclassing it outside this package.
+     * The class is not final only because it needs to be extended by the DecimalFloat in the same package.
+
+     * @param value significant digits
+     * @param scale location of the decimal point
+     */
+    ReadOnlyDecimalFloat(final long value, final int scale)
+    {
+        setAndNormalise(value, scale);
+    }
+
+    /**
+     * @return The same value, but with the type that allows mutations.
+     */
+    public DecimalFloat mutableCopy()
+    {
+        // There is no need to use the public normalizing constructor as the values were already normalized
+        // or created internally without the normalization.
+        // If the public constructor was used, we would not be able to create copies of some
+        // internally created values such as NaN
+
+        final DecimalFloat mutableCopy = new DecimalFloat();
+        mutableCopy.value = this.value;
+        mutableCopy.scale = this.scale;
+        return mutableCopy;
+    }
+
+    public boolean isNaNValue()
+    {
+        return isNaNValue(value, scale);
+    }
+
+    public double toDouble()
+    {
+        if (isNaNValue())
+        {
+            return DOUBLE_NAN_VALUE;
+        }
+        return toDouble(value, scale);
+    }
+
+
+    public static boolean isNaNValue(final long value, final int scale)
+    {
+        return value == ReadOnlyDecimalFloat.VALUE_NAN_VALUE && scale == ReadOnlyDecimalFloat.SCALE_NAN_VALUE;
+    }
+
+    public long value()
+    {
+        return this.value;
+    }
+
+    /**
+     * Get the number of digits to the right of the decimal point.
+     *
+     * @return the number of digits to the right of the decimal point.
+     */
+    public int scale()
+    {
+        return this.scale;
+    }
+
+    public void appendTo(final StringBuilder builder)
+    {
+        CodecUtil.appendFloat(builder, this);
+    }
+
+    @Override
+    public String toString()
+    {
+        final StringBuilder builder = new StringBuilder();
+        appendTo(builder);
+        return builder.toString();
+    }
+
+    @Override
+    public final int compareTo(final ReadOnlyDecimalFloat other)
+    {
+        final long value = this.value;
+        final int scale = this.scale;
+
+        final long otherValue = other.value;
+        final int otherScale = other.scale;
+
+        final long decimalPointDivisor = PowerOf10.pow10(scale);
+        final long otherDecimalPointDivisor = PowerOf10.pow10(otherScale);
+
+        final long valueBeforeDecimalPoint = value / decimalPointDivisor;
+        final long otherValueBeforeDecimalPoint = otherValue / otherDecimalPointDivisor;
+
+        final int beforeDecimalPointComparison = Long.compare(valueBeforeDecimalPoint, otherValueBeforeDecimalPoint);
+
+        if (beforeDecimalPointComparison != 0)
+        {
+            // Can be determined using just the long value before decimal point
+            return beforeDecimalPointComparison;
+        }
+
+        // values after decimal point, but has removed scale entirely
+        long valueAfterDecimalPoint = (value % decimalPointDivisor);
+        long otherValueAfterDecimalPoint = (otherValue % otherDecimalPointDivisor);
+
+        // re-normalise with scales by multiplying the lower scale number up
+        if (scale > otherScale)
+        {
+            final int differenceInScale = scale - otherScale;
+            otherValueAfterDecimalPoint *= PowerOf10.pow10(differenceInScale);
+        }
+        else
+        {
+            final int differenceInScale = otherScale - scale;
+            valueAfterDecimalPoint *= PowerOf10.pow10(differenceInScale);
+        }
+
+        return Long.compare(valueAfterDecimalPoint, otherValueAfterDecimalPoint);
+    }
+
+    /**
+     * This method should satisfy the Effective Java - 3rd Edition - Methods Common to All Objects Item 10
+     * "Obey the general contract when overriding equals",
+     * and it should do it for every x and y where x and y can be an instance of
+     * ReadOnlyDecimalFloat or DecimalFloat, in any order, this method is:
+     * Reflexive : x.equal(x) return true
+     * Symmetric : if x.equals(y) return true, y.equals(x) return true
+     * Transitive : if x.equals(y) return true and y.equals(z) return true, x.equals(z) return true
+     * Consistent : invocations of x.equals(y) return the same value
+     * For any x != null, x.equals(null) returns false
+     * <p>
+     * Any class other than DecimalFloat inheriting ReadOnlyDecimalFloat should overwrite this equal method.
+     * <p>
+     * Support for DecimalFloat was done to provide a backward compatibility when some constants such as ZERO or NAN
+     * were made read only to avoid subtle bugs. By making DecimalFloats equal the corresponding ReadOnlyDecimalFloat
+     * any code that used the predefined constants when they were mutable should still yield the same results,
+     * thus avoiding a different class of subtle errors if the client code was not thoroughly tested
+     *
+     * @param o object to compare with
+     * @return true if any combination of ReadOnlyDecimalFloat or DecimalFloat is equal each other
+     */
+    public final boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+
+        //
+        if (o == null || (ReadOnlyDecimalFloat.class != o.getClass() && DecimalFloat.class != o.getClass()))
+        {
+            return false;
+        }
+
+        final ReadOnlyDecimalFloat that = (ReadOnlyDecimalFloat)o;
+        return scale == that.scale && value == that.value;
+    }
+
+    public final int hashCode()
+    {
+        final int result = (int)(value ^ (value >>> 32));
+        return 31 * result + scale;
+    }
+
+    protected final void setAndNormalise(final long value, final int scale)
+    {
+        this.value = value;
+        this.scale = scale;
+        normalise();
+    }
+
+    private void normalise()
+    {
+        long value = this.value;
+        int scale = this.scale;
+        if (value == 0)
+        {
+            scale = 0;
+        }
+        else if (0 < scale)
+        {
+            while (value % 10 == 0 && 0 < scale)
+            {
+                value /= 10;
+                --scale;
+            }
+        }
+        else if (scale < 0)
+        {
+            while (!isOutsideLimits(value, VALUE_MIN_VAL, VALUE_MAX_VAL) && scale < 0)
+            {
+                value *= 10;
+                ++scale;
+            }
+        }
+        if (isOutsideLimits(scale, SCALE_MIN_VAL, SCALE_MAX_VAL) ||
+            isOutsideLimits(value, VALUE_MIN_VAL, VALUE_MAX_VAL))
+        {
+            throw new ArithmeticException("Out of range: value: " + this.value + ", scale: " + this.scale);
+        }
+        this.value = value;
+        this.scale = scale;
+    }
+
+    private static ReadOnlyDecimalFloat newReadOnlyNanValue()
+    {
+        final ReadOnlyDecimalFloat nanFloat = new ReadOnlyDecimalFloat();
+        nanFloat.value = VALUE_NAN_VALUE;
+        nanFloat.scale = SCALE_NAN_VALUE;
+        return nanFloat;
+    }
+
+    private static boolean isOutsideLimits(final long value, final long lowerBound, final long upperBound)
+    {
+        return value < lowerBound || upperBound < value;
+    }
+
+    private static double toDouble(final long value, final int scale)
+    {
+        int remainingPowersOfTen = scale;
+        double divisor = 1.0;
+        while (remainingPowersOfTen >= HIGHEST_POWER_OF_TEN)
+        {
+            divisor *= POWERS_OF_TEN[HIGHEST_POWER_OF_TEN];
+            remainingPowersOfTen -= HIGHEST_POWER_OF_TEN;
+        }
+        divisor *= POWERS_OF_TEN[remainingPowersOfTen];
+        return value / divisor;
+    }
+}

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/util/MutableAsciiBuffer.java
@@ -278,7 +278,7 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
         return 1;
     }
 
-    public int putFloatAscii(final int offset, final DecimalFloat price)
+    public int putFloatAscii(final int offset, final ReadOnlyDecimalFloat price)
     {
         return putFloatAscii(offset, price.value(), price.scale());
     }
@@ -294,7 +294,7 @@ public final class MutableAsciiBuffer extends UnsafeBuffer implements AsciiBuffe
      */
     public int putFloatAscii(final int offset, final long value, final int scale)
     {
-        if (DecimalFloat.isNaNValue(value, scale))
+        if (ReadOnlyDecimalFloat.isNaNValue(value, scale))
         {
             throw new IllegalArgumentException("You cannot encode NaN into a buffer - it's not a number");
         }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -420,7 +420,7 @@ public class EncoderGeneratorTest
     {
         //Given
         final Encoder encoder = newHeartbeat();
-        final DecimalFloat zero = DecimalFloat.ZERO;
+        final DecimalFloat zero = DecimalFloat.ZERO.mutableCopy();
 
         setFloat(encoder, FLOAT_FIELD, zero);
 
@@ -429,6 +429,7 @@ public class EncoderGeneratorTest
 
         //Then
         assertThat(zero, is(new DecimalFloat()));
+        assertThat(DecimalFloat.ZERO, is(new DecimalFloat()));
     }
 
     @Test

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/DecimalFloatTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/DecimalFloatTest.java
@@ -15,13 +15,20 @@
  */
 package uk.co.real_logic.artio.fields;
 
+import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+
 import uk.co.real_logic.artio.util.AsciiBuffer;
 import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 public class DecimalFloatTest
 {
@@ -143,6 +150,24 @@ public class DecimalFloatTest
     {
         final MutableAsciiBuffer buffer = new MutableAsciiBuffer(new byte[1000]);
         buffer.putFloatAscii(0, DecimalFloat.NAN);
+    }
+
+    @Test
+    @Ignore("reproduced issue https://github.com/real-logic/artio/issues/452")
+    public void shouldNotBeAbleToRedefineConstantValues()
+    {
+        final DecimalFloat value;
+        final DecimalFloat zero = DecimalFloat.ZERO.copy();
+        value = DecimalFloat.ZERO;
+        assertThat(value, equalTo(zero));
+        assertThat(DecimalFloat.ZERO, equalTo(zero));
+
+        // When
+        value.set(new DecimalFloat(5));
+
+        // Then
+        assertThat(value, equalTo(new DecimalFloat(5)));
+        assertThat(DecimalFloat.ZERO, equalTo(zero));
     }
 
     private void parseNumberFromBuffer(final String number)

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/DecimalFloatTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/DecimalFloatTest.java
@@ -15,7 +15,6 @@
  */
 package uk.co.real_logic.artio.fields;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -153,12 +152,11 @@ public class DecimalFloatTest
     }
 
     @Test
-    @Ignore("reproduced issue https://github.com/real-logic/artio/issues/452")
     public void shouldNotBeAbleToRedefineConstantValues()
     {
         final DecimalFloat value;
-        final DecimalFloat zero = DecimalFloat.ZERO.copy();
-        value = DecimalFloat.ZERO;
+        final DecimalFloat zero = DecimalFloat.ZERO.mutableCopy();
+        value = DecimalFloat.ZERO.mutableCopy(); // compiler now prevent from modifying constants such as ZERO
         assertThat(value, equalTo(zero));
         assertThat(DecimalFloat.ZERO, equalTo(zero));
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/ReadOnlyDecimalFloatTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/ReadOnlyDecimalFloatTest.java
@@ -1,0 +1,89 @@
+package uk.co.real_logic.artio.fields;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ReadOnlyDecimalFloatTest
+{
+
+    public static final ReadOnlyDecimalFloat READ_ONLY_FIVE = new ReadOnlyDecimalFloat(5, 0);
+    public static final ReadOnlyDecimalFloat READ_ONLY_ZERO = ReadOnlyDecimalFloat.ZERO;
+
+    @Test
+    public void shouldEqualCorrespondingDecimalFloat()
+    {
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE, ReadOnlyDecimalFloat.MIN_VALUE);
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy(), ReadOnlyDecimalFloat.MIN_VALUE);
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE, ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy());
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy().immutableCopy(), ReadOnlyDecimalFloat.MIN_VALUE);
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE, ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy().immutableCopy());
+    }
+
+    @Test
+    public void shouldNotEqualDifferentDecimalFloat()
+    {
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE, ReadOnlyDecimalFloat.MIN_VALUE);
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy(), ReadOnlyDecimalFloat.MIN_VALUE);
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE, ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy());
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy().immutableCopy(), ReadOnlyDecimalFloat.MIN_VALUE);
+        assertEquals(ReadOnlyDecimalFloat.MIN_VALUE, ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy().immutableCopy());
+    }
+
+    @Test
+    public void shouldNotEqualDifferentReadOnlyDecimalFloat()
+    {
+        assertNotEquals(ReadOnlyDecimalFloat.MIN_VALUE, ReadOnlyDecimalFloat.MAX_VALUE);
+        assertNotEquals(ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy(), ReadOnlyDecimalFloat.MAX_VALUE);
+        assertNotEquals(ReadOnlyDecimalFloat.MAX_VALUE, ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy());
+        assertNotEquals(ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy().immutableCopy(), ReadOnlyDecimalFloat.MAX_VALUE);
+        assertNotEquals(ReadOnlyDecimalFloat.MAX_VALUE, ReadOnlyDecimalFloat.MIN_VALUE.mutableCopy().immutableCopy());
+    }
+
+    @Test
+    public void shouldBeComparableWithDecimalFloat()
+    {
+        assertEquals(0, READ_ONLY_ZERO.compareTo(READ_ONLY_ZERO));
+        assertEquals(0, READ_ONLY_ZERO.compareTo(READ_ONLY_ZERO.mutableCopy()));
+        assertEquals(0, READ_ONLY_ZERO.compareTo(READ_ONLY_ZERO.mutableCopy().immutableCopy()));
+        assertEquals(0, READ_ONLY_ZERO.mutableCopy().compareTo(READ_ONLY_ZERO));
+        assertEquals(0, READ_ONLY_ZERO.mutableCopy().immutableCopy().compareTo(READ_ONLY_ZERO));
+
+        assertEquals(1, READ_ONLY_FIVE.compareTo(READ_ONLY_ZERO));
+        assertEquals(1, READ_ONLY_FIVE.compareTo(READ_ONLY_ZERO.mutableCopy()));
+        assertEquals(1, READ_ONLY_FIVE.compareTo(READ_ONLY_ZERO.mutableCopy().immutableCopy()));
+        assertEquals(1, READ_ONLY_FIVE.mutableCopy().compareTo(READ_ONLY_ZERO));
+        assertEquals(1, READ_ONLY_FIVE.mutableCopy().immutableCopy().compareTo(READ_ONLY_ZERO));
+
+        assertEquals(-1, READ_ONLY_ZERO.compareTo(READ_ONLY_FIVE));
+        assertEquals(-1, READ_ONLY_ZERO.compareTo(READ_ONLY_FIVE.mutableCopy()));
+        assertEquals(-1, READ_ONLY_ZERO.compareTo(READ_ONLY_FIVE.mutableCopy().immutableCopy()));
+        assertEquals(-1, READ_ONLY_ZERO.mutableCopy().compareTo(READ_ONLY_FIVE));
+        assertEquals(-1, READ_ONLY_ZERO.mutableCopy().immutableCopy().compareTo(READ_ONLY_FIVE));
+    }
+
+    @Test
+    public void shouldHaveTheSameHashCodeAsDecimalFloat()
+    {
+        assertEquals(READ_ONLY_ZERO.hashCode(), READ_ONLY_ZERO.mutableCopy().hashCode());
+        assertEquals(READ_ONLY_ZERO.hashCode(), READ_ONLY_ZERO.mutableCopy().immutableCopy().hashCode());
+        assertEquals(READ_ONLY_ZERO.mutableCopy().hashCode(), READ_ONLY_ZERO.hashCode());
+        assertEquals(READ_ONLY_ZERO.mutableCopy().immutableCopy().hashCode(), READ_ONLY_ZERO.hashCode());
+
+        assertNotEquals(READ_ONLY_ZERO.hashCode(), READ_ONLY_FIVE.mutableCopy().hashCode());
+        assertNotEquals(READ_ONLY_ZERO.hashCode(), READ_ONLY_FIVE.mutableCopy().immutableCopy().hashCode());
+        assertNotEquals(READ_ONLY_ZERO.mutableCopy().hashCode(), READ_ONLY_FIVE.hashCode());
+        assertNotEquals(READ_ONLY_ZERO.mutableCopy().immutableCopy().hashCode(), READ_ONLY_FIVE.hashCode());
+    }
+
+    @Test
+    public void shouldDetectNaNRegardlessIfIsMutableOrNot()
+    {
+        assertTrue(ReadOnlyDecimalFloat.NAN.isNaNValue());
+        assertTrue(ReadOnlyDecimalFloat.NAN.mutableCopy().isNaNValue());
+        assertTrue(ReadOnlyDecimalFloat.NAN.mutableCopy().immutableCopy().isNaNValue());
+        assertFalse(READ_ONLY_ZERO.isNaNValue());
+        assertFalse(READ_ONLY_ZERO.mutableCopy().isNaNValue());
+        assertFalse(READ_ONLY_ZERO.mutableCopy().immutableCopy().isNaNValue());
+    }
+}

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
@@ -21,6 +21,7 @@ import uk.co.real_logic.artio.builder.Encoder;
 import uk.co.real_logic.artio.fields.DecimalFloat;
 
 import org.agrona.AsciiSequenceView;
+import uk.co.real_logic.artio.fields.ReadOnlyDecimalFloat;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -62,7 +63,7 @@ public final class Reflection
     public static void setFloat(final Object object, final String setter, final DecimalFloat value)
         throws Exception
     {
-        set(object, setter, DecimalFloat.class, value);
+        set(object, setter, ReadOnlyDecimalFloat.class, value);
     }
 
     public static void setFloat(final Object object, final String setter, final long value, final int scale)


### PR DESCRIPTION
This change fixes the issue #452 

The purpose of this change is to avoid subtle bugs when the seemingly constant value is redefined.

The change tried to conform to the following constraints:

- maintain as much backward compatibility as possible with a minimal or no change required by the library user

- do not adversely affect the performance

### Design

The approach here is to extract a read only superclass. It has several benefits.

- both types can be used interchangeably, so the client's code should just work without them knowing that anything changed in most cases
- the tandem ReadOnly and the mutable DecimalFloat as still effectively final (cannot be extended outside of the library package)
- there should not be any performance overhead (illegal operations are now checked and rejected at compile time)
- it supports immutability for constants that are still visible as if they were declared on the existing DecimalFloat class
- improved discoverability of potential bugs (as above illegal operations are now checked and rejected at compile time)

### Migration process

Upgrade the Artio dependency, compile the downstream project. If no compilation errors, no changes required.

I have tested this version with a large scale project that makes heavy use of Artio codecs and this version was backward compatible apart from one place that took me 30 seconds to change (passing a ZERO as a mutable input argument which is arguably better off being passed as a ReadOnlyDecimalFloat instead)

When it comes to the backward compatibility, the new version should work just fine.
the only required change on the client side (that should be quite rare anyway) is in places where constant such as ZERO or NAN were assigned or passed  to a function that expected DecimalFloat.

The client can either:
- change expected DecimalFloat type to ReadOnlyDecimalFloat
- ask for a mutableCopy()

There should be no other changes required (comparison, equality etc. maintains backward compatibility and works fine with both types interchangeably)

### Value for library users

If there are other changes required, e.g. invocation of a mutating method such as setValue no longer compiles, it means that the upgrade detected a potential error in the client's codebase that tried to modify a constant value. This is the very reason the change was introduced.