### PR TITLE
Do not match subsequences when matching headers

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
@@ -148,7 +148,7 @@ public final class CodecUtil
         final int expectedOffset,
         final int length)
     {
-        if (value.length < length || expected.length < length)
+        if (value.length < offset + length || expected.length < expectedOffset + length)
         {
             return false;
         }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
@@ -164,8 +164,20 @@ public final class CodecUtil
         return true;
     }
 
+    /**
+     * Compares first {@code length} characters of {@code value} with all {@code expected} characters.
+     *
+     * @param value    the array containing the actual value, might be longer than the value itself
+     * @param expected the array containing the expected value, both equal in length
+     * @param length   the length of the actual value
+     * @return true if the actual value is equal to the expected one
+     */
     public static boolean equals(final char[] value, final char[] expected, final int length)
     {
+        if (length != expected.length)
+        {
+            return false;
+        }
         return equals(value, expected, 0, 0, length);
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CodecUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CodecUtilTest.java
@@ -53,6 +53,13 @@ public class CodecUtilTest
     }
 
     @Test
+    public void shouldCheckOffsetAndLength()
+    {
+        assertFalse(CodecUtil.equals("aaaa".toCharArray(), "aaaa".toCharArray(), 3, 0, 2));
+        assertFalse(CodecUtil.equals("aaaa".toCharArray(), "aaaa".toCharArray(), 0, 3, 2));
+    }
+
+    @Test
     public void testHashCodeWithOffset()
     {
         final int firstHash = CodecUtil.hashCode("zyxabc".toCharArray(), 0, 3);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CodecUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CodecUtilTest.java
@@ -23,6 +23,16 @@ public class CodecUtilTest
 {
 
     @Test
+    public void testSimpleEquals()
+    {
+        assertTrue(CodecUtil.equals("abc".toCharArray(), "abc".toCharArray(), 3));
+        assertTrue(CodecUtil.equals("abcd".toCharArray(), "abc".toCharArray(), 3));
+        assertFalse(CodecUtil.equals("abc".toCharArray(), "abx".toCharArray(), 3));
+        assertFalse(CodecUtil.equals("abc".toCharArray(), "abc".toCharArray(), 2));
+        assertFalse(CodecUtil.equals("abcd".toCharArray(), "abc".toCharArray(), 4));
+    }
+
+    @Test
     public void shouldCheckSubsectionOfCharArrays()
     {
         assertTrue(CodecUtil.equals("abc".toCharArray(), "abc    ".toCharArray(), 0, 0, 3));

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixMessagePredicates.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixMessagePredicates.java
@@ -430,10 +430,6 @@ public final class FixMessagePredicates
         {
             final char[] actualChars = charExtractor.apply(header);
             final int length = lengthExtractor.applyAsInt(header);
-            if (length != expectedChars.length)
-            {
-                return false;
-            }
             return CodecUtil.equals(actualChars, expectedChars, length);
         }
     }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixMessagePredicates.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixMessagePredicates.java
@@ -430,6 +430,10 @@ public final class FixMessagePredicates
         {
             final char[] actualChars = charExtractor.apply(header);
             final int length = lengthExtractor.applyAsInt(header);
+            if (length != expectedChars.length)
+            {
+                return false;
+            }
             return CodecUtil.equals(actualChars, expectedChars, length);
         }
     }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderAndTargetSessionIdStrategy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderAndTargetSessionIdStrategy.java
@@ -133,12 +133,12 @@ class SenderAndTargetSessionIdStrategy implements SessionIdStrategy
     {
         final CompositeKeyImpl key = (CompositeKeyImpl)compositeKey;
 
-        if (!CodecUtil.equals(key.remoteCompID, header.senderCompID(), header.senderCompIDLength()))
+        if (!CodecUtil.equals(header.senderCompID(), key.remoteCompID, header.senderCompIDLength()))
         {
             return SENDER_COMP_ID;
         }
 
-        if (!CodecUtil.equals(key.localCompID, header.targetCompID(), header.targetCompIDLength()))
+        if (!CodecUtil.equals(header.targetCompID(), key.localCompID, header.targetCompIDLength()))
         {
             return TARGET_COMP_ID;
         }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderTargetAndSubSessionIdStrategy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderTargetAndSubSessionIdStrategy.java
@@ -148,10 +148,10 @@ class SenderTargetAndSubSessionIdStrategy implements SessionIdStrategy
             return TARGET_COMP_ID;
         }
 
-        final boolean hasSenderSubID = header.hasSenderSubID();
-        if (!(hasSenderSubID && CodecUtil.equals(key.localSubID, header.senderSubID(), header.senderSubIDLength())))
+        final boolean hasTargetSubID = header.hasTargetSubID();
+        if (!(hasTargetSubID && CodecUtil.equals(key.localSubID, header.targetSubID(), header.targetSubIDLength())))
         {
-            return SENDER_SUB_ID;
+            return TARGET_SUB_ID;
         }
 
         return 0;

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderTargetAndSubSessionIdStrategy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SenderTargetAndSubSessionIdStrategy.java
@@ -138,18 +138,18 @@ class SenderTargetAndSubSessionIdStrategy implements SessionIdStrategy
     {
         final CompositeKeyImpl key = (CompositeKeyImpl)compositeKey;
 
-        if (!CodecUtil.equals(key.remoteCompID, header.senderCompID(), header.senderCompIDLength()))
+        if (!CodecUtil.equals(header.senderCompID(), key.remoteCompID, header.senderCompIDLength()))
         {
             return SENDER_COMP_ID;
         }
 
-        if (!CodecUtil.equals(key.localCompID, header.targetCompID(), header.targetCompIDLength()))
+        if (!CodecUtil.equals(header.targetCompID(), key.localCompID, header.targetCompIDLength()))
         {
             return TARGET_COMP_ID;
         }
 
         final boolean hasTargetSubID = header.hasTargetSubID();
-        if (!(hasTargetSubID && CodecUtil.equals(key.localSubID, header.targetSubID(), header.targetSubIDLength())))
+        if (!(hasTargetSubID && CodecUtil.equals(header.targetSubID(), key.localSubID, header.targetSubIDLength())))
         {
             return TARGET_SUB_ID;
         }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/validation/TargetCompIdValidationStrategy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/validation/TargetCompIdValidationStrategy.java
@@ -35,7 +35,7 @@ final class TargetCompIdValidationStrategy implements MessageValidationStrategy
 
     public boolean validate(final SessionHeaderDecoder header)
     {
-        return CodecUtil.equals(gatewayCompId, header.targetCompID(), header.targetCompIDLength());
+        return CodecUtil.equals(header.targetCompID(), gatewayCompId, header.targetCompIDLength());
     }
 
     public int invalidTagId()

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/FixMessagePredicateTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/FixMessagePredicateTest.java
@@ -76,6 +76,7 @@ public class FixMessagePredicateTest
         encoder.body(HEADER_EG);
 
         assertTargetCompId("accept", false);
+        assertTargetCompId("acceptor2", false);
     }
 
     private void assertTargetCompId(final String targetCompIdOf, final boolean expected)

--- a/artio-samples/src/main/java/uk/co/real_logic/artio/example_exchange/ExchangeSessionHandler.java
+++ b/artio-samples/src/main/java/uk/co/real_logic/artio/example_exchange/ExchangeSessionHandler.java
@@ -100,7 +100,7 @@ public class ExchangeSessionHandler implements SessionHandler
 
     private boolean validOrder()
     {
-        if (!CodecUtil.equals(VALID_SYMBOL, newOrderSingle.symbol(), newOrderSingle.symbolLength()))
+        if (!CodecUtil.equals(newOrderSingle.symbol(), VALID_SYMBOL, newOrderSingle.symbolLength()))
         {
             return false;
         }


### PR DESCRIPTION
Header predicate for foobar will match foo, but I believe that should be exact.