### PR TITLE
adding sessionId and firmId long support to forNextSessionVerID

### DIFF
--- a/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/BinaryEntryPointContext.java
+++ b/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/BinaryEntryPointContext.java
@@ -60,7 +60,7 @@ public class BinaryEntryPointContext implements FixPContext
     }
 
     public static BinaryEntryPointContext forNextSessionVerID(
-        final int sessionId, final long nanoTime, final int firmId)
+        final long sessionId, final long nanoTime, final long firmId)
     {
         return new BinaryEntryPointContext(
             sessionId,


### PR DESCRIPTION
Changing sessionId and firmId in forNextSessionVerID method to support long