### PR TITLE
 More fluent way of transcoding optional strings from FIX to SBE

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractHeartbeatDecoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractHeartbeatDecoder.java
@@ -28,5 +28,5 @@ public interface AbstractHeartbeatDecoder extends Decoder
 
     String testReqIDAsString();
 
-    void testReqID(AsciiSequenceView view);
+    AsciiSequenceView testReqID(AsciiSequenceView view);
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractLogonDecoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractLogonDecoder.java
@@ -32,7 +32,7 @@ public interface AbstractLogonDecoder extends Decoder
 
     String usernameAsString();
 
-    void username(AsciiSequenceView view);
+    AsciiSequenceView username(AsciiSequenceView view);
 
     boolean supportsPassword();
 
@@ -44,7 +44,7 @@ public interface AbstractLogonDecoder extends Decoder
 
     String passwordAsString();
 
-    void password(AsciiSequenceView view);
+    AsciiSequenceView password(AsciiSequenceView view);
 
     boolean hasResetSeqNumFlag();
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractLogoutDecoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractLogoutDecoder.java
@@ -28,5 +28,5 @@ public interface AbstractLogoutDecoder extends Decoder
 
     String textAsString();
 
-    void text(AsciiSequenceView view);
+    AsciiSequenceView text(AsciiSequenceView view);
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractTestRequestDecoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractTestRequestDecoder.java
@@ -26,5 +26,5 @@ public interface AbstractTestRequestDecoder extends Decoder
 
     String testReqIDAsString();
 
-    void testReqID(AsciiSequenceView view);
+    AsciiSequenceView testReqID(AsciiSequenceView view);
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractUserRequestDecoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/AbstractUserRequestDecoder.java
@@ -28,7 +28,7 @@ public interface AbstractUserRequestDecoder extends Decoder
 
     String passwordAsString();
 
-    void password(AsciiSequenceView view);
+    AsciiSequenceView password(AsciiSequenceView view);
 
     char[] newPassword();
 
@@ -38,5 +38,5 @@ public interface AbstractUserRequestDecoder extends Decoder
 
     String newPasswordAsString();
 
-    void newPassword(AsciiSequenceView view);
+    AsciiSequenceView newPassword(AsciiSequenceView view);
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/SessionHeaderDecoder.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/decoder/SessionHeaderDecoder.java
@@ -49,7 +49,7 @@ public interface SessionHeaderDecoder
 
     String origSendingTimeAsString();
 
-    void origSendingTime(AsciiSequenceView view);
+    AsciiSequenceView origSendingTime(AsciiSequenceView view);
 
     int msgTypeLength();
 
@@ -76,7 +76,7 @@ public interface SessionHeaderDecoder
 
     String sendingTimeAsString();
 
-    void sendingTime(AsciiSequenceView view);
+    AsciiSequenceView sendingTime(AsciiSequenceView view);
 
     char[] senderCompID();
 
@@ -122,15 +122,15 @@ public interface SessionHeaderDecoder
 
     String targetLocationIDAsString();
 
-    void senderCompID(AsciiSequenceView view);
+    AsciiSequenceView senderCompID(AsciiSequenceView view);
 
-    void senderSubID(AsciiSequenceView view);
+    AsciiSequenceView senderSubID(AsciiSequenceView view);
 
-    void senderLocationID(AsciiSequenceView view);
+    AsciiSequenceView senderLocationID(AsciiSequenceView view);
 
-    void targetCompID(AsciiSequenceView view);
+    AsciiSequenceView targetCompID(AsciiSequenceView view);
 
-    void targetSubID(AsciiSequenceView view);
+    AsciiSequenceView targetSubID(AsciiSequenceView view);
 
-    void targetLocationID(AsciiSequenceView view);
+    AsciiSequenceView targetLocationID(AsciiSequenceView view);
 }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecConfiguration.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecConfiguration.java
@@ -44,6 +44,14 @@ public final class CodecConfiguration
      * </pre>
      */
     public static final String FIX_CODECS_ALLOW_DUPLICATE_FIELDS_PROPERTY = "fix.codecs.allow_duplicate_fields";
+
+    /**
+     * Boolean system property to avoid throwing when an optional string field is unset.
+     * <p>
+     * This is useful to call getters accepting an {@link org.agrona.AsciiSequenceView}
+     * without checking whether the field is set.
+     */
+    public static final String WRAP_EMPTY_BUFFER = "fix.codecs.wrap_empty_buffer";
     public static final String PARENT_PACKAGE_PROPERTY = "fix.codecs.parent_package";
     public static final String FLYWEIGHTS_ENABLED_PROPERTY = "fix.codecs.flyweight";
     public static final String REJECT_UNKNOWN_ENUM_VALUE_PROPERTY = "reject.unknown.enum.value";
@@ -52,6 +60,7 @@ public final class CodecConfiguration
 
     private String parentPackage = System.getProperty(PARENT_PACKAGE_PROPERTY, DEFAULT_PARENT_PACKAGE);
     private boolean flyweightsEnabled = Boolean.getBoolean(FLYWEIGHTS_ENABLED_PROPERTY);
+    private boolean wrapEmptyBuffer = Boolean.getBoolean(WRAP_EMPTY_BUFFER);
     private SharedCodecConfiguration sharedCodecConfiguration;
 
     private String codecRejectUnknownEnumValueEnabled;
@@ -98,6 +107,18 @@ public final class CodecConfiguration
     public CodecConfiguration flyweightsEnabled(final boolean flyweightsEnabled)
     {
         this.flyweightsEnabled = flyweightsEnabled;
+        return this;
+    }
+
+    /**
+     * Suppresses checks for the presence of optional string fields (i.e. no exception is
+     * thrown when unset, instead the AsciiSequenceView wraps an empty buffer).
+     *
+     * Defaults to the value of {@link #WRAP_EMPTY_BUFFER} system property.
+     */
+    public CodecConfiguration wrapEmptyBuffer(final boolean wrapEmptyBuffer)
+    {
+        this.wrapEmptyBuffer = wrapEmptyBuffer;
         return this;
     }
 
@@ -200,6 +221,10 @@ public final class CodecConfiguration
     boolean flyweightsEnabled()
     {
         return flyweightsEnabled;
+    }
+
+    boolean wrapEmptyBuffer() {
+        return wrapEmptyBuffer;
     }
 
     String codecRejectUnknownEnumValueEnabled()

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecConfiguration.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecConfiguration.java
@@ -115,6 +115,9 @@ public final class CodecConfiguration
      * thrown when unset, instead the AsciiSequenceView wraps an empty buffer).
      *
      * Defaults to the value of {@link #WRAP_EMPTY_BUFFER} system property.
+     *
+     * @param wrapEmptyBuffer true to suppress check of optional strings, false to keep checking (default)
+     * @return this
      */
     public CodecConfiguration wrapEmptyBuffer(final boolean wrapEmptyBuffer)
     {
@@ -223,7 +226,8 @@ public final class CodecConfiguration
         return flyweightsEnabled;
     }
 
-    boolean wrapEmptyBuffer() {
+    boolean wrapEmptyBuffer()
+    {
         return wrapEmptyBuffer;
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecGenerator.java
@@ -178,6 +178,7 @@ public final class CodecGenerator
             RejectUnknownField.class,
             RejectUnknownEnumValue.class,
             false,
+            configuration.wrapEmptyBuffer(),
             codecRejectUnknownEnumValueEnabled).generate();
 
         new PrinterGenerator(dictionary, decoderPackage, decoderOutput).generate();
@@ -198,6 +199,7 @@ public final class CodecGenerator
                 RejectUnknownField.class,
                 RejectUnknownEnumValue.class,
                 true,
+                configuration.wrapEmptyBuffer(),
                 codecRejectUnknownEnumValueEnabled).generate();
         }
     }

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -875,7 +875,7 @@ class DecoderGenerator extends Generator
             String.format("    public int %1$sLength();\n", fieldName) : "";
 
         final String stringAsciiView = type.isStringBased() ?
-            String.format("    public void %1$s(AsciiSequenceView view);\n", fieldName) : "";
+            String.format("    public AsciiSequenceView %1$s(AsciiSequenceView view);\n", fieldName) : "";
 
         final String optional = !entry.required() ?
             String.format("    public boolean has%1$s();\n", name) : "";
@@ -1024,7 +1024,7 @@ class DecoderGenerator extends Generator
                         "    {\n" +
                         "        throw new UnsupportedOperationException();\n" +
                         "    }\n\n" +
-                        "    public void %1$s(final AsciiSequenceView view)\n" +
+                        "    public AsciiSequenceView %1$s(final AsciiSequenceView view)\n" +
                         "    {\n" +
                         "        throw new UnsupportedOperationException();\n" +
                         "    }\n\n",
@@ -1287,10 +1287,10 @@ class DecoderGenerator extends Generator
             "    {\n" +
             "        return %3$s;\n" +
             "    }\n\n" +
-            "    public void %1$s(final AsciiSequenceView view)\n" +
+            "    public AsciiSequenceView %1$s(final AsciiSequenceView view)\n" +
             "    {\n" +
             "%2$s" +
-            "        view.wrap(buffer, %1$sOffset, %1$sLength);\n" +
+            "        return view.wrap(buffer, %1$sOffset, %1$sLength);\n" +
             "    }\n\n",
             fieldName,
             optionalCheck,

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -1377,9 +1377,9 @@ class DecoderGenerator extends Generator
     {
         return entry.required() ? "" : String.format(
           "        if (!has%s)\n" +
-            "        {\n" +
-            "        return view.wrap(buffer, 0, 0);\n" +
-            "        }\n\n",
+          "        {\n" +
+          "            return view.wrap(buffer, 0, 0);\n" +
+          "        }\n\n",
           entry.name());
     }
 

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -116,7 +116,7 @@ public abstract class AbstractDecoderGeneratorTest
 
     private static Map<String, CharSequence> generateSources(
         final boolean validation, final boolean rejectingUnknownFields, final boolean rejectingUnknownEnumValue,
-        final boolean flyweightStringsEnabled, boolean wrapEmptyBuffer)
+        final boolean flyweightStringsEnabled, final boolean wrapEmptyBuffer)
     {
         final Class<?> validationClass = validation ? ValidationOn.class : ValidationOff.class;
         final Class<?> rejectUnknownField = rejectingUnknownFields ?
@@ -130,7 +130,8 @@ public abstract class AbstractDecoderGeneratorTest
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, TEST_PACKAGE,
             outputManager, validationClass, rejectUnknownField,
-            rejectUnknownEnumValue, flyweightStringsEnabled, wrapEmptyBuffer, String.valueOf(rejectingUnknownEnumValue));
+            rejectUnknownEnumValue, flyweightStringsEnabled, wrapEmptyBuffer,
+            String.valueOf(rejectingUnknownEnumValue));
         final EncoderGenerator encoderGenerator = new EncoderGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE,
             TEST_PARENT_PACKAGE, outputManager, ValidationOn.class, RejectUnknownFieldOn.class,
             RejectUnknownEnumValueOn.class, RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -85,13 +85,13 @@ public abstract class AbstractDecoderGeneratorTest
     static void generate(final boolean flyweightStringsEnabled) throws Exception
     {
         final Map<String, CharSequence> sourcesWithValidation = generateSources(
-            true, false, true, flyweightStringsEnabled);
+            true, false, true, flyweightStringsEnabled, false);
         final Map<String, CharSequence> sourcesWithNoEnumValueValidation = generateSources(
-            true, false, false, flyweightStringsEnabled);
+            true, false, false, flyweightStringsEnabled, false);
         final Map<String, CharSequence> sourcesWithoutValidation = generateSources(
-            false, false, true, flyweightStringsEnabled);
+            false, false, true, flyweightStringsEnabled, true);
         final Map<String, CharSequence> sourcesRejectingUnknownFields = generateSources(
-            true, true, true, flyweightStringsEnabled);
+            true, true, true, flyweightStringsEnabled, false);
         heartbeat = compileInMemory(HEARTBEAT_DECODER, sourcesWithValidation);
         if (heartbeat == null || CODEC_LOGGING)
         {
@@ -116,7 +116,7 @@ public abstract class AbstractDecoderGeneratorTest
 
     private static Map<String, CharSequence> generateSources(
         final boolean validation, final boolean rejectingUnknownFields, final boolean rejectingUnknownEnumValue,
-        final boolean flyweightStringsEnabled)
+        final boolean flyweightStringsEnabled, boolean wrapEmptyBuffer)
     {
         final Class<?> validationClass = validation ? ValidationOn.class : ValidationOff.class;
         final Class<?> rejectUnknownField = rejectingUnknownFields ?
@@ -130,7 +130,7 @@ public abstract class AbstractDecoderGeneratorTest
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, TEST_PACKAGE,
             outputManager, validationClass, rejectUnknownField,
-            rejectUnknownEnumValue, flyweightStringsEnabled, String.valueOf(rejectingUnknownEnumValue));
+            rejectUnknownEnumValue, flyweightStringsEnabled, wrapEmptyBuffer, String.valueOf(rejectingUnknownEnumValue));
         final EncoderGenerator encoderGenerator = new EncoderGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE,
             TEST_PARENT_PACKAGE, outputManager, ValidationOn.class, RejectUnknownFieldOn.class,
             RejectUnknownEnumValueOn.class, RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGeneratorTest.java
@@ -43,7 +43,7 @@ public class AcceptorGeneratorTest
         RejectUnknownFieldOn.class, RejectUnknownEnumValueOn.class, RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
     private static final DecoderGenerator DECODER_GENERATOR = new DecoderGenerator(
         MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, TEST_PACKAGE, OUTPUT_MANAGER, ValidationOn.class,
-        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false,
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false, false,
         Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
     private static final AcceptorGenerator ACCEPTOR_GENERATOR = new AcceptorGenerator(
         MESSAGE_EXAMPLE, TEST_PACKAGE, OUTPUT_MANAGER);

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CopyToEncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CopyToEncoderGeneratorTest.java
@@ -76,7 +76,7 @@ public class CopyToEncoderGeneratorTest
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE,
             TEST_PARENT_PACKAGE, TEST_PACKAGE, outputManager, ValidationOn.class,
-            RejectUnknownFieldOn.class, RejectUnknownEnumValueOn.class, false,
+            RejectUnknownFieldOn.class, RejectUnknownEnumValueOn.class, false, false,
             RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
         final EncoderGenerator encoderGenerator = new EncoderGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE,
             TEST_PARENT_PACKAGE, outputManager, ValidationOn.class, RejectUnknownFieldOn.class,

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorFlyweightTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorFlyweightTest.java
@@ -58,11 +58,11 @@ public class DecoderGeneratorFlyweightTest extends AbstractDecoderGeneratorTest
         final Decoder decoderWithoutValidation = decodeHeartbeatWithoutValidation(INVALID_FLOAT_VALUE_MESSAGE);
 
         // generated with wrapEmptyBuffer=true
-        AsciiSequenceView view = getAsciiSequenceView(decoderWithoutValidation, "testReqID");
+        final AsciiSequenceView view = getAsciiSequenceView(decoderWithoutValidation, "testReqID");
         assertEquals(0, view.length());
 
         // generated with wrapEmptyBuffer=false
         assertTargetThrows(() -> getAsciiSequenceView(decoder, "testReqID"), IllegalArgumentException.class,
-          "No value for optional field: TestReqID");
+            "No value for optional field: TestReqID");
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorFlyweightTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/DecoderGeneratorFlyweightTest.java
@@ -15,13 +15,15 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
+import org.agrona.AsciiSequenceView;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import uk.co.real_logic.artio.builder.Decoder;
 
-import static uk.co.real_logic.artio.dictionary.ExampleDictionary.INVALID_FLOAT_VALUE_MESSAGE;
-import static uk.co.real_logic.artio.dictionary.ExampleDictionary.INVALID_INT_VALUE_MESSAGE;
+import static org.junit.Assert.assertEquals;
+import static uk.co.real_logic.artio.dictionary.ExampleDictionary.*;
 import static uk.co.real_logic.artio.util.CustomMatchers.assertTargetThrows;
+import static uk.co.real_logic.artio.util.Reflection.getAsciiSequenceView;
 
 public class DecoderGeneratorFlyweightTest extends AbstractDecoderGeneratorTest
 {
@@ -47,5 +49,20 @@ public class DecoderGeneratorFlyweightTest extends AbstractDecoderGeneratorTest
 
         assertTargetThrows(() -> getFloatField(decoder), NumberFormatException.class,
             "'A' isn't a valid digit @ 39 tag=117");
+    }
+
+    @Test
+    public void shouldNotThrowWhenAccessingUnsetString() throws Exception
+    {
+        final Decoder decoder = decodeHeartbeat(INVALID_FLOAT_VALUE_MESSAGE);
+        final Decoder decoderWithoutValidation = decodeHeartbeatWithoutValidation(INVALID_FLOAT_VALUE_MESSAGE);
+
+        // generated with wrapEmptyBuffer=true
+        AsciiSequenceView view = getAsciiSequenceView(decoderWithoutValidation, "testReqID");
+        assertEquals(0, view.length());
+
+        // generated with wrapEmptyBuffer=false
+        assertTargetThrows(() -> getAsciiSequenceView(decoder, "testReqID"), IllegalArgumentException.class,
+          "No value for optional field: TestReqID");
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/PrinterGeneratorTest.java
@@ -41,7 +41,7 @@ public class PrinterGeneratorTest
     private static final DecoderGenerator DECODER_GENERATOR = new DecoderGenerator(
         MESSAGE_EXAMPLE, 1, TEST_PACKAGE, TEST_PARENT_PACKAGE, TEST_PACKAGE,
         OUTPUT_MANAGER, ValidationOn.class,
-        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false,
+        RejectUnknownFieldOff.class, RejectUnknownEnumValueOn.class, false, false,
         Generator.RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
     private static final EncoderGenerator ENCODER_GENERATOR = new EncoderGenerator(
         MESSAGE_EXAMPLE, TEST_PACKAGE, TEST_PARENT_PACKAGE, OUTPUT_MANAGER, ValidationOn.class,

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/ToEncoderDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/ToEncoderDecoderGeneratorTest.java
@@ -93,7 +93,7 @@ public class ToEncoderDecoderGeneratorTest
         final DecoderGenerator decoderGenerator = new DecoderGenerator(
             MESSAGE_EXAMPLE, 1, TEST_PACKAGE,
             TEST_PARENT_PACKAGE, TEST_PACKAGE, outputManager, ValidationOn.class,
-            RejectUnknownFieldOn.class, RejectUnknownEnumValueOn.class, flyweightStringsEnabled,
+            RejectUnknownFieldOn.class, RejectUnknownEnumValueOn.class, flyweightStringsEnabled, false,
             RUNTIME_REJECT_UNKNOWN_ENUM_VALUE_PROPERTY);
         final EncoderGenerator encoderGenerator = new EncoderGenerator(MESSAGE_EXAMPLE, TEST_PACKAGE,
             TEST_PARENT_PACKAGE, outputManager, ValidationOn.class, RejectUnknownFieldOn.class,

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
@@ -251,9 +251,8 @@ public final class Reflection
     public static AsciiSequenceView getAsciiSequenceView(final Object value, final String name) throws Exception
     {
         final AsciiSequenceView view = new AsciiSequenceView();
-        value.getClass()
+        return (AsciiSequenceView) value.getClass()
                 .getMethod(name, AsciiSequenceView.class)
                 .invoke(value, view);
-        return view;
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/Reflection.java
@@ -251,7 +251,7 @@ public final class Reflection
     public static AsciiSequenceView getAsciiSequenceView(final Object value, final String name) throws Exception
     {
         final AsciiSequenceView view = new AsciiSequenceView();
-        return (AsciiSequenceView) value.getClass()
+        return (AsciiSequenceView)value.getClass()
                 .getMethod(name, AsciiSequenceView.class)
                 .invoke(value, view);
     }


### PR DESCRIPTION
See issue #459 

The goal is to be able to do
```java
  execReportEncoder.account(executionReportDecoder.account(asciiSequenceView));
```
instead of 
```java
    if (executionReportDecoder.hasAccount()) {
      executionReportDecoder.account(asciiSequenceView);
      execReportEncoder.account(asciiSequenceView);
    }
    else {
      execReportEncoder.account("");
    }
```