### PR TITLE
Add @Generated annotation to generated types

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/Generated.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/Generated.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2022 Real Logic Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.dictionary;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated member code was generated. Retained on the class,
+ * for use with static analysis tooling.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+@Documented
+@SuppressWarnings("unused")
+public @interface Generated
+{
+    /**
+     * The value element MUST have the name of the code generator. The
+     * name is the fully qualified name of the code generator.
+     *
+     * @return The name of the code generator
+     */
+    String[] value();
+
+    /**
+     * A place-holder for any comments that the code generator may want to
+     * include in the generated code.
+     *
+     * @return Comments that the code generated included
+     */
+    String comments() default "";
+}

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/AcceptorGenerator.java
@@ -16,6 +16,7 @@
 package uk.co.real_logic.artio.dictionary.generation;
 
 import org.agrona.generation.OutputManager;
+import uk.co.real_logic.artio.dictionary.Generated;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.Message;
 import uk.co.real_logic.artio.util.AsciiBuffer;
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.io.Writer;
 
 import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.decoderClassName;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.GENERATED_ANNOTATION;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
 import static uk.co.real_logic.sbe.generation.java.JavaUtil.formatPropertyName;
@@ -123,8 +125,10 @@ class AcceptorGenerator
     private void generateAcceptorClass(final Writer acceptorOutput) throws IOException
     {
         acceptorOutput.append(fileHeader(packageName));
+        acceptorOutput.append(importFor(Generated.class));
         acceptorOutput.append(
             "\n" +
+            GENERATED_ANNOTATION +
             "public interface " + DICTIONARY_ACCEPTOR + "\n" +
             "{\n"
         );
@@ -133,8 +137,10 @@ class AcceptorGenerator
     private void generateDefaultAcceptorClass(final Writer acceptorOutput) throws IOException
     {
         acceptorOutput.append(fileHeader(packageName));
+        acceptorOutput.append(importFor(Generated.class));
         acceptorOutput.append(
             "\n" +
+            GENERATED_ANNOTATION +
             "public class " + DEFAULT_DICTIONARY_ACCEPTOR + " implements " + DICTIONARY_ACCEPTOR + "\n" +
             "{\n"
         );
@@ -220,8 +226,10 @@ class AcceptorGenerator
     {
         decoderOutput.append(fileHeader(packageName));
         decoderOutput.append(importFor(AsciiBuffer.class));
+        decoderOutput.append(importFor(Generated.class));
         decoderOutput.append(
             "\n" +
+            GENERATED_ANNOTATION +
             "public final class " + DICTIONARY_DECODER + "\n" +
             "{\n\n" +
             "    private final " + DICTIONARY_ACCEPTOR + " acceptor;\n\n");

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/ConstantGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/ConstantGenerator.java
@@ -18,6 +18,7 @@ package uk.co.real_logic.artio.dictionary.generation;
 import org.agrona.collections.IntHashSet;
 import org.agrona.generation.OutputManager;
 import uk.co.real_logic.artio.dictionary.CharArraySet;
+import uk.co.real_logic.artio.dictionary.Generated;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.Field;
 
@@ -25,6 +26,7 @@ import java.util.Collection;
 
 import static java.util.stream.Collectors.joining;
 import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.addField;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.GENERATED_ANNOTATION;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
 
@@ -73,6 +75,8 @@ class ConstantGenerator
             out.append(fileHeader(builderPackage));
             out.append(importFor(IntHashSet.class));
             out.append(importFor(CharArraySet.class));
+            out.append(importFor(Generated.class));
+            out.append("\n" + GENERATED_ANNOTATION);
             out.append(body);
             out.append(generateVersion());
             out.append(generateMessageTypes());

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -23,6 +23,7 @@ import uk.co.real_logic.artio.builder.CommonDecoderImpl;
 import uk.co.real_logic.artio.builder.Decoder;
 import uk.co.real_logic.artio.builder.Encoder;
 import uk.co.real_logic.artio.decoder.SessionHeaderDecoder;
+import uk.co.real_logic.artio.dictionary.Generated;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.*;
 import uk.co.real_logic.artio.dictionary.ir.Field.Type;
@@ -74,8 +75,10 @@ class DecoderGenerator extends Generator
 
     // Has to be generated everytime since HeaderDecoder and TrailerDecoder are generated.
     private static final String MESSAGE_DECODER =
-        "import uk.co.real_logic.artio.builder.Decoder;\n" +
+        importFor(Decoder.class) +
+        importFor(Generated.class) +
         "\n" +
+        GENERATED_ANNOTATION +
         "public interface MessageDecoder extends Decoder\n" +
         "{\n" +
         "    HeaderDecoder header();\n" +
@@ -176,6 +179,7 @@ class DecoderGenerator extends Generator
                     out.append(importFor(SessionHeaderDecoder.class));
                 }
                 out.append(importFor(AsciiNumberFormatException.class));
+                out.append(importFor(Generated.class));
 
                 generateImports(out, type);
 
@@ -298,7 +302,9 @@ class DecoderGenerator extends Generator
             extendsClause = "CommonDecoderImpl";
         }
         return String.format(
-            "\n\npublic %3$s%4$sclass %1$s extends %5$s%2$s\n" +
+            "\n" +
+            GENERATED_ANNOTATION +
+            "public %3$s%4$sclass %1$s extends %5$s%2$s\n" +
             "{\n",
             className,
             interfaceList,
@@ -790,9 +796,12 @@ class DecoderGenerator extends Generator
                 out.append(importFor(AsciiNumberFormatException.class));
                 generateImports(out, AggregateType.COMPONENT);
                 importEncoders(component, out);
+                out.append(importFor(Generated.class));
 
                 out.append(String.format(
-                    "\npublic interface %1$s %2$s\n" +
+                    "\n" +
+                    GENERATED_ANNOTATION +
+                    "public interface %1$s %2$s\n" +
                     "{\n\n",
                     className,
                     interfaceExtension));
@@ -1146,6 +1155,7 @@ class DecoderGenerator extends Generator
         if (sharedParent)
         {
             out.append(String.format(
+                "    " + GENERATED_ANNOTATION +
                 "    public abstract class %1$s<T extends %2$s> implements Iterable<T>, java.util.Iterator<T>\n" +
                 "    {\n" +
                 "        private final %3$s parent;\n" +
@@ -1223,6 +1233,7 @@ class DecoderGenerator extends Generator
     {
         final String parentDecoderName = decoderClassName(currentAggregate());
         out.append(String.format(
+            "    " + GENERATED_ANNOTATION +
             "    public class %1$s implements Iterable<%2$s>, java.util.Iterator<%2$s>\n" +
             "    {\n" +
             "        private final %3$s parent;\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -22,6 +22,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.generation.OutputManager;
 import uk.co.real_logic.artio.builder.Encoder;
 import uk.co.real_logic.artio.builder.SessionHeaderEncoder;
+import uk.co.real_logic.artio.dictionary.Generated;
 import uk.co.real_logic.artio.dictionary.ir.*;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.Entry.Element;
@@ -39,6 +40,7 @@ import static java.util.stream.Collectors.joining;
 import static uk.co.real_logic.artio.dictionary.generation.AggregateType.GROUP;
 import static uk.co.real_logic.artio.dictionary.generation.AggregateType.HEADER;
 import static uk.co.real_logic.artio.dictionary.generation.EnumGenerator.enumName;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.GENERATED_ANNOTATION;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
 import static uk.co.real_logic.artio.dictionary.generation.OptionalSessionFields.ENCODER_OPTIONAL_SESSION_FIELDS;
@@ -196,6 +198,7 @@ class EncoderGenerator extends Generator
                 {
                     out.append(importFor("uk.co.real_logic.artio.builder.Abstract" + className));
                 }
+                out.append(importFor(Generated.class));
 
                 generateImports(
                     "Encoder",
@@ -339,7 +342,9 @@ class EncoderGenerator extends Generator
             extendsClause = "";
         }
         return String.format(
-            "\n\npublic %3$s%4$sclass %1$s%5$s%2$s\n" +
+            "\n" +
+            GENERATED_ANNOTATION +
+            "public %3$s%4$sclass %1$s%5$s%2$s\n" +
             "{\n",
             className,
             interfaceList,

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EnumGenerator.java
@@ -23,6 +23,7 @@ import uk.co.real_logic.artio.builder.IntRepresentable;
 import uk.co.real_logic.artio.builder.StringRepresentable;
 import uk.co.real_logic.artio.dictionary.CharArrayMap;
 import uk.co.real_logic.artio.dictionary.CharArrayWrapper;
+import uk.co.real_logic.artio.dictionary.Generated;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.Field;
 import uk.co.real_logic.artio.dictionary.ir.Field.Type;
@@ -143,6 +144,8 @@ final class EnumGenerator
                 out.append(importFor(Map.class));
                 out.append(importFor(HashMap.class));
                 out.append(interfaceToImport);
+                out.append(importFor(Generated.class));
+                out.append("\n" + GENERATED_ANNOTATION);
                 out.append(generateEnumDeclaration(enumName, interfaceToImplement));
 
                 out.append(generateEnumValues(valuesWithSentinels, type));

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/FixDictionaryGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/FixDictionaryGenerator.java
@@ -35,9 +35,11 @@ import uk.co.real_logic.artio.decoder.AbstractTestRequestDecoder;
 import uk.co.real_logic.artio.decoder.AbstractUserRequestDecoder;
 import uk.co.real_logic.artio.decoder.SessionHeaderDecoder;
 import uk.co.real_logic.artio.dictionary.FixDictionary;
+import uk.co.real_logic.artio.dictionary.Generated;
 import uk.co.real_logic.artio.dictionary.ir.Aggregate;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.GENERATED_ANNOTATION;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
 
@@ -149,7 +151,9 @@ class FixDictionaryGenerator
 
                 out.append(importFor(SessionHeaderDecoder.class));
                 out.append(importFor(decoderPackage + ".HeaderDecoder"));
+                out.append(importFor(Generated.class));
 
+                out.append("\n" + GENERATED_ANNOTATION);
                 out.append(sb.toString());
             }
             catch (final IOException e)

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -29,6 +29,7 @@ public final class GenerationUtil
     public static final int MESSAGE_TYPE_BITSHIFT = 8;
 
     public static final String INDENT = "    ";
+    public static final String GENERATED_ANNOTATION = "@Generated(\"uk.co.real_logic.artio\")\n";
 
     private GenerationUtil()
     {

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/PrinterGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/PrinterGenerator.java
@@ -17,6 +17,7 @@ package uk.co.real_logic.artio.dictionary.generation;
 
 import org.agrona.generation.OutputManager;
 import uk.co.real_logic.artio.builder.Printer;
+import uk.co.real_logic.artio.dictionary.Generated;
 import uk.co.real_logic.artio.dictionary.ir.Aggregate;
 import uk.co.real_logic.artio.dictionary.ir.Dictionary;
 import uk.co.real_logic.artio.dictionary.ir.Message;
@@ -28,6 +29,7 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 import static uk.co.real_logic.artio.dictionary.generation.DecoderGenerator.decoderClassName;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.GENERATED_ANNOTATION;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
 
@@ -37,7 +39,10 @@ class PrinterGenerator
     private static final String CLASS_DECLARATION =
         importFor(Printer.class) +
         importFor(AsciiBuffer.class) +
-        "\npublic class PrinterImpl implements Printer\n" +
+        importFor(Generated.class) +
+        "\n" +
+        GENERATED_ANNOTATION +
+        "public class PrinterImpl implements Printer\n" +
         "{\n\n";
 
     private final Dictionary dictionary;


### PR DESCRIPTION
This PR adds a `@Generated` annotation to generated source types. This is useful for various tools (e.g. code coverage analysis) which can use the annotation to omit the generated code from reports.

The annotation `uk.co.real_logic.artio.dictionary.Generated` is being added, rather than using `javax.annotation.Generated` because:
1. The Java annotation was not available until Java 9 (and some still use java 8)
2. The Java annotation has only SOURCE retention, which is not available to code analyzers that work on class files.
