### PR TITLE
Multiple connections for single session after connection timeouts

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
@@ -931,7 +931,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     /**
      * Override the acceptor FIX Dictionary for a given beginString. The beginString to use is extracted from the
      * Provided FIX Dictionary. If you wish to use multiple FIX dictionaries based upon the logon message and they
-     * both have the same beginString field then you should should implement a custom {@link AuthenticationStrategy}
+     * both have the same beginString field then you should implement a custom {@link AuthenticationStrategy}
      * and use the {@link AuthenticationProxy#accept(Class)} method in order to specify the dictionary.
      *
      * @param fixDictionaryClass the FIX Dictionary to use

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/FixEngine.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/FixEngine.java
@@ -37,7 +37,7 @@ import static uk.co.real_logic.artio.dictionary.generation.Exceptions.suppressin
 /**
  * A FIX Engine is a process in the gateway that accepts or initiates FIX connections and
  * hands them off to different FixLibrary instances. The engine can replicate and/or durably
- * store streams2 of FIX messages for replay, archival, administrative or analytics purposes.
+ * store streams of FIX messages for replay, archival, administrative or analytics purposes.
  * <p>
  * Each engine can have one or more associated libraries that manage sessions and perform business
  * logic. These may run in the same JVM process or a different JVM process.
@@ -181,15 +181,15 @@ public final class FixEngine extends GatewayProcess
     }
 
     /**
-     * This method resets the state of the of the FixEngine that also performs usual end of day processing
-     * operations. It must can only be called when the FixEngine object has been closed. These are:
+     * This method resets the state of the FixEngine that also performs usual end of day processing
+     * operations. These are:
      *
      * <ol>
-     *     <li>Reset and optionally back up all Artio state (including session ids and sequence numbers</li>
+     *     <li>Reset and optionally back up all Artio state (including session ids and sequence numbers).</li>
      *     <li>Truncate any recordings associated with this engine instance.</li>
      * </ol>
      *
-     * Blocks until the operation is complete.
+     * It must only be called when the FixEngine object has been closed. Blocks until the operation is complete.
      *
      * @param backupLocation the directory that you wish to copy Artio's session state over to for later inspection.
      *                       If this is null no backup of data will be performed. If the directory exists it will be

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/DefaultTcpChannelSupplier.java
@@ -1,5 +1,6 @@
 package uk.co.real_logic.artio.engine.framer;
 
+import org.agrona.CloseHelper;
 import org.agrona.LangUtil;
 import uk.co.real_logic.artio.dictionary.generation.Exceptions;
 import uk.co.real_logic.artio.engine.EngineConfiguration;
@@ -189,6 +190,7 @@ public class DefaultTcpChannelSupplier extends TcpChannelSupplier
             final SocketChannel channel = iterator.next();
             if (channel.getRemoteAddress().equals(address))
             {
+                CloseHelper.quietClose(channel);
                 iterator.remove();
                 break;
             }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixGatewaySessions.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixGatewaySessions.java
@@ -320,7 +320,7 @@ public class FixGatewaySessions extends GatewaySessions
             {
                 onError(new IllegalStateException(
                     "Persistence Strategy specified INDEXED but " +
-                    "EngineConfiguration has disabled required logging of messsages"));
+                    "EngineConfiguration has disabled required logging of messages"));
 
                 reject(DisconnectReason.INVALID_CONFIGURATION_NOT_LOGGING_MESSAGES);
                 return;

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ConnectAfterTimeoutSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ConnectAfterTimeoutSystemTest.java
@@ -16,6 +16,7 @@
 package uk.co.real_logic.artio.system_tests;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.co.real_logic.artio.Reply;
 import uk.co.real_logic.artio.engine.EngineConfiguration;
@@ -23,6 +24,9 @@ import uk.co.real_logic.artio.engine.FixEngine;
 import uk.co.real_logic.artio.library.LibraryConfiguration;
 import uk.co.real_logic.artio.library.SessionConfiguration;
 import uk.co.real_logic.artio.session.Session;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 
 import static org.junit.Assert.assertEquals;
 import static uk.co.real_logic.artio.TestFixtures.launchMediaDriver;
@@ -76,6 +80,49 @@ public class ConnectAfterTimeoutSystemTest extends AbstractGatewayToGatewaySyste
         connectSessions();
         messagesCanBeExchanged();
         assertInitiatingSequenceIndexIs(0);
+    }
+
+    @Test(timeout = TEST_TIMEOUT_IN_MS + 20_000)
+    @Ignore("manual test")
+    public void testConnectingAfterConnectionTimeouts()
+    {
+        // Suggest running with -Dfix.core.debug=FIX_CONNECTION
+
+        // Launch the acceptor
+        launchAcceptingEngine();
+        final LibraryConfiguration acceptingLibraryConfig = acceptingLibraryConfig(acceptingHandler, nanoClock);
+        acceptingLibrary = testSystem.connect(acceptingLibraryConfig);
+
+        // Make connections time out
+        System.out.printf("Run: sudo iptables -I INPUT -i lo -p tcp --dport %d -j DROP%n", port);
+        sleep();
+
+        // First reply times out
+        final Reply<Session> firstConnectReply = completeInitiateSession();
+        assertEquals(Reply.State.TIMED_OUT, firstConnectReply.state());
+
+        // First reply also times out
+        final Reply<Session> secondConnectReply = completeInitiateSession();
+        assertEquals(Reply.State.TIMED_OUT, secondConnectReply.state());
+
+        // Make connections work again
+        System.out.printf("Run: sudo iptables -D INPUT -i lo -p tcp --dport %d -j DROP%n", port);
+        sleep();
+
+        // Now it should connect
+        connectSessions();
+        messagesCanBeExchanged();
+        assertInitiatingSequenceIndexIs(0);
+    }
+
+    private void sleep()
+    {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() - deadline < 0)
+        {
+            testSystem.poll();
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(100));
+        }
     }
 
     private Reply<Session> completeInitiateSession()


### PR DESCRIPTION
Let's say you have an initiator and your counter-party is dropping SYN packets which causes connection timeouts.
If you try to initiate a few times, the `Reply<Session>`s will all time out. Then, when the counter-party starts
properly accepting connections, Artio might establish multiple connections for that session:

```
[FIX_CONNECTION]Connecting to localhost:10000 from library 2142515358
[FIX_CONNECTION]Initiating session 1 with correlationId 6816641249315627913 from library 2142515358
[FIX_CONNECTION]Initiating session 1 with correlationId 6816641249315627912 from library 2142515358
[FIX_CONNECTION]Initiating session 1 with correlationId 6816641249315627914 from library 2142515358
```

The problem is that the reply timeout comes from the `SessionConfiguration.timeoutInMs()`
and not from the underlying socket, which is still open and the OS is trying to reconnect
(described here: https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/#synsent).

I think the problem is simply that `DefaultTcpChannelSupplier` doesn't close the channel in `stopConnecting`.

You'll probably want to delete my test, because it's manual and hence ignored, but it does show the issue.

Plus some tidy ups.