### PR TITLE
Fixed FIX_MESSAGE_TCP write debug logging

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPoint.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPoint.java
@@ -294,11 +294,12 @@ class FixSenderEndPoint extends SenderEndPoint
         final int startPosition = buffer.position();
 
         ByteBufferUtil.limit(buffer, offset + messageSize);
-        ByteBufferUtil.position(buffer, reattemptBytesWritten + offset);
+        final int writePosition = reattemptBytesWritten + offset;
+        ByteBufferUtil.position(buffer, writePosition);
 
         final int written = channel.write(buffer);
         ByteBufferUtil.position(buffer, offset);
-        DebugLogger.logBytes(FIX_MESSAGE_TCP, "Written  ", buffer, startPosition, written);
+        DebugLogger.logBytes(FIX_MESSAGE_TCP, "Written  ", buffer, writePosition, written);
 
         buffer.limit(startLimit).position(startPosition);
 

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPoint.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPoint.java
@@ -307,7 +307,7 @@ class FixSenderEndPoint extends SenderEndPoint
     }
 
     private void enqueueMessage(
-        final DirectBuffer srcBuffer, final int srcOffst, final int bodyLength,
+        final DirectBuffer srcBuffer, final int srcOffset, final int bodyLength,
         final int metaDataOffset, final int metaDataLength, final int sequenceNumber, final boolean replay)
     {
         final int totalLength = ENQ_MESSAGE_BLOCK_LEN + bodyLength + metaDataLength;
@@ -325,7 +325,7 @@ class FixSenderEndPoint extends SenderEndPoint
         buffer.putInt(reattemptOffset, bodyLength);
         reattemptOffset += SIZE_OF_INT;
 
-        buffer.putBytes(reattemptOffset, srcBuffer, srcOffst, bodyLength);
+        buffer.putBytes(reattemptOffset, srcBuffer, srcOffset, bodyLength);
         reattemptOffset += bodyLength;
 
         buffer.putInt(reattemptOffset, metaDataLength);

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ConnectAfterTimeoutSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ConnectAfterTimeoutSystemTest.java
@@ -61,7 +61,7 @@ public class ConnectAfterTimeoutSystemTest extends AbstractGatewayToGatewaySyste
         final Reply<Session> firstConnectReply = completeInitiateSession();
         assertEquals(Reply.State.TIMED_OUT, firstConnectReply.state());
 
-        // First reply also times out
+        // Second reply also times out
         final Reply<Session> secondConnectReply = completeInitiateSession();
         assertEquals(Reply.State.TIMED_OUT, secondConnectReply.state());
 


### PR DESCRIPTION
I noticed that the debug log of TCP writes contains nonsense, either all zeros or lots of zeros and negative numbers, e.g.:

```
[FIX_MESSAGE_TCP]Written  {60, 0, 0, 0, 0, -64, 1, 0, 0, 0, 0, 0, -83, -68, 11, -84, 2, 0, 0, 0, 4, -8, 87, -1, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 16, 0, -102, 2, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 59, 90, -58, 58, -73, 104, 9, 23, 0, 0, 0, 0, -37, 0, 0, 0, 0, -64, 1, 0, 64, 0, 0, 0, -83, -68, 11, -84, 2, 0, 0, 0, 4, -8, 87, -1, 0, 0, 0, 0, 0, 0, 0, 0, 57, 0, 1, 0, -102, 2, 24, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0}
```

Is there any reason that this logs bytes when the read side logs the ASCII message instead?