### PR TITLE
Fix FIXP protocol issue where CoD event fires when session logout occurs for CANCEL_ON_DISCONNECT_ONLY

### DIFF
--- a/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
+++ b/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
@@ -693,7 +693,10 @@ class InternalBinaryEntryPointConnection
 
     protected Action unbindState(final DisconnectReason reason)
     {
-        cancelOnDisconnect.checkCancelOnDisconnectDisconnect();
+        if (!DisconnectReason.LOGOUT.equals(reason))
+        {
+            cancelOnDisconnect.checkCancelOnDisconnectDisconnect();
+        }
 
         super.unbindState(reason);
         return null;

--- a/artio-binary-entrypoint-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/CancelOnDisconnectBinaryEntrypointSystemTest.java
+++ b/artio-binary-entrypoint-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/CancelOnDisconnectBinaryEntrypointSystemTest.java
@@ -63,6 +63,16 @@ public class CancelOnDisconnectBinaryEntrypointSystemTest extends AbstractBinary
     }
 
     @Test(timeout = TEST_TIMEOUT_IN_MS)
+    public void shouldNotTriggerCancelOnDisconnectTimeoutWhenClientDisconnectForLogoutOnly() throws IOException
+    {
+        setup(CANCEL_ON_TERMINATE_ONLY, COD_TEST_TIMEOUT_IN_MS);
+
+        disconnect();
+
+        assertHandlerNotInvoked(LONG_COD_TEST_TIMEOUT_IN_MS);
+    }
+
+    @Test(timeout = TEST_TIMEOUT_IN_MS)
     public void shouldTriggerCancelOnDisconnectTimeoutForDisconnect() throws IOException
     {
         setup(CANCEL_ON_DISCONNECT_ONLY, COD_TEST_TIMEOUT_IN_MS);
@@ -71,6 +81,16 @@ public class CancelOnDisconnectBinaryEntrypointSystemTest extends AbstractBinary
         disconnect();
 
         assertTriggersCancelOnDisconnect(logoutTimeInNs);
+    }
+
+    @Test(timeout = TEST_TIMEOUT_IN_MS)
+    public void shouldNotTriggerCancelOnDisconnectTimeoutWhenClientTerminateForDisconnectOnly() throws IOException
+    {
+        setup(CANCEL_ON_DISCONNECT_ONLY, COD_TEST_TIMEOUT_IN_MS);
+
+        clientTerminatesConnection(client);
+
+        assertHandlerNotInvoked(LONG_COD_TEST_TIMEOUT_IN_MS);
     }
 
     @Test(timeout = TEST_TIMEOUT_IN_MS)

--- a/artio-core/src/main/java/uk/co/real_logic/artio/library/InternalFixPConnection.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/library/InternalFixPConnection.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import static io.aeron.logbuffer.ControlledFragmentHandler.Action.ABORT;
 import static io.aeron.logbuffer.ControlledFragmentHandler.Action.CONTINUE;
 import static uk.co.real_logic.artio.fixp.FixPConnection.State.*;
-import static uk.co.real_logic.artio.messages.DisconnectReason.APPLICATION_DISCONNECT;
 import static uk.co.real_logic.artio.messages.DisconnectReason.LOGOUT;
 
 public abstract class InternalFixPConnection implements FixPConnection
@@ -369,7 +368,7 @@ public abstract class InternalFixPConnection implements FixPConnection
             return ABORT;
         }
 
-        final Action action = unbindState(APPLICATION_DISCONNECT);
+        final Action action = unbindState(reason);
         if (action != ABORT)
         {
             owner.remove(this);
@@ -381,7 +380,7 @@ public abstract class InternalFixPConnection implements FixPConnection
     protected Action unbindState(final DisconnectReason reason)
     {
         final State oldState = this.state;
-        state(State.UNBOUND);
+        state(UNBOUND);
         final Action action = handler.onDisconnect(this, reason);
         if (action == ABORT)
         {


### PR DESCRIPTION
### What type of PR is this?
FIXP protocol bugfix

### What this PR does / why we need it:
This PR fix a FIXP protocol issue, where Artio triggers the Engine's `FixPCancelOnDisconnectTimeoutHandler#onCancelOnDisconnectTimeout` when the client establishes a connection configured as `CANCEL_ON_DISCONNECT_ONLY` and sends the Terminate message (Logout).

### Issue:
No issue related to this topic

### Have tests been added to ensure this issue is fixed?
Yes, please check the test `shouldNotTriggerCancelOnDisconnectTimeoutWhenClientTerminateForDisconnectOnly`