### PR TITLE
Changing BusinessRejectReason in BusinessMessageReject for BinaryEntryPoint protocol

### DIFF
--- a/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
+++ b/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
@@ -58,7 +58,7 @@ class InternalBinaryEntryPointConnection
     extends InternalFixPConnection implements BinaryEntryPointConnection
 {
     private static final UnsafeBuffer EMPTY_BUFFER = new UnsafeBuffer(new byte[0]);
-    private static final int THROTTLE_REASON = 99;
+    private static final int THROTTLE_REASON = 33000;
 
     private final BinaryEntryPointProxy proxy;
     private final long maxFixPKeepaliveTimeoutInMs;

--- a/artio-binary-entrypoint-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/BinaryEntryPointClient.java
+++ b/artio-binary-entrypoint-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/BinaryEntryPointClient.java
@@ -676,6 +676,6 @@ public final class BinaryEntryPointClient implements AutoCloseable
         assertEquals(refSeqNum, businessReject.refSeqNum());
         assertEquals(MessageType.NewOrderSingle, businessReject.refMsgType());
         assertEquals(rejectRefID, businessReject.businessRejectRefID());
-        assertEquals(99, businessReject.businessRejectReason());
+        assertEquals(33000, businessReject.businessRejectReason());
     }
 }


### PR DESCRIPTION
Resolves #477.