### PR TITLE
Added notApplied method to the binary connection interface.

### DIFF
--- a/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/BinaryEntryPointConnection.java
+++ b/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/BinaryEntryPointConnection.java
@@ -51,6 +51,15 @@ public interface BinaryEntryPointConnection extends FixPConnection
      */
     void terminate(TerminationCode terminationCode);
 
+    /**
+     * Send a notApplied message to the client.
+     *
+     * @param fromSeqNo the first applied sequence number.
+     * @param count How many messages have not been applied.
+     * @return position.
+     */
+    long notApplied(long fromSeqNo, long count);
+
     // -----------------------------------------------
     // Accessors
     // -----------------------------------------------

--- a/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/BinaryEntryPointConnection.java
+++ b/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/BinaryEntryPointConnection.java
@@ -58,7 +58,7 @@ public interface BinaryEntryPointConnection extends FixPConnection
      * @param count How many messages have not been applied.
      * @return position.
      */
-    long notApplied(long fromSeqNo, long count);
+    long trySendNotApplied(long fromSeqNo, long count);
 
     // -----------------------------------------------
     // Accessors

--- a/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
+++ b/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
@@ -232,6 +232,11 @@ class InternalBinaryEntryPointConnection
         internalTerminateInclResend(terminationCode);
     }
 
+    public long notApplied(final long fromSeqNo, final long count)
+    {
+        return this.proxy.sendNotApplied(fromSeqNo, count, requestTimestampInNs());
+    }
+
     // Handles resends
     private void internalTerminateInclResend(final TerminationCode terminationCode)
     {

--- a/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
+++ b/artio-binary-entrypoint-impl/src/main/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnection.java
@@ -232,7 +232,7 @@ class InternalBinaryEntryPointConnection
         internalTerminateInclResend(terminationCode);
     }
 
-    public long notApplied(final long fromSeqNo, final long count)
+    public long trySendNotApplied(final long fromSeqNo, final long count)
     {
         return this.proxy.sendNotApplied(fromSeqNo, count, requestTimestampInNs());
     }

--- a/artio-binary-entrypoint-impl/src/test/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnectionTest.java
+++ b/artio-binary-entrypoint-impl/src/test/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnectionTest.java
@@ -125,7 +125,7 @@ public class InternalBinaryEntryPointConnectionTest
             mock(FixPMessageDissector.class),
             protocol);
 
-        connection.notApplied(0, 5);
+        connection.trySendNotApplied(0, 5);
         verify(proxy, times(1)).sendNotApplied(eq(0L), eq(5L), anyLong());
     }
 

--- a/artio-binary-entrypoint-impl/src/test/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnectionTest.java
+++ b/artio-binary-entrypoint-impl/src/test/java/uk/co/real_logic/artio/binary_entrypoint/InternalBinaryEntryPointConnectionTest.java
@@ -100,6 +100,35 @@ public class InternalBinaryEntryPointConnectionTest
         successfulRetransmit(proxy, requestTimestampInNs, 4L);
     }
 
+    @Test
+    public void shouldSendNotAppliedMessageUsingBinaryProxy()
+    {
+        final BinaryEntryPointProxy proxy = mock(BinaryEntryPointProxy.class);
+        final EpochNanoClock clock = new OffsetEpochNanoClock();
+        final BinaryEntryPointContext context = new BinaryEntryPointContext(SESSION_ID, SESSION_VER_ID,
+            clock.nanoTime(), ENTERING_FIRM, false, "", "", "", "");
+        final GatewayPublication inboundPublication = mock(GatewayPublication.class);
+        final BinaryEntryPointProtocol protocol = new BinaryEntryPointProtocol();
+
+        final InternalBinaryEntryPointConnection connection = new InternalBinaryEntryPointConnection(
+            CONNECTION_ID,
+            mock(GatewayPublication.class),
+            inboundPublication,
+            LIBRARY_ID,
+            mock(FixPSessionOwner.class),
+            UNK_SESSION,
+            UNK_SESSION,
+            0,
+            new CommonConfiguration(),
+            context,
+            proxy,
+            mock(FixPMessageDissector.class),
+            protocol);
+
+        connection.notApplied(0, 5);
+        verify(proxy, times(1)).sendNotApplied(eq(0L), eq(5L), anyLong());
+    }
+
     private void successfulRetransmit(
         final BinaryEntryPointProxy proxy, final long requestTimestampInNs, final long fromSeqNo)
     {


### PR DESCRIPTION
The purpose of this patch is to add the possibility for the user to send a notApplied message to the client using the already created proxy notApplied method. It was added an notApplied method to the binary connection interface. This method was implemented in the internalBinaryConnection class and calls the proxy notApplied method. This way the user can manually send a notApplied message to the client when it needs it.