### PR TITLE
Customisable cancel on disconnect behaviour

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
@@ -42,6 +42,7 @@ import uk.co.real_logic.artio.fields.EpochFractionFormat;
 import uk.co.real_logic.artio.fixp.FixPCancelOnDisconnectTimeoutHandler;
 import uk.co.real_logic.artio.fixp.FixPProtocolFactory;
 import uk.co.real_logic.artio.library.SessionConfiguration;
+import uk.co.real_logic.artio.messages.CancelOnDisconnectOption;
 import uk.co.real_logic.artio.messages.FixPProtocolType;
 import uk.co.real_logic.artio.messages.InitialAcceptedSessionOwner;
 import uk.co.real_logic.artio.session.CancelOnDisconnectTimeoutHandler;
@@ -68,6 +69,7 @@ import static uk.co.real_logic.artio.dictionary.generation.CodecUtil.MISSING_INT
 import static uk.co.real_logic.artio.engine.logger.ReplayIndexDescriptor.HEADER_FILE_SIZE;
 import static uk.co.real_logic.artio.engine.logger.ReplayIndexDescriptor.MAX_FILE_SEGMENT_CAPACITY;
 import static uk.co.real_logic.artio.library.SessionConfiguration.*;
+import static uk.co.real_logic.artio.messages.CancelOnDisconnectOption.DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT;
 import static uk.co.real_logic.artio.messages.FixPProtocolType.ILINK_3;
 import static uk.co.real_logic.artio.validation.SessionPersistenceStrategy.alwaysTransient;
 
@@ -232,6 +234,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     public static final int DEFAULT_REPRODUCTION_REPLAY_STREAM = 7;
 
     public static final int DEFAULT_INITIAL_SEQUENCE_INDEX = 0;
+    public static final int DEFAULT_CANCEL_ON_DISCONNECT_TIMEOUT_WINDOW_IN_MS = 0;
 
     private String host = null;
     private int port;
@@ -319,6 +322,8 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     private int throttleWindowInMs = NO_THROTTLE_WINDOW;
     private int throttleLimitOfMessages = NO_THROTTLE_WINDOW;
     private long timeIndexReplayFlushIntervalInNs = DEFAULT_TIME_INDEX_FLUSH_INTERVAL_IN_NS;
+    private CancelOnDisconnectOption cancelOnDisconnectOption = DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT;
+    private int cancelOnDisconnectTimeoutWindowInMs = DEFAULT_CANCEL_ON_DISCONNECT_TIMEOUT_WINDOW_IN_MS;
 
     private EngineReproductionConfiguration reproductionConfiguration;
     private ReproductionMessageHandler reproductionMessageHandler = (connectionId, bytes) ->
@@ -784,7 +789,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
      * Sets the {@link SessionConfiguration#closedResendInterval()} property for accepted Sessions.
      *
      * @param acceptedSessionClosedResendInterval the {@link SessionConfiguration#closedResendInterval()} property for
-     *                                           accepted Sessions.
+     *                                            accepted Sessions.
      * @return this
      */
     public EngineConfiguration acceptedSessionClosedResendInterval(final boolean acceptedSessionClosedResendInterval)
@@ -797,7 +802,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
      * Sets the {@link SessionConfiguration#resendRequestChunkSize()} property for accepted Sessions.
      *
      * @param acceptedSessionResendRequestChunkSize the {@link SessionConfiguration#resendRequestChunkSize()} property
-     *                                             for accepted Sessions.
+     *                                              for accepted Sessions.
      * @return this
      */
     public EngineConfiguration acceptedSessionResendRequestChunkSize(final int acceptedSessionResendRequestChunkSize)
@@ -1268,6 +1273,35 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     public EngineConfiguration reproductionReplayStream(final int reproductionReplayStream)
     {
         this.reproductionReplayStream = reproductionReplayStream;
+        return this;
+    }
+
+    /**
+     * Sets the default option in the case that no cancel on disconnect option is specified on the logon message.
+     * The default value for this field is {@link CancelOnDisconnectOption#DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT}
+     *
+     * @param cancelOnDisconnectOption the cancel on disconnect option to use if none is provided by the initiator.
+     * @return this
+     */
+    public EngineConfiguration cancelOnDisconnectOption(final CancelOnDisconnectOption cancelOnDisconnectOption)
+    {
+        this.cancelOnDisconnectOption = cancelOnDisconnectOption;
+        return this;
+    }
+
+    /**
+     * Sets the default cancel on disconnection timeout window in the case that none is specified on the logon message.
+     * This is only used when the resolved cancel on disconnect option is not
+     * {@link CancelOnDisconnectOption#DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT}. The default value for this field is
+     * {@link #DEFAULT_CANCEL_ON_DISCONNECT_TIMEOUT_WINDOW_IN_MS}
+     *
+     * @param cancelOnDisconnectTimeoutWindowInMs the cancel on disconnect timeout window to use if none is provided by
+     *                                            the initiator.
+     * @return this
+     */
+    public EngineConfiguration cancelOnDisconnectTimeoutWindowInMs(final int cancelOnDisconnectTimeoutWindowInMs)
+    {
+        this.cancelOnDisconnectTimeoutWindowInMs = cancelOnDisconnectTimeoutWindowInMs;
         return this;
     }
 
@@ -1991,6 +2025,16 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     public long timeIndexReplayFlushIntervalInNs()
     {
         return timeIndexReplayFlushIntervalInNs;
+    }
+
+    public CancelOnDisconnectOption cancelOnDisconnectOption()
+    {
+        return cancelOnDisconnectOption;
+    }
+
+    public int cancelOnDisconnectTimeoutWindowInMs()
+    {
+        return cancelOnDisconnectTimeoutWindowInMs;
     }
 
     public boolean indexChecksumEnabled()

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixGatewaySession.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixGatewaySession.java
@@ -34,7 +34,6 @@ import static uk.co.real_logic.artio.LogTag.FIX_MESSAGE;
 import static uk.co.real_logic.artio.LogTag.GATEWAY_MESSAGE;
 import static uk.co.real_logic.artio.engine.FixEngine.ENGINE_LIBRARY_ID;
 import static uk.co.real_logic.artio.engine.logger.SequenceNumberIndexWriter.NO_REQUIRED_POSITION;
-import static uk.co.real_logic.artio.messages.CancelOnDisconnectOption.DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT;
 import static uk.co.real_logic.artio.messages.DisconnectReason.ENGINE_SHUTDOWN;
 
 class FixGatewaySession extends GatewaySession implements ConnectedSessionInfo, FixSessionOwner
@@ -407,7 +406,7 @@ class FixGatewaySession extends GatewaySession implements ConnectedSessionInfo, 
 
     public CancelOnDisconnectOption cancelOnDisconnectOption()
     {
-        return cancelOnDisconnectOption == null ? DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT : cancelOnDisconnectOption;
+        return cancelOnDisconnectOption == null ? configuration.cancelOnDisconnectOption() : cancelOnDisconnectOption;
     }
 
     public long cancelOnDisconnectTimeoutWindowInNs()

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/CancelOnDisconnectTimeoutHandler.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/CancelOnDisconnectTimeoutHandler.java
@@ -20,12 +20,16 @@ package uk.co.real_logic.artio.session;
  *
  * In order for this handler to be invoked:
  * <ul>
- *  <li>Your FIX session dictionary must contain a cancel on disconnect type field associated with a logon
- *  message</li>
- *  <li>A session must specify a CancelOnDisconnectType field in it's logon message that requires
- * a cancel on either logout, disconnect or both</li>
- *  <li>the CODTimeoutWindow also specified in the logon message must have expired without a reconnect</li>
+ *  <li>The FIX session must have a cancel on disconnect type configured that requires a cancel on either logout,
+ *  disconnect or both. This may be be provided either via the logon message or the acceptor engine configuration</li>
+ *  <li>The CODTimeoutWindow also specified in the logon message or acceptor engine defaults must have expired without
+ *  a reconnect</li>
  * </ul>.
+ *
+ * To provide these values on the logon message your FIX session dictionary must contain a CancelOnDisconnectType
+ * field and optionally a CODTimeoutWindow field. Each of these configuration options are checked by first taking
+ * the value provided in the logon message if it is specified and otherwise taking it from the acceptor engine
+ * configuration.
  *
  * You can see <a href="https://github.com/real-logic/artio/wiki/Cancel-On-Disconnect-Notification">the wiki</a>
  * for more details around Cancel on disconnect support.

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/Session.java
@@ -458,7 +458,8 @@ public class Session
 
     /**
      * Gets the cancel on disconnect option from the Logon message. Note: a missing COD option will result in
-     * {@link CancelOnDisconnectOption#DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT}.
+     * the value set in
+     * {@link uk.co.real_logic.artio.engine.EngineConfiguration#cancelOnDisconnectOption(CancelOnDisconnectOption)}.
      *
      * @return cancel on disconnect option received in the Logon message.
      */
@@ -2633,7 +2634,7 @@ public class Session
     {
         this.cancelOnDisconnectTimeoutWindowInNs = Math.min(
             MAX_COD_TIMEOUT_IN_NS, cancelOnDisconnectTimeoutWindowInNs);
-        cancelOnDisconnect.cancelOnDisconnectTimeoutWindowInNs(cancelOnDisconnectTimeoutWindowInNs);
+        cancelOnDisconnect.cancelOnDisconnectTimeoutWindowInNs(this.cancelOnDisconnectTimeoutWindowInNs);
     }
 
     void fixDictionary(final FixDictionary fixDictionary)

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AbstractGatewayToGatewaySystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AbstractGatewayToGatewaySystemTest.java
@@ -29,6 +29,7 @@ import uk.co.real_logic.artio.*;
 import uk.co.real_logic.artio.Reply.State;
 import uk.co.real_logic.artio.builder.HeaderEncoder;
 import uk.co.real_logic.artio.builder.ResendRequestEncoder;
+import uk.co.real_logic.artio.dictionary.FixDictionary;
 import uk.co.real_logic.artio.dictionary.generation.Exceptions;
 import uk.co.real_logic.artio.engine.ConnectedSessionInfo;
 import uk.co.real_logic.artio.engine.EngineConfiguration;
@@ -280,9 +281,14 @@ public class AbstractGatewayToGatewaySystemTest
 
     void connectSessions()
     {
+        connectSessions(null);
+    }
+
+    void connectSessions(final Class<? extends FixDictionary> fixDictionary)
+    {
         connectTimeRange = new TimeRange(nanoClock);
         final Reply<Session> reply = initiate(
-            initiatingLibrary, port, INITIATOR_ID, ACCEPTOR_ID, TEST_REPLY_TIMEOUT_IN_MS);
+            initiatingLibrary, port, INITIATOR_ID, ACCEPTOR_ID, TEST_REPLY_TIMEOUT_IN_MS, true, fixDictionary);
         completeConnectInitiatingSession(reply);
         connectTimeRange.end();
     }

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AsyncAuthenticatorTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/AsyncAuthenticatorTest.java
@@ -402,7 +402,7 @@ public class AsyncAuthenticatorTest extends AbstractGatewayToGatewaySystemTest
     private Reply<Session> acquireAuthProxy()
     {
         final Reply<Session> reply = initiate(initiatingLibrary, port, INITIATOR_ID, ACCEPTOR_ID,
-            initiateTimeoutInMs, false);
+            initiateTimeoutInMs, false, null);
 
         assertEventuallyTrue("failed to receive auth proxy", () ->
         {

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/SystemTestUtil.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/SystemTestUtil.java
@@ -178,12 +178,13 @@ public final class SystemTestUtil
         final FixLibrary library, final int port, final String senderCompId, final String targetCompId,
         final long timeoutInMs)
     {
-        return initiate(library, port, senderCompId, targetCompId, timeoutInMs, true);
+        return initiate(library, port, senderCompId, targetCompId, timeoutInMs, true, null);
     }
 
     static Reply<Session> initiate(
         final FixLibrary library, final int port, final String senderCompId, final String targetCompId,
-        final long timeoutInMs, final boolean disconnectOnFirstMessageNotLogon)
+        final long timeoutInMs, final boolean disconnectOnFirstMessageNotLogon,
+        final Class<? extends FixDictionary> fixDictionary)
     {
         final SessionConfiguration config = SessionConfiguration.builder()
             .address("localhost", port)
@@ -192,6 +193,7 @@ public final class SystemTestUtil
             .targetCompId(targetCompId)
             .timeoutInMs(timeoutInMs)
             .disconnectOnFirstMessageNotLogon(disconnectOnFirstMessageNotLogon)
+            .fixDictionary(fixDictionary)
             .build();
 
         return library.initiate(config);
@@ -565,6 +567,13 @@ public final class SystemTestUtil
                 testSystem.poll();
                 return session.state() == DISCONNECTED && session.connectionId() == NO_CONNECTION_ID;
             });
+    }
+
+    public static long disconnectSession(final Session session)
+    {
+        final long position = session.requestDisconnect();
+        assertThat(position, greaterThan(0L));
+        return position;
     }
 
     public static long logoutSession(final Session session)


### PR DESCRIPTION
This changes providing a customizable cancel on disconnect option to an engine that will be applied in the case a login message does not provide one. The use case if for supporting an api that always uses cancel on disconnect and does not want to provide an option in the FIX api.