### PR TITLE
Reset buffer references in string-like fields in generated encoders

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -434,6 +434,17 @@ class DecoderGenerator extends Generator
         }
     }
 
+    protected String resetLength(final String name)
+    {
+        return String.format(
+                "    public void %1$s()\n" +
+                        "    {\n" +
+                        "        %2$sLength = 0;\n" +
+                        "    }\n\n",
+                nameOfResetMethod(name),
+                formatPropertyName(name));
+    }
+
     private String iteratorClassName(final Group group, final boolean ofParent)
     {
         final String prefix = ofParent ? "Abstract" : "";

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -249,6 +249,23 @@ class EncoderGenerator extends Generator
         }
     }
 
+    protected String resetLength(final String name)
+    {
+        return String.format(
+                "    public void %1$s()\n" +
+                        "    {\n" +
+                        "        %2$sLength = 0;\n" +
+                        "        if (%2$sInternalBuffer != null)\n" +
+                        "        {\n" +
+                        "            %2$s.wrap(%2$sInternalBuffer);\n" +
+                        "            %2$sInternalBuffer = null;\n" +
+                        "            %2$sOffset = 0;\n" +
+                        "        }\n" +
+                        "    }\n\n",
+                nameOfResetMethod(name),
+                formatPropertyName(name));
+    }
+
     private void generateAggregateClass(
         final Aggregate aggregate,
         final AggregateType type,
@@ -736,11 +753,13 @@ class EncoderGenerator extends Generator
         final String className, final String fieldName, final String name, final String javadoc)
     {
         return String.format(
-            "    %4$s final MutableDirectBuffer %1$s = new UnsafeBuffer();\n\n" +
-            "    %4$s int %1$sOffset = 0;\n\n" +
+            "    %4$s final MutableDirectBuffer %1$s = new UnsafeBuffer();\n" +
+            "    %4$s byte[] %1$sInternalBuffer;\n" +
+            "    %4$s int %1$sOffset = 0;\n" +
             "    %4$s int %1$sLength = 0;\n\n" +
             "    %5$spublic %2$s %1$s(final DirectBuffer value, final int offset, final int length)\n" +
             "    {\n" +
+            "        %1$sInternalBuffer = %1$s.byteArray();\n" +
             "        %1$s.wrap(value);\n" +
             "        %1$sOffset = offset;\n" +
             "        %1$sLength = length;\n" +
@@ -756,6 +775,7 @@ class EncoderGenerator extends Generator
             "    }\n\n" +
             "    %5$spublic %2$s %1$s(final byte[] value, final int offset, final int length)\n" +
             "    {\n" +
+            "        %1$sInternalBuffer = %1$s.byteArray();\n" +
             "        %1$s.wrap(value);\n" +
             "        %1$sOffset = offset;\n" +
             "        %1$sLength = length;\n" +
@@ -782,6 +802,7 @@ class EncoderGenerator extends Generator
             "    }\n\n" +
             "    %5$spublic MutableDirectBuffer %1$s()\n" +
             "    {\n" +
+            "        %1$sInternalBuffer = %1$s.byteArray();\n" +
             "        return %1$s;\n" +
             "    }\n\n" +
             "    %5$spublic String %1$sAsString()\n" +
@@ -816,6 +837,7 @@ class EncoderGenerator extends Generator
             "        final DirectBuffer buffer = value.buffer();\n" +
             "        if (buffer != null)\n" +
             "        {\n" +
+            "            %1$sInternalBuffer = %1$s.byteArray();\n" +
             "            %1$s.wrap(buffer);\n" +
             "            %1$sOffset = value.offset();\n" +
             "            %1$sLength = value.length();\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -428,16 +428,7 @@ public abstract class Generator
 
     protected abstract String resetRequiredFloat(String name);
 
-    protected String resetLength(final String name)
-    {
-        return String.format(
-            "    public void %1$s()\n" +
-            "    {\n" +
-            "        %2$sLength = 0;\n" +
-            "    }\n\n",
-            nameOfResetMethod(name),
-            formatPropertyName(name));
-    }
+    protected abstract String resetLength(String name);
 
     protected String resetByFlag(final String name)
     {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -160,6 +160,28 @@ public class EncoderGeneratorTest
     }
 
     @Test
+    public void shouldNotUseAsciiSequenceViewAfterReset() throws Exception
+    {
+        final Encoder encoder = newHeartbeat();
+
+        final byte[] originalValue = { 97, 98, 99, 100 };
+        final byte[] byteArray = new byte[originalValue.length];
+        System.arraycopy(originalValue, 0, byteArray, 0, originalValue.length);
+
+        final AsciiSequenceView asciiSequenceView = new AsciiSequenceView();
+        asciiSequenceView.wrap(new UnsafeBuffer(byteArray), 0, byteArray.length);
+
+        heartbeat
+                .getMethod(TEST_REQ_ID, AsciiSequenceView.class)
+                .invoke(encoder, asciiSequenceView);
+
+        reset(encoder);
+
+        setCharSequence(encoder, TEST_REQ_ID, "xxx");
+        assertArrayEquals(originalValue, byteArray);
+    }
+
+    @Test
     public void shouldWriteByteArraySettersToFields() throws Exception
     {
         final Encoder encoder = newHeartbeat();


### PR DESCRIPTION
The generated encoders contain different ways of setting string-like fields.  Some methods take buffers owned by the application, e.g. passing in an AsciiSequenceView.  Other methods take data that is copied into the internal buffer, e.g. passing in a CharSequence.

If an application uses both styles, it could first pass in an AsciiSequenceView (which would point to some kind of input buffer), then on a later code path, pass in a CharSequence.  This will result in the encoder copying the CharSequence into the input buffer, corrupting that buffer.

This change takes a reference to the buffer created in the UnsafeBuffer (owned by the encoder) whenever the application passes in an application-owned buffer, like an AsciiSequenceView.  On reset, it resets the UnsafeBuffer to point it back to the original buffer.