### PR TITLE
Prevent writing to application-supplied buffers when encoding strings

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/CodecUtil.java
@@ -106,18 +106,23 @@ public final class CodecUtil
     }
 
     // NB: only valid for ASCII bytes.
-    public static void toBytes(final CharSequence value, final MutableDirectBuffer buffer)
+    public static boolean toBytes(final CharSequence value, final MutableDirectBuffer buffer)
     {
+        boolean bufferChanged = false;
+
         final int length = value.length();
         if (buffer.capacity() < length)
         {
             buffer.wrap(new byte[length]);
+            bufferChanged = true;
         }
 
         for (int i = 0; i < length; i++)
         {
             buffer.putByte(i, (byte)value.charAt(i));
         }
+
+        return bufferChanged;
     }
 
     // NB: only valid for ASCII bytes.
@@ -127,18 +132,23 @@ public final class CodecUtil
     }
 
     // NB: only valid for ASCII bytes.
-    public static void toBytes(
+    public static boolean toBytes(
         final char[] value, final MutableDirectBuffer buffer, final int offset, final int length)
     {
+        boolean bufferChanged = false;
+
         if (buffer.capacity() < length)
         {
             buffer.wrap(new byte[length]);
+            bufferChanged = true;
         }
 
         for (int i = 0; i < length; i++)
         {
             buffer.putByte(i, (byte)value[i + offset]);
         }
+
+        return bufferChanged;
     }
 
     public static boolean equals(
@@ -237,17 +247,19 @@ public final class CodecUtil
         }
     }
 
-    public static void copyInto(
+    public static boolean copyInto(
         final MutableDirectBuffer buffer, final byte[] data, final int offset, final int length)
     {
         final byte[] dest = buffer.byteArray();
         if (dest != null && dest.length >= length)
         {
             System.arraycopy(data, offset, dest, 0, length);
+            return false;
         }
         else
         {
             buffer.wrap(Arrays.copyOfRange(data, offset, offset + length));
+            return true;
         }
     }
 

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -445,6 +445,17 @@ class DecoderGenerator extends Generator
         return formatPropertyName(iteratorClassName(group, false));
     }
 
+    protected String resetLength(final String name)
+    {
+        return String.format(
+            "    public void %1$s()\n" +
+            "    {\n" +
+            "        %2$sLength = 0;\n" +
+            "    }\n\n",
+            nameOfResetMethod(name),
+            formatPropertyName(name));
+    }
+
     protected String resetRequiredFloat(final String name)
     {
         final String lengthReset = flyweightsEnabled ? "        %1$sLength = 0;\n" : "";

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -764,7 +764,7 @@ class EncoderGenerator extends Generator
             "    %5$spublic %2$s %1$sAsCopy(final byte[] value, final int offset, final int length)\n" +
             "    {\n" +
             "        copyInto(%1$s, value, offset, length);\n" +
-            "        %1$sOffset = offset;\n" +
+            "        %1$sOffset = 0;\n" +
             "        %1$sLength = length;\n" +
             "        return this;\n" +
             "    }\n\n" +

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/Generator.java
@@ -428,16 +428,7 @@ public abstract class Generator
 
     protected abstract String resetRequiredFloat(String name);
 
-    protected String resetLength(final String name)
-    {
-        return String.format(
-            "    public void %1$s()\n" +
-            "    {\n" +
-            "        %2$sLength = 0;\n" +
-            "    }\n\n",
-            nameOfResetMethod(name),
-            formatPropertyName(name));
-    }
+    protected abstract String resetLength(String name);
 
     protected String resetByFlag(final String name)
     {

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/ExampleDictionary.java
@@ -78,6 +78,7 @@ public final class ExampleDictionary
     public static final byte[] LONG_VALUE_IN_BYTES = { 97, 98, 99, 100 };
     public static final byte[] PREFIXED_VALUE_IN_BYTES = {0, 97, 98, 99, 100, 0};
     public static final String TEST_REQ_ID = "testReqID";
+    public static final String TEST_REQ_ID_AS_COPY = "testReqIDAsCopy";
     public static final String ON_BEHALF_OF_COMP_ID = "onBehalfOfCompID";
     public static final String INT_FIELD = "intField";
     public static final String LONG_FIELD = "longField";

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CodecUtilTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/CodecUtilTest.java
@@ -15,9 +15,12 @@
  */
 package uk.co.real_logic.artio.dictionary.generation;
 
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+import static uk.co.real_logic.artio.dictionary.ExampleDictionary.LONG_VALUE_IN_BYTES;
 
 public class CodecUtilTest
 {
@@ -75,5 +78,50 @@ public class CodecUtilTest
         final int firstHash = CodecUtil.hashCode("zyxabc".toCharArray(), 0, 3);
         final int secondHash = CodecUtil.hashCode("abczyx".toCharArray(), 3, 3);
         assertEquals(firstHash, secondHash);
+    }
+
+    @Test
+    public void testToBytes()
+    {
+        final MutableDirectBuffer buffer = new UnsafeBuffer();
+
+        assertTrue(CodecUtil.toBytes("ab", buffer));
+        assertEquals("ab", buffer.getStringWithoutLengthAscii(0, 2));
+
+        assertFalse(CodecUtil.toBytes("c", buffer));
+        assertEquals("c", buffer.getStringWithoutLengthAscii(0, 1));
+
+        assertTrue(CodecUtil.toBytes("def", buffer));
+        assertEquals("def", buffer.getStringWithoutLengthAscii(0, 3));
+    }
+
+    @Test
+    public void testToBytesWithOffsetAndLength()
+    {
+        final MutableDirectBuffer buffer = new UnsafeBuffer();
+
+        assertTrue(CodecUtil.toBytes("ab".toCharArray(), buffer, 0, 2));
+        assertEquals("ab", buffer.getStringWithoutLengthAscii(0, 2));
+
+        assertFalse(CodecUtil.toBytes("abc".toCharArray(), buffer, 2, 1));
+        assertEquals("c", buffer.getStringWithoutLengthAscii(0, 1));
+
+        assertTrue(CodecUtil.toBytes("def".toCharArray(), buffer, 0, 3));
+        assertEquals("def", buffer.getStringWithoutLengthAscii(0, 3));
+    }
+
+    @Test
+    public void testCopyIntoBuffer()
+    {
+        final MutableDirectBuffer buffer = new UnsafeBuffer();
+
+        assertTrue(CodecUtil.copyInto(buffer, LONG_VALUE_IN_BYTES, 0, 2));
+        assertEquals("ab", buffer.getStringWithoutLengthAscii(0, 2));
+
+        assertFalse(CodecUtil.copyInto(buffer, LONG_VALUE_IN_BYTES, 2, 1));
+        assertEquals("c", buffer.getStringWithoutLengthAscii(0, 1));
+
+        assertTrue(CodecUtil.copyInto(buffer, LONG_VALUE_IN_BYTES, 0, 4));
+        assertEquals("abcd", buffer.getStringWithoutLengthAscii(0, 4));
     }
 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -187,6 +187,22 @@ public class EncoderGeneratorTest
     }
 
     @Test
+    public void offsetAndLengthByteArrayCopyingSettersWriteFields() throws Exception
+    {
+        final Encoder encoder = newHeartbeat();
+
+        heartbeat
+            .getMethod(TEST_REQ_ID_AS_COPY, byte[].class, int.class, int.class)
+            .invoke(encoder, PREFIXED_VALUE_IN_BYTES, 1, 3);
+
+        assertArrayEquals(VALUE_IN_BYTES, getTestReqIdBytes(encoder));
+        assertTestReqIdOffset(0, encoder);
+        assertTestReqIdLength(3, encoder);
+
+        assertEncodesTestReqIdFully(encoder);
+    }
+
+    @Test
     public void shouldWriteDirectBufferSettersToFields() throws Exception
     {
         final Encoder encoder = newHeartbeat();
@@ -1144,9 +1160,9 @@ public class EncoderGeneratorTest
         assertEquals(expectedLength, getField(encoder, TEST_REQ_ID_LENGTH));
     }
 
-    private void assertTestReqIdOffset(final int expectedoffset, final Object encoder) throws Exception
+    private void assertTestReqIdOffset(final int expectedOffset, final Object encoder) throws Exception
     {
-        assertEquals(expectedoffset, getField(encoder, TEST_REQ_ID_OFFSET));
+        assertEquals(expectedOffset, getField(encoder, TEST_REQ_ID_OFFSET));
     }
 
     private void assertEncodesTestReqIdFully(final Encoder encoder) throws Exception

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/EncoderGeneratorTest.java
@@ -138,13 +138,29 @@ public class EncoderGeneratorTest
     {
         final Object encoder = heartbeat.getConstructor().newInstance();
 
-        heartbeat
-                .getMethod(TEST_REQ_ID, AsciiSequenceView.class)
-                .invoke(encoder, new AsciiSequenceView());
+        setTestReqIdTo(encoder, new AsciiSequenceView());
 
         assertArrayEquals(new byte[0], getTestReqIdBytes(encoder));
         assertTestReqIdOffset(0, encoder);
         assertTestReqIdLength(0, encoder);
+    }
+
+    @Test
+    public void shouldNotUseAsciiSequenceViewAfterReset() throws Exception
+    {
+        final Encoder encoder = newHeartbeat();
+
+        final byte[] originalValue = LONG_VALUE_IN_BYTES;
+        final byte[] byteArray = originalValue.clone();
+
+        final AsciiSequenceView asciiSequenceView = new AsciiSequenceView();
+        asciiSequenceView.wrap(new UnsafeBuffer(byteArray), 0, byteArray.length);
+
+        setTestReqIdTo(encoder, asciiSequenceView);
+        reset(encoder);
+        setTestReqIdTo(encoder, "xxx");
+
+        assertArrayEquals(originalValue, byteArray);
     }
 
     @Test
@@ -1143,6 +1159,13 @@ public class EncoderGeneratorTest
     private void setTestReqIdTo(final Object encoder, final String value) throws Exception
     {
         setCharSequence(encoder, TEST_REQ_ID, value);
+    }
+
+    private void setTestReqIdTo(final Object encoder, final AsciiSequenceView asciiSequenceView) throws Exception
+    {
+        heartbeat
+            .getMethod(TEST_REQ_ID, AsciiSequenceView.class)
+            .invoke(encoder, asciiSequenceView);
     }
 
     private Encoder newHeartbeat() throws Exception


### PR DESCRIPTION
Hi, @anotherchrissmith. One issue I see in https://github.com/real-logic/artio/pull/484 is that the internal buffer reference could end up pointing to an application-supplied buffer, e.g. if you call any of the setters twice. Here I slightly changed it to save the internal buffer reference only when the encoder allocates a new one. Calling setters of different kinds for the same field could still overwrite a buffer, but after reset it should be fine, and we could add a conditional wrap before copying if needed as it should be unlikely. This should save some GC write barriers too.

Also fixed an unrelated bug which I found when reading the surrounding code.

Can you please test this and let me know if it works for you?