### PR TITLE
Allowing custom text in Session.logoutAndDisconnect call

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/DirectSessionProxy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/DirectSessionProxy.java
@@ -267,9 +267,13 @@ public class DirectSessionProxy implements SessionProxy
         return string != null && string.length() > 0;
     }
 
-    public long sendLogout(final int msgSeqNo, final int sequenceIndex, final int lastMsgSeqNumProcessed)
+    public long sendLogout(
+        final int msgSeqNo,
+        final int sequenceIndex,
+        final int lastMsgSeqNumProcessed,
+        final byte[] text)
     {
-        return sendLogout(msgSeqNo, null, 0, sequenceIndex, lastMsgSeqNumProcessed);
+        return sendLogout(msgSeqNo, text, 0, sequenceIndex, lastMsgSeqNumProcessed);
     }
 
     public long sendLogout(

--- a/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionProxy.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/session/SessionProxy.java
@@ -54,7 +54,7 @@ public interface SessionProxy
         CancelOnDisconnectOption cancelOnDisconnectOption,
         int cancelOnDisconnectTimeoutWindowInMs);
 
-    long sendLogout(int msgSeqNo, int sequenceIndex, int lastMsgSeqNumProcessed);
+    long sendLogout(int msgSeqNo, int sequenceIndex, int lastMsgSeqNumProcessed, byte[] text);
 
     long sendLogout(
         int msgSeqNo, int sequenceIndex, int rejectReason, int lastMsgSeqNumProcessed);

--- a/artio-core/src/test/java/uk/co/real_logic/artio/session/AbstractSessionTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/session/AbstractSessionTest.java
@@ -366,7 +366,10 @@ public abstract class AbstractSessionTest
 
     private void backPressureLogout()
     {
-        when(sessionProxy.sendLogout(anyInt(), eq(SEQUENCE_INDEX), anyInt())).thenReturn(BACK_PRESSURED, POSITION);
+        when(sessionProxy.sendLogout(anyInt(),
+          eq(SEQUENCE_INDEX),
+          anyInt(),
+          any())).thenReturn(BACK_PRESSURED, POSITION);
 
         backPressureDisconnect();
     }
@@ -659,7 +662,7 @@ public abstract class AbstractSessionTest
     private void verifyLogoutOnlyOnce()
     {
         verify(sessionProxy, times(1)).sendLogout(
-            anyInt(), eq(SEQUENCE_INDEX), eq(NO_LAST_MSG_SEQ_NUM_PROCESSED));
+            anyInt(), eq(SEQUENCE_INDEX), eq(NO_LAST_MSG_SEQ_NUM_PROCESSED), any());
     }
 
     @Test
@@ -1276,7 +1279,12 @@ public abstract class AbstractSessionTest
 
     public void verifyLogout(final int msgSeqNo, final VerificationMode times)
     {
-        verify(sessionProxy, times).sendLogout(msgSeqNo, SEQUENCE_INDEX, NO_LAST_MSG_SEQ_NUM_PROCESSED);
+        verifyLogout(msgSeqNo, times, null);
+    }
+
+    public void verifyLogout(final int msgSeqNo, final VerificationMode times, final byte[] text)
+    {
+        verify(sessionProxy, times).sendLogout(msgSeqNo, SEQUENCE_INDEX, NO_LAST_MSG_SEQ_NUM_PROCESSED, text);
     }
 
     public void assertState(final SessionState state)

--- a/artio-core/src/test/java/uk/co/real_logic/artio/session/AcceptorSessionTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/session/AcceptorSessionTest.java
@@ -97,6 +97,17 @@ public class AcceptorSessionTest extends AbstractSessionTest
     }
 
     @Test
+    public void shouldRequestLogoutWithCustomText()
+    {
+        shouldBeActivatedBySuccessfulLogin();
+        final byte[] text = "custom text".getBytes();
+
+        session.logoutAndDisconnect(text);
+
+        verifyLogout(2, times(1), text);
+    }
+
+    @Test
     public void shouldRequestResendIfHighSeqNoLogon()
     {
         onLogon(3);

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ExternallyControlledSystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ExternallyControlledSystemTest.java
@@ -408,13 +408,18 @@ public class ExternallyControlledSystemTest extends AbstractGatewayToGatewaySyst
             return acceptingSessionWriter.send(logon, adjustedMsgSeqNo);
         }
 
-        public long sendLogout(final int msgSeqNo, final int sequenceIndex, final int lastMsgSeqNumProcessed)
+        public long sendLogout(
+            final int msgSeqNo, final int sequenceIndex, final int lastMsgSeqNumProcessed, final byte[] text)
         {
             sentLogouts++;
 
             final int adjustedMsgSeqNo = msgSeqNo + sequenceNumberAdjustment;
             final HeaderEncoder header = logout.header();
             setupHeader(header, adjustedMsgSeqNo);
+            if (text != null)
+            {
+                logout.text(text);
+            }
 
             if (send)
             {


### PR DESCRIPTION
This will allow an application to call `logoutAndDisconnect` in a session by passing a custom text

This implements https://weareadaptive.atlassian.net/browse/HYD-2072
