### PR TITLE
sessionKey null check for command line

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
@@ -1142,24 +1142,26 @@ class Framer implements Agent, EngineEndPointHandler, ProtocolHandler
         final long sessionId = sessionInfo.sessionId();
         final CompositeKey sessionKey = sessionInfo.sessionKey();
 
-        final int lastReceivedSequenceNumber = receivedSequenceNumberIndex.lastKnownSequenceNumber(sessionId);
-        final int lastSentSequenceNumber = sentSequenceNumberIndex.lastKnownSequenceNumber(sessionId);
+        if (sessionKey != null) {
+            final int lastReceivedSequenceNumber = receivedSequenceNumberIndex.lastKnownSequenceNumber(sessionId);
+            final int lastSentSequenceNumber = sentSequenceNumberIndex.lastKnownSequenceNumber(sessionId);
 
-        sessionsEncoder.next()
-            .sessionId(sessionId)
-            .connectionId(connectionId)
-            .lastReceivedSequenceNumber(lastReceivedSequenceNumber)
-            .lastSentSequenceNumber(lastSentSequenceNumber)
-            .lastLogonTime(lastLogonTime)
-            .sequenceIndex(sessionInfo.sequenceIndex())
-            .slowStatus(isSlowConsumer ? SlowStatus.SLOW : SlowStatus.NOT_SLOW)
-            .address(address)
-            .localCompId(sessionKey.localCompId())
-            .localSubId(sessionKey.localSubId())
-            .localLocationId(sessionKey.localLocationId())
-            .remoteCompId(sessionKey.remoteCompId())
-            .remoteSubId(sessionKey.remoteSubId())
-            .remoteLocationId(sessionKey.remoteLocationId());
+            sessionsEncoder.next()
+                    .sessionId(sessionId)
+                    .connectionId(connectionId)
+                    .lastReceivedSequenceNumber(lastReceivedSequenceNumber)
+                    .lastSentSequenceNumber(lastSentSequenceNumber)
+                    .lastLogonTime(lastLogonTime)
+                    .sequenceIndex(sessionInfo.sequenceIndex())
+                    .slowStatus(isSlowConsumer ? SlowStatus.SLOW : SlowStatus.NOT_SLOW)
+                    .address(address)
+                    .localCompId(sessionKey.localCompId())
+                    .localSubId(sessionKey.localSubId())
+                    .localLocationId(sessionKey.localLocationId())
+                    .remoteCompId(sessionKey.remoteCompId())
+                    .remoteSubId(sessionKey.remoteSubId())
+                    .remoteLocationId(sessionKey.remoteLocationId());
+        }
     }
 
     public void onAdminResetSequenceNumbersRequest(final long correlationId, final long sessionId)

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
@@ -1142,7 +1142,8 @@ class Framer implements Agent, EngineEndPointHandler, ProtocolHandler
         final long sessionId = sessionInfo.sessionId();
         final CompositeKey sessionKey = sessionInfo.sessionKey();
 
-        if (sessionKey != null) {
+        if (sessionKey != null)
+        {
             final int lastReceivedSequenceNumber = receivedSequenceNumberIndex.lastKnownSequenceNumber(sessionId);
             final int lastSentSequenceNumber = sentSequenceNumberIndex.lastKnownSequenceNumber(sessionId);
 


### PR DESCRIPTION
**Issue:**
Framer.java - Line 158
            sessionsEncoder.next() .....
                    .localCompId(sessionKey.localCompId()
NullPointerException - sessionKey is Null

**Steps to reproduce:**
1. Start Artio server with sequence numbers IN(1) OUT(1)
2. Start any test FIX client with sequence numbers IN(10) OUT(1)
3. The sessions wont connect because sequence mismatch
4. Client keeps connection attempts to server
5. Start Artio command line (ArtioAdminTool)
6. Fire command - printAllSessions
7. Times out error because no output is received

**Cause:**
When a new client attempts to connect to Artio server, new instance of FixGatewaySession is created with sessionKey = null
The sessionKey is populated on Logon (FixGatewaySession.onLogon)
But in a scenario where there is sequence mismatch, the FixGatewaySession instance is created but onLogon callback is not invoked. Therefore sessionKey remains uninitialised

**Solution:**
Null check is added for sessionKey. The command printAllSessions works as expected after this change.

Many Thanks! 

cc: @wojciech-adaptive 