### PR TITLE
Back pressured endpoint needs to be removed after disconnected (reason=slow_consumer).

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixPSenderEndPoints.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixPSenderEndPoints.java
@@ -66,6 +66,7 @@ public class FixPSenderEndPoints implements AutoCloseable
         if (endPoint != null)
         {
             endPoint.close();
+            this.backPressuredEndpoints = ArrayUtil.remove(backPressuredEndpoints, endPoint);
         }
     }
 


### PR DESCRIPTION
The FixP endpoint is present after a disconnect and sender reattempt will loop forever.

count=1058640,firstTime=1694518887149,lastTime=1694518909110

java.nio.channels.ClosedChannelException
	at java.base/sun.nio.ch.SocketChannelImpl.ensureOpenAndConnected(SocketChannelImpl.java:215)
	at java.base/sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:527)
	at uk.co.real_logic.artio.engine.framer.DefaultTcpChannel.write(DefaultTcpChannel.java:45)
	at uk.co.real_logic.artio.engine.framer.FixPSenderEndPoint.writeBuffer(FixPSenderEndPoint.java:105)
	at uk.co.real_logic.artio.engine.framer.ImplicitFixPSenderEndPoint.processReattemptBuffer(ImplicitFixPSenderEndPoint.java:190)
	at uk.co.real_logic.artio.engine.framer.ImplicitFixPSenderEndPoint.reattempt(ImplicitFixPSenderEndPoint.java:217)
	at uk.co.real_logic.artio.engine.framer.FixPSenderEndPoints.reattempt(FixPSenderEndPoints.java:48)
	at uk.co.real_logic.artio.engine.framer.Framer.sendOutboundMessages(Framer.java:446)
	at uk.co.real_logic.artio.engine.framer.Framer.doWork(Framer.java:382)
	at org.agrona.concurrent.AgentRunner.doWork(AgentRunner.java:304)
	at org.agrona.concurrent.AgentRunner.workLoop(AgentRunner.java:296)
	at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:162)
	at java.base/java.lang.Thread.run(Thread.java:833)

count=1058708,firstTime=1694518887149,lastTime=1694518909114