### PR TITLE
fix for #498

### DIFF
--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/util/TestMessages.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/util/TestMessages.java
@@ -82,6 +82,10 @@ public final class TestMessages
     public static final byte[] INVALID_LENGTH_MESSAGE = toAscii(
         "8=FIX.4.4\0019=5\00135=A\00134=1\00149=TW\00152=20150604-12:46:54\00156=ISLD\00198=0\00110=000\001");
 
+    public static final byte[] OVERSIZED_MESSAGE_START =
+            toAscii("8=FIX.4.2\0019=99999\00135=D\00134=4\00149=ABC_DEFG01\001" +
+                    "52=20090323-15:40:29\00156=CCG\001115=XYZ\00111=NF 0542/03232009\00154=1\00138=100\00155=CVS\00140=1");
+
     public static final byte[] ZERO_CHECKSUM_MESSAGE = toAscii(
         "8=FIX.4.4\0019=0067\00135=0\00149=acceptor\00156=initiator\00134=2" +
             "\00152=20160415-12:50:23.294\001112=hi\00110=000\001");

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixReceiverEndPoint.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixReceiverEndPoint.java
@@ -410,6 +410,7 @@ class FixReceiverEndPoint extends ReceiverEndPoint
                 final int endOfChecksumTag = startOfChecksumTag + MIN_CHECKSUM_SIZE;
                 if (endOfChecksumTag >= usedBufferData)
                 {
+                    disconnectOnOversizedMessage(offset, readTimestampInNs);
                     break;
                 }
 
@@ -938,6 +939,18 @@ class FixReceiverEndPoint extends ReceiverEndPoint
     {
         DebugLogger.log(FIX_MESSAGE, "Invalidated (IAE): ", buffer, offset, MIN_MESSAGE_SIZE);
         return saveInvalidMessage(offset, readTimestamp);
+    }
+
+    private void disconnectOnOversizedMessage(final int offset, final long readTimestamp)
+    {
+        if (offset == 0 && this.byteBuffer.remaining() == 0)
+        {
+            saveInvalidMessage(offset, readTimestamp);
+            errorHandler.onError(new Exception(String.format(
+                "Unable to frame message, receiver buffer too small. connectionId=%d",
+                connectionId)));
+            disconnectEndpoint(DisconnectReason.EXCEPTION);
+        }
     }
 
     private boolean saveInvalidMessage(final int offset, final int length, final long readTimestamp)


### PR DESCRIPTION
Fix https://github.com/real-logic/artio/issues/498, a bug where Artio silently stops processing incoming messages when one can't fit in the receiver buffer

This is based on 0.131 and we'd greatly appreciate it if you could also create a patch release for it i.e., 0.131.1
