### PR TITLE
Add option to replace binary separator with pipe

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixArchivePrinter.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/FixArchivePrinter.java
@@ -64,7 +64,7 @@ public final class FixArchivePrinter
     private FixMessagePredicate predicate = FixMessagePredicates.alwaysTrue();
     private boolean follow = false;
     private boolean fixp = false;
-    private boolean pipeDelimiter = false;
+    private char delimiter = Character.MIN_VALUE;
     private Class<? extends FixDictionary> fixDictionaryType = null;
     private Predicate<SessionHeaderDecoder> headerPredicate = null;
     private final PrintStream out;
@@ -142,10 +142,6 @@ public final class FixArchivePrinter
                     fixp = true;
                     break;
 
-                case "pipe-delimiter":
-                    pipeDelimiter = true;
-                    break;
-
                 default:
                     requiredArgument(eqIndex);
             }
@@ -205,6 +201,10 @@ public final class FixArchivePrinter
                     break;
                 case "log-file-dir":
                     logFileDir = optionValue;
+                    break;
+
+                case "delimiter":
+                    delimiter = optionValue.charAt(0);
                     break;
             }
         }
@@ -381,8 +381,8 @@ public final class FixArchivePrinter
             "  This can be used to optimize scans that are time based",
             false);
         printOption(
-            "pipe-delimiter",
-            "Replace the binary delimiter with a pipe",
+            "delimiter",
+            "Specifies the character to replace the binary delimiter with",
             false);
     }
 
@@ -405,8 +405,8 @@ public final class FixArchivePrinter
     {
         final MessageStatus status = message.status();
         final long timestamp = message.timestamp();
-        final String body = pipeDelimiter ? message.body().replace('\u0001', '|') : message.body();
+        final String body =
+            delimiter != Character.MIN_VALUE ? message.body().replace('\u0001', delimiter) : message.body();
         out.printf("%1$20s: %2$s (%3$s)%n", timestamp, body, status);
     }
-
 }

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ArchivePrinterIntegrationTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ArchivePrinterIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2015-2024 Real Logic Limited, Adaptive Financial Consulting Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.real_logic.artio.system_tests;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static uk.co.real_logic.artio.TestFixtures.launchMediaDriver;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.ACCEPTOR_LOGS;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.acceptingLibraryConfig;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.connect;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.delete;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.launchInitiatingEngine;
+import static uk.co.real_logic.artio.system_tests.SystemTestUtil.newInitiatingLibrary;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aeron.Aeron;
+import uk.co.real_logic.artio.engine.EngineConfiguration;
+import uk.co.real_logic.artio.engine.logger.FixArchivePrinter;
+import uk.co.real_logic.artio.library.LibraryConfiguration;
+
+public class ArchivePrinterIntegrationTest extends AbstractGatewayToGatewaySystemTest
+{
+    private final FakeConnectHandler fakeConnectHandler = new FakeConnectHandler();
+
+    @Before
+    public void launch()
+    {
+        delete(ACCEPTOR_LOGS);
+
+        mediaDriver = launchMediaDriver();
+
+        launchAcceptingEngine();
+        initiatingEngine = launchInitiatingEngine(libraryAeronPort, nanoClock);
+
+        final LibraryConfiguration acceptingLibraryConfig = acceptingLibraryConfig(acceptingHandler, nanoClock);
+        acceptingLibraryConfig.libraryConnectHandler(fakeConnectHandler);
+        acceptingLibrary = connect(acceptingLibraryConfig);
+        initiatingLibrary = newInitiatingLibrary(libraryAeronPort, initiatingHandler, nanoClock);
+        testSystem = new TestSystem(acceptingLibrary, initiatingLibrary);
+
+        connectSessions();
+    }
+
+    @Test(timeout = TEST_TIMEOUT_IN_MS)
+    public void shouldUseDefaultDelimiter()
+    {
+        setupAndExchangeMessages();
+
+        final EngineConfiguration configuration = acceptingEngine.configuration();
+        final Aeron.Context context = configuration.aeronContext();
+        final ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+        final FixArchivePrinter fixArchivePrinter = new FixArchivePrinter(new PrintStream(outputBytes), System.err);
+        final String[] args = new String[] {
+            "--aeron-channel=" + configuration.libraryAeronChannel(),
+            "--log-file-dir=" + configuration.logFileDir(),
+            "--aeron-dir-name=" + context.aeronDirectory().getAbsolutePath(),
+            "--query-stream-id=" + configuration.outboundLibraryStream()
+        };
+
+        fixArchivePrinter.scan(args);
+
+        assertThat(outputBytes.toString(), containsString("\u0001112=hi"));
+    }
+
+    @Test(timeout = TEST_TIMEOUT_IN_MS)
+    public void canUsePipeAsDelimiter()
+    {
+        setupAndExchangeMessages();
+
+        final EngineConfiguration configuration = acceptingEngine.configuration();
+        final Aeron.Context context = configuration.aeronContext();
+        final ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+        final FixArchivePrinter fixArchivePrinter = new FixArchivePrinter(new PrintStream(outputBytes), System.err);
+        final String[] args = new String[] {
+            "--pipe-delimiter",
+            "--aeron-channel=" + configuration.libraryAeronChannel(),
+            "--log-file-dir=" + configuration.logFileDir(),
+            "--aeron-dir-name=" + context.aeronDirectory().getAbsolutePath(),
+            "--query-stream-id=" + configuration.outboundLibraryStream()
+        };
+
+        fixArchivePrinter.scan(args);
+
+        assertThat(outputBytes.toString(), containsString("|112=hi1"));
+    }
+
+    private void setupAndExchangeMessages()
+    {
+        messagesCanBeExchanged();
+
+        assertInitiatingSequenceIndexIs(0);
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ArchivePrinterIntegrationTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/ArchivePrinterIntegrationTest.java
@@ -82,7 +82,7 @@ public class ArchivePrinterIntegrationTest extends AbstractGatewayToGatewaySyste
     }
 
     @Test(timeout = TEST_TIMEOUT_IN_MS)
-    public void canUsePipeAsDelimiter()
+    public void canUseSpecifiedCharAsDelimiter()
     {
         setupAndExchangeMessages();
 
@@ -91,7 +91,7 @@ public class ArchivePrinterIntegrationTest extends AbstractGatewayToGatewaySyste
         final ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
         final FixArchivePrinter fixArchivePrinter = new FixArchivePrinter(new PrintStream(outputBytes), System.err);
         final String[] args = new String[] {
-            "--pipe-delimiter",
+            "--delimiter=|",
             "--aeron-channel=" + configuration.libraryAeronChannel(),
             "--log-file-dir=" + configuration.logFileDir(),
             "--aeron-dir-name=" + context.aeronDirectory().getAbsolutePath(),
@@ -100,7 +100,7 @@ public class ArchivePrinterIntegrationTest extends AbstractGatewayToGatewaySyste
 
         fixArchivePrinter.scan(args);
 
-        assertThat(outputBytes.toString(), containsString("|112=hi1"));
+        assertThat(outputBytes.toString(), containsString("|112=hi"));
     }
 
     private void setupAndExchangeMessages()
@@ -110,17 +110,3 @@ public class ArchivePrinterIntegrationTest extends AbstractGatewayToGatewaySyste
         assertInitiatingSequenceIndexIs(0);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
A change to FixArchivePrinter to allow replacing the binary separator in the FIX message body with a pipe via program arguments.