### PR TITLE
Corrected `CustOrderCapacity` in `ILink3SystemTest`

### DIFF
--- a/artio-ilink-system-tests/src/test/java/uk/co/real_logic/artio/ilink/ILink3SystemTest.java
+++ b/artio-ilink-system-tests/src/test/java/uk/co/real_logic/artio/ilink/ILink3SystemTest.java
@@ -283,7 +283,7 @@ public class ILink3SystemTest
             .avgPxGroupID(0, PartyDetailsDefinitionRequest518Encoder.avgPxGroupIDNullValue())
             .selfMatchPreventionID(PartyDetailsDefinitionRequest518Encoder.selfMatchPreventionIDNullValue())
             .cmtaGiveupCD(CmtaGiveUpCD.GiveUp)
-            .custOrderCapacity(CustOrderCapacity.Clearingfirmtradingforitsproprietaryaccount)
+            .custOrderCapacity(CustOrderCapacity.Memberfirmtradingforitsproprietaryaccount)
             .clearingAccountType(ClearingAcctType.Firm)
             .selfMatchPreventionInstruction(SMPI.CancelOldest)
             .avgPxIndicator(AvgPxInd.NoAveragePricing)


### PR DESCRIPTION
`Clearingfirmtradingforitsproprietaryaccount` is not available in schema anymore.