### PR TITLE
LibraryTimeout publish sessions

### DIFF
--- a/artio-codecs/src/main/resources/uk/co/real_logic/artio/messages/message-schema.xml
+++ b/artio-codecs/src/main/resources/uk/co/real_logic/artio/messages/message-schema.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="uk.co.real_logic.artio.messages"
                    id="666"
-                   version="25"
+                   version="26"
                    semanticVersion="0.2"
                    description="Internal messaging format used by the FIX Gateway"
                    byteOrder="littleEndian">
@@ -499,6 +499,9 @@
                  description="notifies library instances that they have been timed out, added for monitoring purposes">
         <field name="libraryId" id="1" type="LibraryId"/>
         <field name="connectCorrelationId" id="2" type="CorrelationId"/>
+        <group name="sessions" id="3" dimensionType="groupSizeEncoding" sinceVersion="26">
+            <field name="sessionId" id="4" type="FixSessionId"/>
+        </group>
     </sbe:message>
 
     <sbe:message name="FollowerSessionReply" id="48"

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/Framer.java
@@ -559,9 +559,8 @@ class Framer implements Agent, EngineEndPointHandler, ProtocolHandler
 
     private void saveLibraryTimeout(final LibraryInfo library)
     {
-        final int libraryId = library.libraryId();
-        schedule(() -> inboundPublication.saveLibraryTimeout(libraryId, 0));
-        schedule(() -> outboundPublication.saveLibraryTimeout(libraryId, 0));
+        schedule(() -> inboundPublication.saveLibraryTimeout(library, 0));
+        schedule(() -> outboundPublication.saveLibraryTimeout(library, 0));
     }
 
     private void acquireLibrarySessions(final LiveLibraryInfo library)

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/FramerTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/FramerTest.java
@@ -37,6 +37,7 @@ import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 import uk.co.real_logic.artio.CloseChecker;
 import uk.co.real_logic.artio.FixCounters;
+import uk.co.real_logic.artio.LivenessDetector;
 import uk.co.real_logic.artio.Timing;
 import uk.co.real_logic.artio.dictionary.FixDictionary;
 import uk.co.real_logic.artio.engine.*;
@@ -140,6 +141,12 @@ public class FramerTest
 
     private final MutableLong connectionId = new MutableLong(NO_CONNECTION_ID);
     private final ErrorHandler errorHandler = mock(ErrorHandler.class);
+    private final LivenessDetector livenessDetector = mock(LivenessDetector.class);
+
+    private final LiveLibraryInfo libraryInfo = new LiveLibraryInfo(
+        errorHandler,
+        LIBRARY_ID, LIBRARY_NAME, livenessDetector, 1,
+        false);
 
     @Before
     @SuppressWarnings("unchecked")
@@ -1004,7 +1011,7 @@ public class FramerTest
 
     private void verifyLibraryTimeout()
     {
-        verify(inboundPublication).saveLibraryTimeout(LIBRARY_ID, 0);
+        verify(inboundPublication).saveLibraryTimeout(libraryInfo, 0);
     }
 
     private void libraryHasAcceptedClient() throws IOException


### PR DESCRIPTION
Changes to expose Session info (LibraryTimeOut) owned by that timed out library instance, because "engine.libraries().resultIfPresent().get(0).sessions()" does not contain library info once it was timed out (stopped)