### PR TITLE
Suppress "this-escape" warnings from generated encoders and decoders

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -329,6 +329,7 @@ class DecoderGenerator extends Generator
         return String.format(
             "\n" +
             GENERATED_ANNOTATION +
+            SUPPRESS_THIS_ESCAPE_ANNOTATION +
             "public %3$s%4$sclass %1$s extends %5$s%2$s\n" +
             "{\n",
             className,

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -42,6 +42,7 @@ import static uk.co.real_logic.artio.dictionary.generation.AggregateType.GROUP;
 import static uk.co.real_logic.artio.dictionary.generation.AggregateType.HEADER;
 import static uk.co.real_logic.artio.dictionary.generation.EnumGenerator.enumName;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.GENERATED_ANNOTATION;
+import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.SUPPRESS_THIS_ESCAPE_ANNOTATION;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.fileHeader;
 import static uk.co.real_logic.artio.dictionary.generation.GenerationUtil.importFor;
 import static uk.co.real_logic.artio.dictionary.generation.OptionalSessionFields.ENCODER_OPTIONAL_SESSION_FIELDS;
@@ -347,6 +348,7 @@ class EncoderGenerator extends Generator
         return String.format(
             "\n" +
             GENERATED_ANNOTATION +
+            SUPPRESS_THIS_ESCAPE_ANNOTATION +
             "public %3$s%4$sclass %1$s%5$s%2$s\n" +
             "{\n",
             className,

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/GenerationUtil.java
@@ -30,6 +30,7 @@ public final class GenerationUtil
 
     public static final String INDENT = "    ";
     public static final String GENERATED_ANNOTATION = "@Generated(\"uk.co.real_logic.artio\")\n";
+    public static final String SUPPRESS_THIS_ESCAPE_ANNOTATION = "@SuppressWarnings(\"this-escape\")\n";
 
     private GenerationUtil()
     {


### PR DESCRIPTION
see https://github.com/real-logic/artio/issues/494

This is the simplest, least intrusive change to allow generated decoders to be built under JDK21 without warnings.