### PR TITLE
HY-73: bugfix when resetting groups decoder, then old group reference…

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -416,28 +416,21 @@ class DecoderGenerator extends Generator
                 "    {\n" +
                 "        for (final %2$s %6$s : %5$s.iterator())\n" +
                 "        {\n" +
+                "            %6$s.reset();\n" +
                 "            if (%6$s.next() == null)\n" +
                 "            {\n" +
-                "                %6$s.reset();\n" +
                 "                break;\n" +
-                "            }\n" +
-                "            else\n" +
-                "            {\n" +
-                "                %6$s.reset();\n" +
                 "            }\n" +
                 "        }\n" +
                 "        %3$s = MISSING_INT;\n" +
                 "        has%4$s = false;\n" +
-                "        %7$s = null;\n" +
                 "    }\n\n",
                 resetMethod,
                 decoderClassName(name),
                 formatPropertyName(numberField.name()),
                 numberField.name(),
                 iteratorFieldName(group),
-                formatPropertyName(decoderClassName(name)),
-                formatPropertyName(name)
-            );
+                formatPropertyName(decoderClassName(name)));
         }
     }
 
@@ -491,9 +484,6 @@ class DecoderGenerator extends Generator
     {
         return
             "        buffer = null;\n" +
-              (isGroup ?
-            "        next = null;\n" : ""
-              ) +
             "        if (" + CODEC_VALIDATION_ENABLED + ")\n" +
             "        {\n" +
             "            invalidTagId = Decoder.NO_ERROR;\n" +
@@ -1743,6 +1733,7 @@ class DecoderGenerator extends Generator
             "        this.buffer = buffer;\n" +
             "        final int end = offset + length;\n" +
             "        int position = offset;\n" +
+            "        int positionIter = position;\n" +
             (hasCommonCompounds ? "        position += header.decode(buffer, position, length);\n" : "") +
             (isGroup ? "        seenFields.clear();\n" : "") +
             "        int tag;\n\n" +
@@ -1921,7 +1912,17 @@ class DecoderGenerator extends Generator
             "                {\n" +
             "                    if (%1$sCurrent != null)\n" +
             "                    {\n" +
-            "                        position += %1$sCurrent.decode(buffer, position, end - position);\n" +
+            "                        positionIter = %1$sCurrent.decode(buffer, position, end - position);\n" +
+            "                        if (positionIter == 0 && " + CODEC_VALIDATION_ENABLED + ")\n" +
+            "                        {\n" +
+            "                                invalidTagId = tag;\n" +
+            "                                rejectReason = " + INCORRECT_NUMINGROUP_COUNT_FOR_REPEATING_GROUP + ";\n" +
+            "                                break;\n" +
+            "                        }\n" +
+            "                        else\n" +
+            "                        {\n" +
+            "                                position += positionIter;\n" +
+            "                        }\n" +
             "                        %1$sCurrent = %1$sCurrent.next();\n" +
             "                    }\n" +
             "                }\n" +

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -1179,10 +1179,14 @@ public abstract class AbstractDecoderGeneratorTest
         assertEquals(2, getNoEgGroupGroupCounter(decoder));
 
         group = getEgGroup(decoder);
-        assertNull(getNestedGroup(group));
+
+        // Although the message does not have nestedEg tags, the decoders will remain
+        // This is to ensure allocation is done only when it's necessary to add new elements to a repeating group
+        // for more details see issue https://github.com/real-logic/artio/issues/532
+        assertNotNull(getNestedGroup(group));
 
         group = next(group);
-        assertNull(getNestedGroup(group));
+        assertNotNull(getNestedGroup(group));
     }
 
     @Test


### PR DESCRIPTION
…s were being nullified which caused unecessary allocation on new decodings