### PR TITLE
Disconnect sessions when library times out in SOLE_LIBRARY mode

### DIFF
--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/SoleLibrarySystemTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/SoleLibrarySystemTest.java
@@ -219,21 +219,27 @@ public class SoleLibrarySystemTest extends AbstractGatewayToGatewaySystemTest
         testSystem.remove(initiatingLibrary);
         awaitLibraryDisconnect(initiatingEngine, testSystem);
 
-        assertEventuallyTrue("Accepting library did not recognize disconnected session", () -> {
-            testSystem.poll();
-            final List<Session> sessions = acceptingLibrary.sessions();
-            assertEquals(1, sessions.size());
-            final Session session = sessions.get(0);
-            assertEquals(SessionState.DISCONNECTED, session.state());
-        });
+        assertEventuallyTrue("Accepting library did not recognize disconnected session",
+            () ->
+            {
+                testSystem.poll();
+                final List<Session> sessions = acceptingLibrary.sessions();
+                assertEquals(1, sessions.size());
+                final Session session = sessions.get(0);
+                assertEquals(SessionState.DISCONNECTED, session.state());
+            }
+        );
 
-        assertEventuallyTrue("Initiating Engine did not disconnect session", () -> {
-            final Reply<List<LibraryInfo>> libraryInfoReply = initiatingEngine.libraries();
-            assertTrue(libraryInfoReply.hasCompleted());
-            final List<LibraryInfo> libraryInfo = libraryInfoReply.resultIfPresent();
-            assertEquals(1, libraryInfo.size());
-            final LibraryInfo libInfo = libraryInfo.get(0);
-            assertEquals(0, libInfo.sessions().size());
-        });
+        assertEventuallyTrue("Initiating Engine did not disconnect session",
+            () ->
+            {
+                final Reply<List<LibraryInfo>> libraryInfoReply = initiatingEngine.libraries();
+                assertTrue(libraryInfoReply.hasCompleted());
+                final List<LibraryInfo> libraryInfo = libraryInfoReply.resultIfPresent();
+                assertEquals(1, libraryInfo.size());
+                final LibraryInfo libInfo = libraryInfo.get(0);
+                assertEquals(0, libInfo.sessions().size());
+            }
+        );
     }
 }


### PR DESCRIPTION
This PR is to revisit library timeouts for when FixEngine is launched with initialAcceptedSessionOwner being SOLE_LIBRARY. If FixEngine uses SOLE_LIBRARY mode, it will disconnect FIX session connections if library times out.