### PR TITLE
Fix validation bug from #546 causing failure for rest of day

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -771,7 +771,7 @@ class DecoderGenerator extends Generator
         {
 
             charsValidation = String.format(
-                "        if (%3$s && %1$sAsChars.length > 1)\n" +
+                "        if (%3$s && %1$sLength > 1)\n" +
                 "        {\n" +
                 "            invalidTagId = %2$s;\n" +
                 "            rejectReason = " + VALUE_IS_INCORRECT + ";\n" +
@@ -1459,10 +1459,10 @@ class DecoderGenerator extends Generator
 
         return String.format(
             "    %10$s %1$s %2$s%3$s;\n\n" +
-              (type.isCharOrBooleanBased() ? "    %10$s char[] %2$sAsChars = new char[1];\n" +
-                "    public char[] %2$sAsChars()" +
+              (type.isCharOrBooleanBased() ? "    %10$s int %2$sLength = 0;\n" +
+                "    public int %2$sLength()" +
                 "    {\n" +
-                "       return %2$sAsChars;\n" +
+                "       return %2$sLength;\n" +
                 "    }\n" : "") +
             "%4$s" +
             "    %11$spublic %1$s %2$s()\n" +
@@ -2072,7 +2072,7 @@ class DecoderGenerator extends Generator
             constantName(name),
             optionalAssign(entry),
             fieldDecodeMethod(field, fieldName),
-            readCharsFromBuffer(field, fieldName),
+            getCharOrBooleanLength(field, fieldName),
             storeOffsetForVariableLengthFields(field.type(), fieldName),
             storeLengthForVariableLengthFields(field.type(), fieldName),
             suffix);
@@ -2194,15 +2194,14 @@ class DecoderGenerator extends Generator
         return prefix + decodeMethod + ";\n";
     }
 
-    private String readCharsFromBuffer(final Field field, final String fieldName)
+    private String getCharOrBooleanLength(final Field field, final String fieldName)
     {
         if (!field.type().isCharOrBooleanBased())
         {
             return "";
         }
 
-        return String.format("                %1$sAsChars = buffer.getChars(%1$sAsChars, valueOffset, " +
-          "valueLength);\n", fieldName);
+        return String.format("                %1$sLength = valueLength;\n", fieldName);
     }
 
     protected String stringAppendTo(final String fieldName)

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/dictionary/generation/AbstractDecoderGeneratorTest.java
@@ -1410,7 +1410,7 @@ public abstract class AbstractDecoderGeneratorTest
     {
         final Decoder decoder = decodeHeartbeatWithoutValidation(INCORRECT_BOOLEAN_VALUE_MESSAGE);
         assertEquals(true, getBooleanField(decoder));
-        assertArrayEquals(new char[]{'Y', 'Y'}, getChars(decoder, "booleanFieldAsChars"));
+        assertEquals(2, getInt(decoder, "booleanFieldLength"));
 
         assertValid(decoder);
     }
@@ -1420,7 +1420,7 @@ public abstract class AbstractDecoderGeneratorTest
     {
         final Decoder decoder = decodeHeartbeat(INCORRECT_BOOLEAN_VALUE_MESSAGE);
         assertEquals(true, getBooleanField(decoder));
-        assertArrayEquals(new char[]{'Y', 'Y'}, getChars(decoder, "booleanFieldAsChars"));
+        assertEquals(2, getInt(decoder, "booleanFieldLength"));
 
         assertInvalid(decoder, 5, 118);
     }
@@ -1430,7 +1430,7 @@ public abstract class AbstractDecoderGeneratorTest
     {
         final Decoder decoder = decodeHeartbeat(INCORRECT_SIZE_NO_ENUM_CHAR_VALUE_MESSAGE);
         assertEquals('a', getChar(decoder, "charNoEnumField"));
-        assertArrayEquals(new char[]{'a', 'b'}, getChars(decoder, "charNoEnumFieldAsChars"));
+        assertEquals(2, getInt(decoder, "charNoEnumFieldLength"));
 
         assertInvalid(decoder, 5, 144);
     }
@@ -1440,7 +1440,7 @@ public abstract class AbstractDecoderGeneratorTest
     {
         final Decoder decoder = decodeHeartbeat(INCORRECT_SIZE_CHAR_VALUE_MESSAGE);
         assertEquals('a', getCharField(decoder));
-        assertArrayEquals(new char[]{'a', 'b'}, getChars(decoder, "charFieldAsChars"));
+        assertEquals(2, getInt(decoder, "charFieldLength"));
 
         assertInvalid(decoder, 5, 128);
     }
@@ -1450,7 +1450,7 @@ public abstract class AbstractDecoderGeneratorTest
     {
         final Decoder decoder = decodeHeartbeat(INCORRECT_SIZE_2_CHAR_VALUE_MESSAGE);
         assertEquals('z', getCharField(decoder));
-        assertArrayEquals(new char[]{'z'}, getChars(decoder, "charFieldAsChars"));
+        assertEquals(1, getInt(decoder, "charFieldLength"));
 
         assertInvalid(decoder, 5, 128);
     }


### PR DESCRIPTION
This PR fixes a bug introduced in #546 where a validation failure would cause every subsequent message to fail validation. #546 added validation for the length of boolean and char fields, asserting that the fix tag was only a single character long. Using `Rule80A` (tag 47) as an example, a buffer would be created for the decoder:
```
this.rule80AAsChars = new char[1];
```
When a message was decoded, the value of the fix tag would be copied into the buffer:
```
case 47:
   this.rule80A = buffer.getChar(valueOffset);
   this.rule80AAsChars = buffer.getChars(this.rule80AAsChars, valueOffset, valueLength);
   break;
```
`getChars` is designed to create a new, larger buffer if the field it attempts to read is too large for the current buffer:
```
public char[] getChars(final char[] oldBuffer, final int offset, final int length)
{
    final char[] resultBuffer = oldBuffer.length < length ? new char[length] : oldBuffer;
    for (int i = 0; i < length; i++)
    {
        resultBuffer[i] = getChar(i + offset);
    }
    return resultBuffer;
}
```
The validation would then check the size of the buffer length:
```
} else if (Validation.CODEC_VALIDATION_ENABLED && this.rule80AAsChars.length > 1) {
```
Because the buffer was never resized/reset for each fix message, anytime large tag value was sent (e.g. `47=AB`) the buffer size would be increased and remain that size. Each subsequent check of `${tag}AsChars.length` would then fail. 

This PR removes the `${tag}AsChars` field and replaces it with a `${tag}Length` field for boolean and char fields that holds the length of the field to ensure subsequent messages with the correct length are valid. It maintains the same validation behavior while avoiding heap allocations for every message. 