### PR TITLE
Qualify encoder fields with this. to avoid clashes

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/DecoderGenerator.java
@@ -468,7 +468,7 @@ class DecoderGenerator extends Generator
         return String.format(
             "    public void %1$s()\n" +
             "    {\n" +
-            "        %2$sLength = 0;\n" +
+            "        this.%2$sLength = 0;\n" +
             "    }\n\n",
             nameOfResetMethod(name),
             formatPropertyName(name));
@@ -476,7 +476,7 @@ class DecoderGenerator extends Generator
 
     protected String resetRequiredFloat(final String name)
     {
-        final String lengthReset = flyweightsEnabled ? "        %1$sLength = 0;\n" : "";
+        final String lengthReset = flyweightsEnabled ? "        this.%1$sLength = 0;\n" : "";
 
         return String.format(
             "    public void %2$s()\n" +
@@ -2081,14 +2081,14 @@ class DecoderGenerator extends Generator
     private String storeLengthForVariableLengthFields(final Type type, final String fieldName)
     {
         return type.hasLengthField(flyweightsEnabled) ?
-            String.format("                %sLength = valueLength;\n", fieldName) :
+            String.format("                this.%sLength = valueLength;\n", fieldName) :
             "";
     }
 
     private String storeOffsetForVariableLengthFields(final Type type, final String fieldName)
     {
         return type.hasOffsetField(flyweightsEnabled) ?
-            String.format("                %sOffset = valueOffset;\n", fieldName) :
+            String.format("                this.%sOffset = valueOffset;\n", fieldName) :
             "";
     }
 
@@ -2255,8 +2255,8 @@ class DecoderGenerator extends Generator
         return String.format(
             "    public void %1$s()\n" +
                     "    {\n" +
-                    "        %2$sOffset = 0;\n" +
-                    "        %2$sLength = 0;\n" +
+                    "        this.%2$sOffset = 0;\n" +
+                    "        this.%2$sLength = 0;\n" +
                     "    }\n\n",
             nameOfResetMethod(name),
             formatPropertyName(name));

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/dictionary/generation/EncoderGenerator.java
@@ -678,7 +678,7 @@ class EncoderGenerator extends Generator
         return String.format(
             "    %4$spublic %2$s %1$sAsCopy(final byte[] value, final int offset, final int length)\n" +
             "    {\n" +
-            "        %1$s = copyInto(%1$s, value, offset, length);\n" +
+            "        this.%1$s = copyInto(this.%1$s, value, offset, length);\n" +
             "%3$s" +
             "        return this;\n" +
             "    }\n\n",
@@ -740,14 +740,14 @@ class EncoderGenerator extends Generator
     {
         return String.format(
             "    %4$s final MutableDirectBuffer %1$s = new UnsafeBuffer();\n" +
-            "    %4$s byte[] %1$sInternalBuffer = %1$s.byteArray();\n" +
+            "    %4$s byte[] %1$sInternalBuffer = this.%1$s.byteArray();\n" +
             "    %4$s int %1$sOffset = 0;\n" +
             "    %4$s int %1$sLength = 0;\n\n" +
             "    %5$spublic %2$s %1$s(final DirectBuffer value, final int offset, final int length)\n" +
             "    {\n" +
-            "        %1$s.wrap(value);\n" +
-            "        %1$sOffset = offset;\n" +
-            "        %1$sLength = length;\n" +
+            "        this.%1$s.wrap(value);\n" +
+            "        this.%1$sOffset = offset;\n" +
+            "        this.%1$sLength = length;\n" +
             "        return this;\n" +
             "    }\n\n" +
             "    %5$spublic %2$s %1$s(final DirectBuffer value, final int length)\n" +
@@ -760,19 +760,19 @@ class EncoderGenerator extends Generator
             "    }\n\n" +
             "    %5$spublic %2$s %1$s(final byte[] value, final int offset, final int length)\n" +
             "    {\n" +
-            "        %1$s.wrap(value);\n" +
-            "        %1$sOffset = offset;\n" +
-            "        %1$sLength = length;\n" +
+            "        this.%1$s.wrap(value);\n" +
+            "        this.%1$sOffset = offset;\n" +
+            "        this.%1$sLength = length;\n" +
             "        return this;\n" +
             "    }\n\n" +
             "    %5$spublic %2$s %1$sAsCopy(final byte[] value, final int offset, final int length)\n" +
             "    {\n" +
-            "        if (copyInto(%1$s, value, offset, length))\n" +
+            "        if (copyInto(this.%1$s, value, offset, length))\n" +
             "        {\n" +
-            "            %1$sInternalBuffer = %1$s.byteArray();\n" +
+            "            %1$sInternalBuffer = this.%1$s.byteArray();\n" +
             "        }\n" +
-            "        %1$sOffset = 0;\n" +
-            "        %1$sLength = length;\n" +
+            "        this.%1$sOffset = 0;\n" +
+            "        this.%1$sLength = length;\n" +
             "        return this;\n" +
             "    }\n\n" +
             "    %5$spublic %2$s %1$s(final byte[] value, final int length)\n" +
@@ -813,12 +813,12 @@ class EncoderGenerator extends Generator
             "%2$s" +
             "    %5$spublic %3$s %1$s(final CharSequence value)\n" +
             "    {\n" +
-            "        if (toBytes(value, %1$s))\n" +
+            "        if (toBytes(value, this.%1$s))\n" +
             "        {\n" +
-            "            %1$sInternalBuffer = %1$s.byteArray();\n" +
+            "            %1$sInternalBuffer = this.%1$s.byteArray();\n" +
             "        }\n" +
-            "        %1$sOffset = 0;\n" +
-            "        %1$sLength = value.length();\n" +
+            "        this.%1$sOffset = 0;\n" +
+            "        this.%1$sLength = value.length();\n" +
             "        return this;\n" +
             "    }\n\n" +
             "    %5$spublic %3$s %1$s(final AsciiSequenceView value)\n" +
@@ -826,9 +826,9 @@ class EncoderGenerator extends Generator
             "        final DirectBuffer buffer = value.buffer();\n" +
             "        if (buffer != null)\n" +
             "        {\n" +
-            "            %1$s.wrap(buffer);\n" +
-            "            %1$sOffset = value.offset();\n" +
-            "            %1$sLength = value.length();\n" +
+            "            this.%1$s.wrap(buffer);\n" +
+            "            this.%1$sOffset = value.offset();\n" +
+            "            this.%1$sLength = value.length();\n" +
             "        }\n" +
             "        return this;\n" +
             "    }\n\n" +
@@ -842,12 +842,12 @@ class EncoderGenerator extends Generator
             "    }\n\n" +
             "    %5$spublic %3$s %1$s(final char[] value, final int offset, final int length)\n" +
             "    {\n" +
-            "        if (toBytes(value, %1$s, offset, length))\n" +
+            "        if (toBytes(value, this.%1$s, offset, length))\n" +
             "        {\n" +
-            "            %1$sInternalBuffer = %1$s.byteArray();\n" +
+            "            %1$sInternalBuffer = this.%1$s.byteArray();\n" +
             "        }\n" +
-            "        %1$sOffset = 0;\n" +
-            "        %1$sLength = length;\n" +
+            "        this.%1$sOffset = 0;\n" +
+            "        this.%1$sLength = length;\n" +
             "        return this;\n" +
             "    }\n\n" +
             "%4$s",
@@ -905,13 +905,13 @@ class EncoderGenerator extends Generator
             "%2$s" +
             "    %7$spublic %3$s %1$s(ReadOnlyDecimalFloat value)\n" +
             "    {\n" +
-            "        %1$s.set(value);\n" +
+            "        this.%1$s.set(value);\n" +
             "%4$s" +
             "        return this;\n" +
             "    }\n\n" +
             "    %7$spublic %3$s %1$s(long value, int scale)\n" +
             "    {\n" +
-            "        %1$s.set(value, scale);\n" +
+            "        this.%1$s.set(value, scale);\n" +
             "%4$s" +
             "        return this;\n" +
             "    }\n\n" +
@@ -1228,7 +1228,7 @@ class EncoderGenerator extends Generator
     private String resetAnyFields(final Entry entry)
     {
         return String.format(
-            "        %1$s.reset();\n",
+            "        this.%1$s.reset();\n",
             formatPropertyName(entry.name()));
     }
 
@@ -1274,7 +1274,7 @@ class EncoderGenerator extends Generator
         }
 
         return String.format(
-            "        %1$s.copyTo(%2$s.%1$s());\n",
+            "        this.%1$s.copyTo(%2$s.%1$s());\n",
             formatPropertyName(element.name()),
             encoderName);
     }
@@ -1474,7 +1474,7 @@ class EncoderGenerator extends Generator
     private String callComponentReset(final Entry entry)
     {
         return String.format(
-            "        %1$s.reset();\n",
+            "        this.%1$s.reset();\n",
             formatPropertyName(entry.name()));
     }
 


### PR DESCRIPTION
We had some cases recently where the generated encoders were failing to compile because we had a field called value (the same could happen with fields named offset or length, which are less likely but possible), where the generated encoder was shadowing the field with method parameters.

We can resolve this by qualifying field access with `this`, which only increases clarity and disambiguates the reference - this change includes at least as many as required to permit us to compile with the field names.