### PR TITLE
Adjust return value to `endOfField + 1`

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/otf/OtfParser.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/otf/OtfParser.java
@@ -219,7 +219,7 @@ public final class OtfParser
             return position;
         }
 
-        return endOfField;
+        return endOfField + 1;
     }
 
     private boolean isEndOfGroup(final IntHashSet groupFields)


### PR DESCRIPTION
When parsing a group with no items in it, the cursor should be moved past the SOH