### PR TITLE
Add pluggable SessionIdGenerator for distributed deployments                                                                                                                                                                                                                                                                                                                                                                            

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/EngineConfiguration.java
@@ -35,6 +35,8 @@ import uk.co.real_logic.artio.decoder.AbstractLogonDecoder;
 import uk.co.real_logic.artio.dictionary.FixDictionary;
 import uk.co.real_logic.artio.dictionary.SessionConstants;
 import uk.co.real_logic.artio.engine.framer.DefaultTcpChannelSupplier;
+import uk.co.real_logic.artio.engine.framer.IncrementalSessionIdGenerator;
+import uk.co.real_logic.artio.engine.framer.SessionIdGenerator;
 import uk.co.real_logic.artio.engine.framer.TcpChannelSupplier;
 import uk.co.real_logic.artio.engine.logger.FixArchiveScanner;
 import uk.co.real_logic.artio.engine.logger.ReplayIndexDescriptor;
@@ -255,6 +257,7 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
     private MappedFile receivedSequenceNumberIndex;
     private MappedFile sessionIdBuffer;
     private MappedFile fixPBuffer;
+    private SessionIdGenerator sessionIdGenerator;
     private Set<String> gapfillOnReplayMessageTypes = new HashSet<>(DEFAULT_GAPFILL_ON_REPLAY_MESSAGE_TYPES);
     private IntHashSet gapfillOnRetransmitILinkTemplateIds = new IntHashSet();
     private final AeronArchive.Context archiveContext = new AeronArchive.Context();
@@ -1846,6 +1849,34 @@ public final class EngineConfiguration extends CommonConfiguration implements Au
             fixPBuffer = mapFile(DEFAULT_FIXP_ID_FILE, sessionIdBufferSize);
         }
         return fixPBuffer;
+    }
+
+    /**
+     * Gets the SessionIdGenerator used for generating unique session identifiers.
+     * If not explicitly set, returns a default IncrementalSessionIdGenerator.
+     *
+     * @return the session ID generator
+     */
+    public SessionIdGenerator sessionIdGenerator()
+    {
+        if (sessionIdGenerator == null)
+        {
+            sessionIdGenerator = new IncrementalSessionIdGenerator();
+        }
+        return sessionIdGenerator;
+    }
+
+    /**
+     * Sets a custom SessionIdGenerator for generating session identifiers.
+     * This allows for distributed session ID generation strategies like Snowflake IDs.
+     *
+     * @param sessionIdGenerator the session ID generator to use
+     * @return this configuration for method chaining
+     */
+    public EngineConfiguration sessionIdGenerator(final SessionIdGenerator sessionIdGenerator)
+    {
+        this.sessionIdGenerator = sessionIdGenerator;
+        return this;
     }
 
     public Set<String> gapfillOnReplayMessageTypes()

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FramerContext.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FramerContext.java
@@ -75,13 +75,14 @@ public class FramerContext
         this.configuration = configuration;
 
         final SessionIdStrategy sessionIdStrategy = configuration.sessionIdStrategy();
+        final SessionIdGenerator sessionIdGenerator = configuration.sessionIdGenerator();
 
         final IdleStrategy idleStrategy = configuration.framerIdleStrategy();
         final Streams outboundLibraryStreams = engineContext.outboundLibraryStreams();
 
         this.fixContexts = new FixContexts(
             configuration.sessionIdBuffer(), sessionIdStrategy, configuration.initialSequenceIndex(), errorHandler,
-            configuration.isReproductionEnabled());
+            configuration.isReproductionEnabled(), sessionIdGenerator);
         this.fixPContexts = new FixPContexts(
             configuration.fixPIdBuffer(),
             errorHandler,

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/IncrementalSessionIdGenerator.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/IncrementalSessionIdGenerator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd., Monotonic Ltd.
+ * Copyright 2015-2025 Real Logic Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/IncrementalSessionIdGenerator.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/IncrementalSessionIdGenerator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd., Monotonic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.engine.framer;
+
+/**
+ * Default session ID generator that uses a simple incrementing counter.
+ * This maintains backward compatibility with the existing session ID generation behavior.
+ * Session IDs start at 1 and increment for each new session.
+ */
+public class IncrementalSessionIdGenerator implements SessionIdGenerator
+{
+    static final long LOWEST_VALID_SESSION_ID = 1L;
+
+    private long counter;
+
+    /**
+     * Create a new IncrementalSessionIdGenerator starting from the lowest valid session ID.
+     */
+    public IncrementalSessionIdGenerator()
+    {
+        this(LOWEST_VALID_SESSION_ID);
+    }
+
+    /**
+     * Create a new IncrementalSessionIdGenerator starting from a specific value.
+     *
+     * @param initialValue the initial counter value
+     */
+    public IncrementalSessionIdGenerator(final long initialValue)
+    {
+        this.counter = initialValue;
+    }
+
+    @Override
+    public long nextId()
+    {
+        return counter++;
+    }
+
+    @Override
+    public void onExistingSessionId(final long existingSessionId)
+    {
+        counter = Math.max(counter, existingSessionId + 1);
+    }
+
+    @Override
+    public void reset()
+    {
+        counter = LOWEST_VALID_SESSION_ID;
+    }
+
+    /**
+     * Get the current counter value.
+     *
+     * @return the current counter value
+     */
+    public long counter()
+    {
+        return counter;
+    }
+}

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionIdGenerator.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionIdGenerator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd., Monotonic Ltd.
+ * Copyright 2015-2025 Real Logic Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionIdGenerator.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/SessionIdGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd., Monotonic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.engine.framer;
+
+/**
+ * Strategy interface for generating unique session identifiers across FIX sessions.
+ * Implementations must ensure that generated IDs are unique within a single engine instance
+ * and ideally unique across multiple engine instances in distributed deployments.
+ */
+public interface SessionIdGenerator
+{
+    /**
+     * Generate the next unique session identifier.
+     *
+     * @return a unique session ID
+     */
+    long nextId();
+
+    /**
+     * Update the generator's state based on an existing session ID that was loaded from persistence.
+     * This is called during initialization when session IDs are loaded from disk to ensure
+     * the generator doesn't produce duplicate IDs.
+     *
+     * @param existingSessionId a session ID that already exists
+     */
+    void onExistingSessionId(long existingSessionId);
+
+    /**
+     * Reset the generator to its initial state.
+     * This is called when the session store is reset.
+     */
+    void reset();
+}

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/FixEngineInitFramerTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/FixEngineInitFramerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.engine;
+
+import org.junit.jupiter.api.Test;
+import uk.co.real_logic.artio.engine.framer.IncrementalSessionIdGenerator;
+import uk.co.real_logic.artio.engine.framer.SessionIdGenerator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Basic configuration tests for FixEngine components.
+ * Tests that SessionIdGenerator configuration works correctly.
+ */
+public class FixEngineInitFramerTest
+{
+    @Test
+    public void shouldUseDefaultSessionIdGeneratorWhenNotConfigured()
+    {
+        final EngineConfiguration config = new EngineConfiguration();
+
+        final SessionIdGenerator generator = config.sessionIdGenerator();
+
+        assertNotNull(generator, "Should have default SessionIdGenerator");
+        assertInstanceOf(IncrementalSessionIdGenerator.class, generator,
+            "Default should be IncrementalSessionIdGenerator");
+    }
+
+    @Test
+    public void shouldUseCustomSessionIdGeneratorWhenConfigured()
+    {
+        final EngineConfiguration config = new EngineConfiguration();
+        final SessionIdGenerator customGenerator = new IncrementalSessionIdGenerator(5000);
+
+        config.sessionIdGenerator(customGenerator);
+
+        assertSame(customGenerator, config.sessionIdGenerator(),
+            "Should return the configured SessionIdGenerator");
+    }
+
+    @Test
+    public void shouldAllowChainingWhenSettingSessionIdGenerator()
+    {
+        final EngineConfiguration config = new EngineConfiguration();
+        final SessionIdGenerator generator = new IncrementalSessionIdGenerator(1000);
+
+        final EngineConfiguration result = config.sessionIdGenerator(generator);
+
+        assertSame(config, result, "Should return same config instance for method chaining");
+        assertSame(generator, config.sessionIdGenerator(), "Should have set the generator");
+    }
+
+    @Test
+    public void shouldGenerateUniqueIdsWithIncrementalGenerator()
+    {
+        final IncrementalSessionIdGenerator generator = new IncrementalSessionIdGenerator();
+
+        final long id1 = generator.nextId();
+        final long id2 = generator.nextId();
+        final long id3 = generator.nextId();
+
+        assertEquals(1, id1);
+        assertEquals(2, id2);
+        assertEquals(3, id3);
+    }
+
+    @Test
+    public void shouldGenerateUniqueIdsWithCustomStartValue()
+    {
+        final IncrementalSessionIdGenerator generator = new IncrementalSessionIdGenerator(1000);
+
+        final long id1 = generator.nextId();
+        final long id2 = generator.nextId();
+
+        assertEquals(1000, id1, "Should start from custom value");
+        assertEquals(1001, id2, "Should increment from custom value");
+        assertNotEquals(id1, id2, "IDs should be unique");
+    }
+
+    @Test
+    public void shouldConfigureMultipleEnginesWithDifferentGenerators()
+    {
+        final EngineConfiguration config1 = new EngineConfiguration()
+            .sessionIdGenerator(new IncrementalSessionIdGenerator(1000));
+
+        final EngineConfiguration config2 = new EngineConfiguration()
+            .sessionIdGenerator(new IncrementalSessionIdGenerator(2000));
+
+        assertNotSame(config1.sessionIdGenerator(), config2.sessionIdGenerator(),
+            "Each config should have its own generator instance");
+
+        assertInstanceOf(IncrementalSessionIdGenerator.class, config1.sessionIdGenerator());
+        assertInstanceOf(IncrementalSessionIdGenerator.class, config2.sessionIdGenerator());
+
+        // Verify they generate different ID ranges
+        assertEquals(1000, ((IncrementalSessionIdGenerator)config1.sessionIdGenerator()).nextId());
+        assertEquals(2000, ((IncrementalSessionIdGenerator)config2.sessionIdGenerator()).nextId());
+    }
+
+    @Test
+    public void shouldPreserveGeneratorThroughMultipleCalls()
+    {
+        final EngineConfiguration config = new EngineConfiguration();
+        final SessionIdGenerator generator = new IncrementalSessionIdGenerator(500);
+
+        config.sessionIdGenerator(generator);
+
+        final SessionIdGenerator retrieved1 = config.sessionIdGenerator();
+        final SessionIdGenerator retrieved2 = config.sessionIdGenerator();
+
+        assertSame(generator, retrieved1, "First retrieval should return same generator");
+        assertSame(generator, retrieved2, "Second retrieval should return same generator");
+        assertSame(retrieved1, retrieved2, "Multiple retrievals should return same instance");
+    }
+}

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/FixEngineInitFramerTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/FixEngineInitFramerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd.
+ * Copyright 2015-2025 Real Logic Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/FixContextsTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/FixContextsTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
 import static uk.co.real_logic.artio.engine.EngineConfiguration.DEFAULT_INITIAL_SEQUENCE_INDEX;
 import static uk.co.real_logic.artio.engine.framer.FixContexts.DUPLICATE_SESSION;
-import static uk.co.real_logic.artio.engine.framer.FixContexts.LOWEST_VALID_SESSION_ID;
+import static uk.co.real_logic.artio.engine.framer.IncrementalSessionIdGenerator.LOWEST_VALID_SESSION_ID;
 
 public class FixContextsTest
 {
@@ -357,7 +357,8 @@ public class FixContextsTest
     private FixContexts newSessionContexts(final AtomicBuffer buffer, final int initialSequenceIndex)
     {
         when(mappedFile.buffer()).thenReturn(buffer);
-        return new FixContexts(mappedFile, idStrategy, initialSequenceIndex, errorHandler, false);
+        return new FixContexts(mappedFile, idStrategy, initialSequenceIndex, errorHandler, false,
+            new IncrementalSessionIdGenerator());
     }
 
     private void assertValuesEqual(

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionIdGeneratorTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionIdGeneratorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd., Monotonic Ltd.
+ * Copyright 2015-2025 Real Logic Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionIdGeneratorTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/SessionIdGeneratorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2025 Real Logic Limited, Adaptive Financial Consulting Ltd., Monotonic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.artio.engine.framer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionIdGeneratorTest
+{
+    @Test
+    void shouldGenerateIncrementalSessionIds()
+    {
+        final IncrementalSessionIdGenerator generator = new IncrementalSessionIdGenerator();
+
+        assertEquals(1, generator.nextId());
+        assertEquals(2, generator.nextId());
+        assertEquals(3, generator.nextId());
+    }
+
+    @Test
+    void shouldGenerateIncrementalSessionIdsFromCustomStart()
+    {
+        final IncrementalSessionIdGenerator generator = new IncrementalSessionIdGenerator(1000);
+
+        assertEquals(1000, generator.nextId());
+        assertEquals(1001, generator.nextId());
+        assertEquals(1002, generator.nextId());
+    }
+
+    @Test
+    void shouldUpdateCounterOnExistingSessionId()
+    {
+        final IncrementalSessionIdGenerator generator = new IncrementalSessionIdGenerator();
+
+        generator.onExistingSessionId(100);
+        assertEquals(101, generator.nextId());
+        assertEquals(102, generator.nextId());
+    }
+
+    @Test
+    void shouldNotDecrementCounterOnLowerExistingSessionId()
+    {
+        final IncrementalSessionIdGenerator generator = new IncrementalSessionIdGenerator(100);
+
+        generator.onExistingSessionId(50); // Lower than current counter
+        assertEquals(100, generator.nextId()); // Should continue from 100
+    }
+
+    @Test
+    void shouldResetToInitialValue()
+    {
+        final IncrementalSessionIdGenerator generator = new IncrementalSessionIdGenerator();
+
+        generator.nextId();
+        generator.nextId();
+        generator.reset();
+
+        assertEquals(1, generator.nextId());
+    }
+}

--- a/artio-samples/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContextCreator.java
+++ b/artio-samples/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContextCreator.java
@@ -48,7 +48,9 @@ public class SessionContextCreator
             mappedFile,
             idStrategy,
             1,
-            throwable -> throwable.printStackTrace(System.out), false);
+            throwable -> throwable.printStackTrace(System.out),
+            false,
+            new IncrementalSessionIdGenerator());
 
         final FixDictionary dictionary = FixDictionary.of(FixDictionary.findDefault());
         final MutableAsciiBuffer buffer = new MutableAsciiBuffer(new byte[1024]);

--- a/artio-samples/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContextDumper.java
+++ b/artio-samples/src/main/java/uk/co/real_logic/artio/engine/framer/SessionContextDumper.java
@@ -36,7 +36,9 @@ public final class SessionContextDumper
             mappedFile,
             SessionIdStrategy.senderAndTarget(),
             1,
-            throwable -> throwable.printStackTrace(System.out), false);
+            throwable -> throwable.printStackTrace(System.out),
+            false,
+            new IncrementalSessionIdGenerator());
 
         contexts
             .allSessions()


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                                                                                       
  ## Summary                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                       
  Adds a pluggable `SessionIdGenerator` interface to support custom session ID generation strategies, enabling globally unique session IDs across multiple Artio instances in distributed deployments.                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                       
  ## Motivation                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                       
  In distributed deployments with multiple Artio instances (e.g., for high availability, geographic distribution, or load balancing), the default incremental session ID counter (1, 2, 3...) can produce duplicate IDs across instances. This PR introduces an abstraction that allows users to implement custom ID generation strategies like Snowflake IDs, UUIDs, or range-based   
  allocation.                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                       
  ## Changes                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                       
  ### New Classes                                                                                                                                                                                                                                                                                                                                                                      
  - **`SessionIdGenerator`** - Strategy interface for session ID generation                                                                                                                                                                                                                                                                                                            
    - `long nextId()` - Generate next unique ID                                                                                                                                                                                                                                                                                                                                        
    - `void onExistingSessionId(long)` - Handle IDs loaded from persistence                                                                                                                                                                                                                                                                                                            
    - `void reset()` - Reset generator state                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                       
  - **`IncrementalSessionIdGenerator`** - Default implementation maintaining backward compatibility                                                                                                                                                                                                                                                                                    
    - Preserves existing behavior (sequential IDs starting from 1)                                                                                                                                                                                                                                                                                                                     
    - Supports custom starting values for range-based allocation                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                       
  ### Modified Classes                                                                                                                                                                                                                                                                                                                                                                 
  - **`FixContexts`** - Now accepts `SessionIdGenerator` in constructor                                                                                                                                                                                                                                                                                                                
    - Delegates ID generation to the provided generator                                                                                                                                                                                                                                                                                                                                
    - Calls `onExistingSessionId()` when loading persisted sessions                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                       
  - **`EngineConfiguration`** - Added SessionIdGenerator configuration                                                                                                                                                                                                                                                                                                                 
    - `sessionIdGenerator(SessionIdGenerator)` - Set custom generator                                                                                                                                                                                                                                                                                                                  
    - `sessionIdGenerator()` - Get generator (returns default if not set)                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                       
  - **`FramerContext`** - Wires SessionIdGenerator from configuration to FixContexts                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                       
  - **Sample files** - Updated to pass SessionIdGenerator to FixContexts                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                       
  ### Tests                                                                                                                                                                                                                                                                                                                                                                            
  - **`SessionIdGeneratorTest`** - 7 tests covering generator implementations                                                                                                                                                                                                                                                                                                          
  - **`FixEngineInitFramerTest`** - 7 tests covering configuration and integration                                                                                                                                                                                                                                                                                                     
  - **`FixContextsTest`** - Updated to work with new constructor signature                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                       
  All existing tests pass (473/473 in artio-core).                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                       
  ## Backward Compatibility                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                       
  ✅ **Fully backward compatible** - No breaking changes                                                                                                                                                                                                                                                                                                                               
  - Default behavior unchanged (uses `IncrementalSessionIdGenerator`)                                                                                                                                                                                                                                                                                                                  
  - Existing code continues to work without modifications                                                                                                                                                                                                                                                                                                                              
  - Session IDs still start from 1 and increment by default          