### PR TITLE
Release replay query subscriptions when replay operations finish

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayOperation.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayOperation.java
@@ -81,6 +81,7 @@ public class ReplayOperation
     private final LogTag logTag;
     private final CountersReader countersReader;
     private final Subscription subscription;
+    private final Runnable onClosed;
 
     // fields reset for each recordingRange
     private int replayedMessages = 0;
@@ -89,6 +90,7 @@ public class ReplayOperation
     private long replaySessionId;
     private int aeronSessionId;
     private Image image;
+    private boolean closeNotified;
 
     private enum State
     {
@@ -108,7 +110,8 @@ public class ReplayOperation
         final Subscription subscription,
         final int archiveReplayStream,
         final LogTag logTag,
-        final MessageTracker messageTracker)
+        final MessageTracker messageTracker,
+        final Runnable onClosed)
     {
         this.messageTracker = messageTracker;
         assembler = new ControlledFragmentAssembler(this.messageTracker);
@@ -122,6 +125,7 @@ public class ReplayOperation
         final Aeron aeron = aeronArchive.context().aeron();
         countersReader = aeron.countersReader();
         this.subscription = subscription;
+        this.onClosed = onClosed;
 
         logTagEnabled = DebugLogger.isEnabled(logTag);
     }
@@ -174,7 +178,7 @@ public class ReplayOperation
                     // There isn't a current replay in progress.
                     logClosed();
                     state = State.CLOSED;
-                    return true;
+                    return notifyClosed();
                 }
             }
 
@@ -235,7 +239,7 @@ public class ReplayOperation
 
             case CLOSED:
                 logClosed();
-                return true;
+                return notifyClosed();
 
             default:
                 throw new IllegalStateException("Illegal state: " + state);
@@ -245,6 +249,17 @@ public class ReplayOperation
     private void logClosed()
     {
         DebugLogger.log(logTag, CLOSED_FORMATTER.get(), replaySessionId);
+    }
+
+    private boolean notifyClosed()
+    {
+        if (!closeNotified)
+        {
+            closeNotified = true;
+            onClosed.run();
+        }
+
+        return true;
     }
 
     private boolean attemptReplay()
@@ -447,5 +462,6 @@ public class ReplayOperation
     {
         startClose();
         attemptClose();
+        notifyClosed();
     }
 }

--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayQuery.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/logger/ReplayQuery.java
@@ -78,6 +78,7 @@ public class ReplayQuery implements AutoCloseable
     private final long indexFileSize;
 
     private Subscription replaySubscription;
+    private int activeReplayOperations;
 
     public ReplayQuery(
         final String logFileDir,
@@ -197,8 +198,10 @@ public class ReplayQuery implements AutoCloseable
     public void close()
     {
         fixSessionToIndex.clear();
+        activeReplayOperations = 0;
 
         CloseHelper.close(replaySubscription);
+        replaySubscription = null;
     }
 
     public void onReset(final long fixSessionId)
@@ -230,6 +233,8 @@ public class ReplayQuery implements AutoCloseable
                 IPC_CHANNEL, archiveReplayStream);
         }
 
+        activeReplayOperations++;
+
         return new ReplayOperation(
             ranges,
             aeronArchive,
@@ -237,7 +242,17 @@ public class ReplayQuery implements AutoCloseable
             replaySubscription,
             archiveReplayStream,
             logTag,
-            messageTracker);
+            messageTracker,
+            this::onReplayOperationClosed);
+    }
+
+    private void onReplayOperationClosed()
+    {
+        if (activeReplayOperations > 0 && --activeReplayOperations == 0)
+        {
+            CloseHelper.close(replaySubscription);
+            replaySubscription = null;
+        }
     }
 
     private final class SessionQuery implements AutoCloseable

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayerTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayerTest.java
@@ -158,6 +158,11 @@ public class ReplayerTest extends AbstractLogTest
         return when(replayOperation.pollReplay());
     }
 
+    private void whenReplayCompletes(final Answer<Boolean> answer)
+    {
+        whenReplayQueried().then(answer).thenReturn(true);
+    }
+
     @Test
     public void shouldParseResendRequest()
     {
@@ -269,7 +274,7 @@ public class ReplayerTest extends AbstractLogTest
         backpressureTryClaim();
 
         setReplayedMessages(2);
-        whenReplayQueried().then(inv ->
+        whenReplayCompletes(inv ->
         {
             onTestRequest(SEQUENCE_NUMBER);
 
@@ -423,7 +428,7 @@ public class ReplayerTest extends AbstractLogTest
         final int endSeqNo = endSeqNoForTwoMessages();
         setReplayedMessages(2);
 
-        whenReplayQueried().then(inv ->
+        whenReplayCompletes(inv ->
         {
             setupCapturingClaim();
             final int srcLength = onExampleMessage(BEGIN_SEQ_NO);
@@ -543,7 +548,7 @@ public class ReplayerTest extends AbstractLogTest
     @Test
     public void shouldReplayMessageWithExpandingBodyLengthWhenBackPressured()
     {
-        whenReplayQueried().then(inv ->
+        whenReplayCompletes(inv ->
         {
             bufferContainsMessage(MESSAGE_REQUIRING_LONGER_BODY_LENGTH);
 
@@ -678,7 +683,7 @@ public class ReplayerTest extends AbstractLogTest
 
     private void onReplay(final int endSeqNo, final int overriddenBeginSeqNo, final Answer<Boolean> answer)
     {
-        whenReplayQueried().then(answer);
+        whenReplayCompletes(answer);
 
         final long result = bufferHasResendRequest(endSeqNo);
         onRequestResendMessage(result, endSeqNo, overriddenBeginSeqNo);

--- a/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/RequestSessionReplaySubscriberLeakTest.java
+++ b/artio-system-tests/src/test/java/uk/co/real_logic/artio/system_tests/RequestSessionReplaySubscriberLeakTest.java
@@ -130,6 +130,7 @@ public class RequestSessionReplaySubscriberLeakTest extends AbstractGatewayToGat
     public void subscriberPositionsShouldNotGrowOverRepeatedCycles()
     {
         final int cycles = 5;
+        final int subPosBefore = countSubscriberPositions();
 
         for (int i = 0; i < cycles; i++)
         {
@@ -158,19 +159,11 @@ public class RequestSessionReplaySubscriberLeakTest extends AbstractGatewayToGat
             testSystem.poll();
         }
 
-        final int subPosCount = countSubscriberPositions();
-
-        // With the leak, each cycle adds stale subscriber positions.  A healthy system should have a bounded, small number.
-        // Typically, 2-4 subscriber positions are expected (engine + library streams).
-        // With the leak we see subPosCount grow linearly with cycles.
-        if (subPosCount > 10)
-        {
-            throw new AssertionError(
-                "Subscriber position count (" + subPosCount + ") grew beyond expected bounds " +
-                    "after " + cycles + " release/acquire-with-replay cycles. " +
-                    "This indicates IpcPublication subscriber positions are leaking because " +
-                    "ReplayOperation.stopReplay() is never called after successful catchup replay.");
-        }
+        final int subPosAfter = countSubscriberPositions();
+        assertEquals(subPosBefore, subPosAfter,
+            "Subscriber positions leaked over repeated catchup replays: before=" + subPosBefore +
+                " after=" + subPosAfter +
+                " after cycles=" + cycles + ".");
     }
 
     private int countSubscriberPositions()


### PR DESCRIPTION
From what I can tell, the change introduced in 31e14a6 is necessary, but not sufficient. This change ensures that catchup replay no longer leaves the replay query subscribed after it is idle, preventing stale subscriber positions from accumulating on the replay stream.