### PR TITLE
fix: prevent FixSenderEndPoint from livelocking on ReplayComplete followed by StartReplay

### DIFF
--- a/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPoint.java
+++ b/artio-core/src/main/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPoint.java
@@ -482,6 +482,13 @@ class FixSenderEndPoint extends SenderEndPoint
                 }
                 else if (enqueueType == ENQ_REPLAY_COMPLETE)
                 {
+                    if (offset + ENQ_REPLAY_COMPLETE_LEN > reattemptBufferUsage)
+                    {
+                        throw new IllegalStateException(
+                            "Incomplete replay complete entry, usage = " + reattemptState.usage +
+                            ", offset = " + offset + ", replay = " + replay);
+                    }
+
                     final int idOffset = offset + SIZE_OF_INT;
                     final long correlationId = buffer.getLong(idOffset);
                     this.reattemptBytesWritten = NO_REATTEMPT;
@@ -491,7 +498,15 @@ class FixSenderEndPoint extends SenderEndPoint
 
                     // peek the next message to see if we need to continue replaying
                     // If not then we end the replay, otherwise we keep replaying
-                    if (buffer.getInt(endOfReplayEntry) != ENQ_START_REPLAY)
+                    final boolean nextReplayQueued = endOfReplayEntry + ENQ_START_REPLAY_LEN <= reattemptBufferUsage &&
+                        buffer.getInt(endOfReplayEntry) == ENQ_START_REPLAY;
+                    channel.onReplayComplete(correlationId);
+
+                    if (nextReplayQueued)
+                    {
+                        offset = endOfReplayEntry;
+                    }
+                    else
                     {
                         replaying(false, correlationId);
                         reattemptState.shuffleWritten(endOfReplayEntry);
@@ -501,7 +516,17 @@ class FixSenderEndPoint extends SenderEndPoint
                 }
                 else if (enqueueType == ENQ_START_REPLAY)
                 {
-                    // We just ensure that we're still replaying and skip these messages
+                    if (offset + ENQ_START_REPLAY_LEN > reattemptBufferUsage)
+                    {
+                        throw new IllegalStateException(
+                            "Incomplete start replay entry, usage = " + reattemptState.usage +
+                            ", offset = " + offset + ", replay = " + replay);
+                    }
+
+                    // A start marker can sit behind retrying data. Refresh the active correlation id before replay
+                    // messages after this marker are sent.
+                    final long correlationId = buffer.getLong(offset + SIZE_OF_INT);
+                    replaying(true, correlationId);
                     offset += ENQ_START_REPLAY_LEN;
                 }
                 else
@@ -565,12 +590,13 @@ class FixSenderEndPoint extends SenderEndPoint
                 final boolean other = !replaying;
                 final ReattemptState reattemptState = reattemptState(other);
                 final int usage = reattemptState.usage;
+                final boolean normalMessagesBlockedByReplay = replaying && this.replaying;
                 if (usage == 0)
                 {
                     requiresRetry(false);
                     sendSlowStatus(false);
                 }
-                else
+                else if (!normalMessagesBlockedByReplay)
                 {
                     this.replaying(!replaying, replayCorrelationId);
                     bytesInBuffer.setOrdered(usage);

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPointTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/framer/FixSenderEndPointTest.java
@@ -24,17 +24,20 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 import uk.co.real_logic.artio.engine.MessageTimingHandler;
 import uk.co.real_logic.artio.engine.SenderSequenceNumber;
 import uk.co.real_logic.artio.messages.MessageHeaderDecoder;
+import uk.co.real_logic.artio.messages.ReplayCompleteDecoder;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.aeron.Publication.BACK_PRESSURED;
 import static io.aeron.logbuffer.ControlledFragmentHandler.Action.CONTINUE;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -315,6 +318,158 @@ public class FixSenderEndPointTest
         verifyNoMoreErrors();
     }
 
+    @Test
+    @Timeout(1)
+    public void shouldContinueRetryingWhenReplayCompleteIsFollowedByQueuedStartReplay()
+    {
+        startValidReplay();
+
+        channelWillWrite(0);
+        onReplayMessage(0, 1);
+        onReplayComplete();
+        byteBufferWrittenTwice();
+
+        endPoint.onStartReplay(REPLAY_CORRELATION_ID_2);
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferWritten();
+
+        assertReplaying();
+        assertDoesNotRequireReattempting();
+        assertBytesInBuffer(0);
+
+        verifyNoMoreErrors();
+    }
+
+    @Test
+    public void shouldNotSendQueuedNormalMessagesAfterQueuedStartReplayUntilReplayCompletes()
+    {
+        startValidReplay();
+
+        channelWillWrite(0);
+        onReplayMessage(0, 1);
+        onReplayComplete();
+        byteBufferWrittenTwice();
+
+        onOutboundMessage(0);
+        byteBufferWritten();
+        endPoint.onStartReplay(REPLAY_CORRELATION_ID_2);
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferWritten();
+
+        assertReplaying();
+        assertRequiresReattempting();
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferNotWritten();
+
+        assertReplaying();
+        assertRequiresReattempting();
+
+        endPoint.onReplayComplete(REPLAY_CORRELATION_ID_2);
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferWritten();
+
+        assertNotReplaying();
+        assertDoesNotRequireReattempting();
+        assertBytesInBuffer(0);
+
+        verifyNoMoreErrors();
+    }
+
+    @Test
+    public void shouldStopReplayingWhenReplayCompleteIsNotFollowedByQueuedStartReplay()
+    {
+        startValidReplay();
+
+        channelWillWrite(0);
+        onReplayMessage(0, 1);
+        onReplayComplete();
+        byteBufferWrittenTwice();
+
+        onReplayComplete();
+        byteBufferWritten();
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferWritten();
+
+        assertNotReplaying();
+        assertDoesNotRequireReattempting();
+        assertBytesInBuffer(0);
+
+        verifyNoMoreErrors();
+    }
+
+    @Test
+    public void shouldRetryQueuedLastReplayMessageWhenReplayCompletePublicationIsBackPressured()
+    {
+        doReturn(BACK_PRESSURED)
+            .doReturn(BACK_PRESSURED)
+            .doAnswer(invocation ->
+            {
+                final BufferClaim claim = invocation.getArgument(1);
+                final int length = invocation.getArgument(0);
+                claim.wrap(inboundBuffer, 0, length + DataHeaderFlyweight.HEADER_LENGTH);
+                return 1L;
+            })
+            .when(inboundPublication).tryClaim(anyInt(), any());
+
+        startValidReplay();
+
+        onReplayMessage(0, 1);
+        byteBufferNotWritten();
+        assertBytesInBuffer(BODY_LENGTH + ENQ_MESSAGE_BLOCK_LEN);
+
+        poll();
+        byteBufferNotWritten();
+        assertReattemptBytesWritten(0);
+        assertBytesInBuffer(BODY_LENGTH + ENQ_MESSAGE_BLOCK_LEN);
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferWritten();
+
+        assertReplaying();
+        assertDoesNotRequireReattempting();
+        assertBytesInBuffer(0);
+
+        verifyNoMoreErrors();
+    }
+
+    @Test
+    public void shouldUseQueuedStartReplayCorrelationId()
+    {
+        becomeSlowConsumer();
+
+        endPoint.onValidResendRequest(REPLAY_CORRELATION_ID_2);
+        endPoint.onStartReplay(REPLAY_CORRELATION_ID_2);
+        onReplayMessage(0, 1);
+        endPoint.onReplayComplete(REPLAY_CORRELATION_ID_2);
+        byteBufferWritten();
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferWritten();
+
+        channelWillWrite(BODY_LENGTH);
+        poll();
+        byteBufferWritten();
+
+        assertReplayCompleteCorrelationId(REPLAY_CORRELATION_ID_2);
+        assertNotReplaying();
+        assertDoesNotRequireReattempting();
+        assertBytesInBuffer(0);
+
+        verifyNoMoreErrors();
+    }
+
     private void assertReplaying()
     {
         assertTrue(endPoint.isReplaying(), "not isReplaying");
@@ -374,7 +529,12 @@ public class FixSenderEndPointTest
 
     private void onReplayMessage(final long timeInMs)
     {
-        assertEquals(CONTINUE, endPoint.onReplayMessage(buffer, MSG_OFFSET, BODY_LENGTH, timeInMs, 0));
+        onReplayMessage(timeInMs, 0);
+    }
+
+    private void onReplayMessage(final long timeInMs, final int sequenceNumber)
+    {
+        assertEquals(CONTINUE, endPoint.onReplayMessage(buffer, MSG_OFFSET, BODY_LENGTH, timeInMs, sequenceNumber));
     }
 
     private void verifySlowConsumerDisconnect(final VerificationMode times)
@@ -408,6 +568,20 @@ public class FixSenderEndPointTest
             assertRequiresReattempting();
         }
         assertEquals(bytes, bytesInBuffer.get());
+    }
+
+    private void assertReplayCompleteCorrelationId(final long expectedCorrelationId)
+    {
+        final MessageHeaderDecoder messageHeader = new MessageHeaderDecoder();
+        final ReplayCompleteDecoder replayComplete = new ReplayCompleteDecoder();
+        int offset = DataHeaderFlyweight.HEADER_LENGTH;
+
+        messageHeader.wrap(inboundBuffer, offset);
+        assertEquals(ReplayCompleteDecoder.TEMPLATE_ID, messageHeader.templateId());
+        offset += MessageHeaderDecoder.ENCODED_LENGTH;
+
+        replayComplete.wrap(inboundBuffer, offset, messageHeader.blockLength(), messageHeader.version());
+        assertEquals(expectedCorrelationId, replayComplete.correlationId());
     }
 
     private void assertRequiresReattempting()

--- a/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayQueryTest.java
+++ b/artio-core/src/test/java/uk/co/real_logic/artio/engine/logger/ReplayQueryTest.java
@@ -1,0 +1,61 @@
+package uk.co.real_logic.artio.engine.logger;
+
+import io.aeron.Aeron;
+import io.aeron.Subscription;
+import io.aeron.archive.client.AeronArchive;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.status.CountersReader;
+import org.junit.jupiter.api.Test;
+import uk.co.real_logic.artio.LogTag;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+import static io.aeron.CommonContext.IPC_CHANNEL;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class ReplayQueryTest
+{
+    private static final int ARCHIVE_REPLAY_STREAM = 4;
+
+    @Test
+    public void shouldCloseReplaySubscriptionWhenQueryCloses()
+    {
+        final AeronArchive aeronArchive = mock(AeronArchive.class);
+        final AeronArchive.Context archiveContext = mock(AeronArchive.Context.class);
+        final Aeron aeron = mock(Aeron.class);
+        final Subscription subscription = mock(Subscription.class);
+        final CountersReader countersReader = mock(CountersReader.class);
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final IdleStrategy idleStrategy = mock(IdleStrategy.class);
+
+        when(aeronArchive.context()).thenReturn(archiveContext);
+        when(archiveContext.aeron()).thenReturn(aeron);
+        when(aeron.countersReader()).thenReturn(countersReader);
+        when(aeron.addSubscription(IPC_CHANNEL, ARCHIVE_REPLAY_STREAM)).thenReturn(subscription);
+
+        final ReplayQuery replayQuery = new ReplayQuery(
+            "unused",
+            1,
+            1,
+            (file) -> ByteBuffer.allocate(0),
+            1,
+            idleStrategy,
+            aeronArchive,
+            errorHandler,
+            NoOpReplayQueryListener.INSTANCE,
+            ARCHIVE_REPLAY_STREAM,
+            8,
+            8);
+
+        final ReplayOperation replayOperation = replayQuery.newReplayOperation(
+            Collections.emptyList(), LogTag.REPLAY, mock(MessageTracker.class));
+        assertTrue(replayOperation.pollReplay());
+
+        replayQuery.close();
+
+        verify(subscription).close();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/artiofix/artio/issues/573