### PR TITLE
Reject invalid week-of-month in MonthYear decode

### DIFF
--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/CalendricalUtil.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/CalendricalUtil.java
@@ -54,6 +54,9 @@ public final class CalendricalUtil
     private static final int MIN_DAY_OF_MONTH = 1;
     private static final int MAX_DAY_OF_MONTH = 31;
 
+    private static final int MIN_WEEK_OF_MONTH = 1;
+    private static final int MAX_WEEK_OF_MONTH = 5;
+
     // ------------ Decoding ------------
 
     public static boolean isValidMonth(final int month)
@@ -64,6 +67,11 @@ public final class CalendricalUtil
     public static boolean isValidDayOfMonth(final int dayOfMonth)
     {
         return dayOfMonth >= MIN_DAY_OF_MONTH && dayOfMonth <= MAX_DAY_OF_MONTH;
+    }
+
+    public static boolean isValidWeekOfMonth(final int weekOfMonth)
+    {
+        return weekOfMonth >= MIN_WEEK_OF_MONTH && weekOfMonth <= MAX_WEEK_OF_MONTH;
     }
 
     static int getValidInt(

--- a/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/MonthYear.java
+++ b/artio-codecs/src/main/java/uk/co/real_logic/artio/fields/MonthYear.java
@@ -22,6 +22,7 @@ import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 import java.time.Month;
 
 import static uk.co.real_logic.artio.fields.CalendricalUtil.isValidDayOfMonth;
+import static uk.co.real_logic.artio.fields.CalendricalUtil.isValidWeekOfMonth;
 import static uk.co.real_logic.artio.fields.CalendricalUtil.isValidMonth;
 
 /**
@@ -157,7 +158,7 @@ public final class MonthYear
                 final int endWeek = startWeek + SIZE_OF_WEEK_OF_MONTH;
                 final int weekOfMonth = buffer.getNatural(startWeek, endWeek);
 
-                if (!isValidDayOfMonth(weekOfMonth))
+                if (!isValidWeekOfMonth(weekOfMonth))
                 {
                     return false;
                 }

--- a/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/MonthYearTest.java
+++ b/artio-codecs/src/test/java/uk/co/real_logic/artio/fields/MonthYearTest.java
@@ -27,6 +27,7 @@ import static java.time.Month.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
@@ -110,6 +111,22 @@ public class MonthYearTest
     public void shouldDecodeValidDatesWithWeek(final String input, final MonthYear expectedMonthYear)
     {
         assertDecodesMonthYear(input, expectedMonthYear);
+    }
+
+    public static Stream<Arguments> invalidMonthYearsWithWeek()
+    {
+        return Stream.of(of("201502w0"), of("201502w6"), of("999912w9"));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "invalidMonthYearsWithWeek")
+    public void shouldRejectInvalidWeekOfMonth(final String input)
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[input.length()]);
+        final MutableAsciiBuffer asciiFlyweight = new MutableAsciiBuffer(buffer);
+        asciiFlyweight.putAscii(0, input);
+
+        assertFalse(monthYear.decode(asciiFlyweight, 0, input.length()));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
MonthYear validated the week-of-month subfield with `isValidDayOfMonth` (1-31), so `w6`-`w9` decoded as valid. A FIX MonthYear week is `w1`-`w5`; this adds `isValidWeekOfMonth` and uses it, mirroring the existing `isValidMonth`/`isValidDayOfMonth` helpers.